### PR TITLE
Minor improvements in `fock_prob()`

### DIFF
--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -329,15 +329,14 @@ def fock_prob(s2, ocp, tol=1.0e-13):
     occupation pattern ocp"""
     beta = np.concatenate((s2.mean, np.conjugate(s2.mean)))
     nmodes = s2.nlen
-    sq = s2.qmat()
-    sqinv = np.linalg.inv(sq)
+    sqinv = np.linalg.inv(s2.qmat())
     pref = np.exp(-0.5*np.dot(np.dot(beta, sqinv), np.conjugate(beta)))
     sqd = np.sqrt(1/np.linalg.det(s2.qmat()).real)
-    gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(sqinv)), beta)
     if sum(ocp) != 0:
+        gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(sqinv)), beta)
         ind = gen_indices(ocp)
         ina = tuple(np.concatenate((ind, ind+nmodes)))
-        A = np.round(s2.Amat(), 14) #Shouldn't this depend on toL?
+        A = s2.Amat() # I don't see why you would want to round here and if, then shouldn't this depend on toL?
         doubles = True
         if np.linalg.norm(s2.mean)*np.sqrt(2) < tol: #This is equivalent to np.linalg.norm(beta) < tol but twice as fast. Is the sqrt(2) really needed?
             singles = False

--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -332,13 +332,15 @@ def fock_prob(s2, ocp, tol=1.0e-13):
     sqinv = np.linalg.inv(s2.qmat())
     pref = np.exp(-0.5*np.dot(np.dot(beta, sqinv), np.conjugate(beta)))
     sqd = np.sqrt(1/np.linalg.det(s2.qmat()).real)
-    if not all(p==0 for p in ocp):
+    if not all(p == 0 for p in ocp):
         gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(sqinv)), beta)
         ind = gen_indices(ocp)
         ina = tuple(np.concatenate((ind, ind+nmodes)))
-        A = s2.Amat() # I don't see why you would want to round here and if, then shouldn't this depend on toL?
+        A = s2.Amat()
         doubles = True
-        if np.linalg.norm(s2.mean)*np.sqrt(2) < tol: #This is equivalent to np.linalg.norm(beta) < tol but twice as fast. Is the sqrt(2) really needed?
+        if np.linalg.norm(s2.mean)*np.sqrt(2) < tol:
+            # This is equivalent to np.linalg.norm(beta) < tol but twice as fast.
+            # Is the sqrt(2) really needed?
             singles = False
         else:
             singles = True

--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -332,7 +332,7 @@ def fock_prob(s2, ocp, tol=1.0e-13):
     sqinv = np.linalg.inv(s2.qmat())
     pref = np.exp(-0.5*np.dot(np.dot(beta, sqinv), np.conjugate(beta)))
     sqd = np.sqrt(1/np.linalg.det(s2.qmat()).real)
-    if sum(ocp) != 0:
+    if not all(p==0 for p in ocp):
         gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(sqinv)), beta)
         ind = gen_indices(ocp)
         ina = tuple(np.concatenate((ind, ind+nmodes)))

--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -330,9 +330,10 @@ def fock_prob(s2, ocp, tol=1.0e-13):
     beta = np.concatenate((s2.mean, np.conjugate(s2.mean)))
     nmodes = s2.nlen
     sq = s2.qmat()
-    pref = np.exp(-0.5*np.dot(np.dot(beta, np.linalg.inv(sq)), np.conjugate(beta)))
+    sqinv = np.linalg.inv(sq)
+    pref = np.exp(-0.5*np.dot(np.dot(beta, sqinv), np.conjugate(beta)))
     sqd = np.sqrt(1/np.linalg.det(s2.qmat()).real)
-    gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(np.linalg.inv(sq))), beta)
+    gamma = np.dot(np.dot(xmat(nmodes), np.conjugate(sqinv)), beta)
     if sum(ocp) != 0:
         ind = gen_indices(ocp)
         ina = tuple(np.concatenate((ind, ind+nmodes)))
@@ -352,7 +353,6 @@ def fock_prob(s2, ocp, tol=1.0e-13):
 
             for j in i:
                 if len(j) == 1:
-
                     pp = pp*gamma[j]
                 if len(j) == 2:
                     pp = pp*A[j]

--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -352,11 +352,11 @@ def fock_prob(s2, ocp, tol=1.0e-13):
 
             for j in i:
                 if len(j) == 1:
-                    pp = pp*gamma[j]
+                    pp *= gamma[j]
                 if len(j) == 2:
-                    pp = pp*A[j]
+                    pp *= A[j]
 
-            ssum = ssum+pp
+            ssum += pp
 
         return (pref*sqd*ssum).real/np.prod(factorial(ocp))
     else:

--- a/strawberryfields/backends/gaussianbackend/ops.py
+++ b/strawberryfields/backends/gaussianbackend/ops.py
@@ -337,9 +337,9 @@ def fock_prob(s2, ocp, tol=1.0e-13):
     if sum(ocp) != 0:
         ind = gen_indices(ocp)
         ina = tuple(np.concatenate((ind, ind+nmodes)))
-        A = np.round(s2.Amat(), 14)
+        A = np.round(s2.Amat(), 14) #Shouldn't this depend on toL?
         doubles = True
-        if np.linalg.norm(beta) < tol:
+        if np.linalg.norm(s2.mean)*np.sqrt(2) < tol: #This is equivalent to np.linalg.norm(beta) < tol but twice as fast. Is the sqrt(2) really needed?
             singles = False
         else:
             singles = True


### PR DESCRIPTION
Some minor improvements to `fock_prob()` that should make the code a bit more readable and which, in test runs with cProfile, reduce the average run-time of the unite tests of the `gaussian` backend by a few percent (for larger systems the difference should be more substantial). Hope you find these useful!