### PR TITLE
Caching of numerical prefactors as tensors for beamsplitter

### DIFF
--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -200,6 +200,7 @@ class QReg(object):
             if graph != self._graph:
                 del self._graph  # get rid of the old graph from memory
                 self._graph = graph
+                ops.get_prefac_tensor.cache_clear() # clear any cached tensors that may live on old graph
             self._make_vac_states()
             self._state_history = []
             self._cache = {}

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -90,6 +90,9 @@ def unravel_index(ind, tensor_shape):
 
 @lru_cache()
 def get_prefac_tensor(D, directory, save):
+    """Equivalent to the functionality of shared_ops the bs_factors functions from shared_ops,
+    but caches the return value as a tensor. This allows us to re-use the same prefactors and save
+    space on the computational graph."""
     try:
         prefac = load_bs_factors(D, directory)
     except FileNotFoundError:

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -29,11 +29,11 @@ Contents
 # pylint: disable=too-many-arguments
 
 from string import ascii_lowercase as indices
+from functools import lru_cache
 
 import tensorflow as tf
 import numpy as np
 from scipy.special import binom, factorial
-from functools import lru_cache
 
 from ..shared_ops import generate_bs_factors, load_bs_factors, save_bs_factors, squeeze_parity
 

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -33,6 +33,7 @@ from string import ascii_lowercase as indices
 import tensorflow as tf
 import numpy as np
 from scipy.special import binom, factorial
+from functools import lru_cache
 
 from ..shared_ops import generate_bs_factors, load_bs_factors, save_bs_factors, squeeze_parity
 
@@ -86,6 +87,17 @@ def unravel_index(ind, tensor_shape):
     strides_shifted = tf.cumprod(tensor_shape, exclusive=True, reverse=True)
     unraveled_coords = (ind % strides) // strides_shifted
     return tf.transpose(unraveled_coords)
+
+@lru_cache()
+def get_prefac_tensor(D, directory, save):
+    try:
+        prefac = load_bs_factors(D, directory)
+    except FileNotFoundError:
+        prefac = generate_bs_factors(D)
+        if save:
+            save_bs_factors(prefac, directory)
+    prefac = tf.expand_dims(tf.cast(prefac[:D, :D, :D, :D, :D], def_type), 0)
+    return prefac
 
 ###################################################################
 
@@ -283,13 +295,7 @@ def beamsplitter_matrix(t, r, D, batched=False, save=False, directory=None):
     M_minus_n_plus_k = tf.where(tf.greater(M_minus_n_plus_k, 0), M_minus_n_plus_k, tf.zeros_like(M_minus_n_plus_k))
 
     # load parameter-independent prefactors
-    try:
-        prefac = load_bs_factors(D, directory)
-    except FileNotFoundError:
-        prefac = generate_bs_factors(D)
-        if save:
-            save_bs_factors(prefac, directory)
-    prefac = tf.expand_dims(tf.cast(prefac[:D, :D, :D, :D, :D], def_type), 0)
+    prefac = get_prefac_tensor(D, directory, save)
 
     powers = tf.cast(tf.pow(mag_t, k) * tf.pow(mag_r, n_minus_k) * tf.pow(mag_r, N_minus_k) * tf.pow(mag_t, M_minus_n_plus_k), def_type)
     phase = tf.exp(1j * tf.cast(phase_r * (n - N), def_type))


### PR DESCRIPTION
**Description of the Change:**
Adds caching of numerical prefactors to the beamsplitter gate in the tensorflow backend

**Benefits:**
Saves space on the computational graph

**Possible Drawbacks:**
None that I can see. These prefactors are created once in the computational graph and re-used as needed, rather than being re-created for every beamsplitter

**Related GitHub Issues:**
NA