### PR TITLE
New single mode state preps

### DIFF
--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -90,6 +90,7 @@ for quantum optical circuits.
     get_cutoff_dim
     prepare_fock_state
     prepare_ket_state
+    prepare_dm_state
     cubic_phase
     kerr_interaction
     measure_fock
@@ -504,6 +505,19 @@ class BaseFock(BaseBackend):
             mode (int): which mode to prepare the state in
         """
         raise NotImplementedError
+
+    def prepare_dm_state(self, state, mode):
+        r"""Prepare the given mixed state (in the Fock basis) in the specified mode.
+
+        The requested mode is traced out and replaced with the given mixed state (in the Fock basis).
+        As a result the state will have to be described using a density matrix.
+
+        Args:
+            state (array): density matrix in the Fock basis
+            mode (int): which mode to prepare the state in
+        """
+        raise NotImplementedError
+
 
     def cubic_phase(self, gamma, mode):
         r"""Apply the cubic phase operation to the specified mode.

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -586,6 +586,10 @@ class BaseGaussian(BaseBackend):
         # pylint: disable=unused-argument,missing-docstring
         raise NotApplicableError
 
+    def prepare_dm_state(self, state, mode):
+        # pylint: disable=unused-argument,missing-docstring
+        raise NotApplicableError
+
     def cubic_phase(self, gamma, mode):
         # pylint: disable=unused-argument,missing-docstring
         raise NotApplicableError

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -386,7 +386,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        raise NotImplementedError
+        self.qreg.prepare(state, self._remap_modes(mode))
 
     def prepare_multimode_ket_state(self, state, modes):
         """Prepare an arbitrary pure state on the specified modes.

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -375,9 +375,20 @@ class FockBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self.qreg.prepare(state, self._remap_modes(mode))
+        self._prepare_state(state, mode)
 
     def prepare_dm_state(self, state, mode):
+        """Prepare an arbitrary mixed state on the specified mode.
+        Note: this will convert the state representation to mixed.
+
+        Args:
+            state (array): density matrix representation of state to prepare
+            mode (int): index of mode where state is prepared
+
+        """
+        self._prepare_state(state, mode)
+
+    def _prepare_state(self, state, mode):
         """Prepare an arbitrary mixed state on the specified mode.
         Note: this will convert the state representation to mixed.
 

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -377,6 +377,39 @@ class FockBackend(BaseFock):
         """
         self.qreg.prepare(state, self._remap_modes(mode))
 
+    def prepare_dm_state(self, state, mode):
+        """Prepare an arbitrary mixed state on the specified mode.
+        Note: this will convert the state representation to mixed.
+
+        Args:
+            state (array): density matrix representation of state to prepare
+            mode (int): index of mode where state is prepared
+
+        """
+        raise NotImplementedError
+
+    def prepare_multimode_ket_state(self, state, modes):
+        """Prepare an arbitrary pure state on the specified modes.
+        Note: this may convert the state representation to mixed.
+
+        Args:
+            state (array): vector representation of ket state to prepare
+            modes (list[int]): indices of modes where state is prepared
+
+        """
+        raise NotImplementedError
+
+    def prepare_multimode_dm_state(self, state, modes):
+        """Prepare an arbitrary mixed state on the specified modes.
+        Note: this will convert the state representation to mixed.
+
+        Args:
+            state (array): density matrix representation of state to prepare
+            mode (list[int]): indices of modes where state is prepared
+
+        """
+        raise NotImplementedError
+
     def measure_fock(self, modes, select=None, **kwargs):
         """Perform a Fock measurement on the specified modes.
 

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -225,10 +225,34 @@ class TFBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        with tf.name_scope('Prepare_ket'):
+        self._prepare_state(state, mode)
+
+    def prepare_dm_state(self, state, mode):
+        """
+        Prepare an arbitrary mixed state on the specified mode.
+        Note: this does convert the state representation to mixed.
+
+        Args:
+            state (array): matrix representation of the state to prepare
+            mode (int): index of mode where state is prepared
+
+        """
+        self._prepare_state(state, mode)
+
+    def _prepare_state(self, state, mode):
+        """
+        Prepare an arbitrary pure or mixed state on the specified mode.
+        Note: this may convert the state representation to mixed.
+
+        Args:
+            state (array): matrix representation of the state to prepare
+            mode (int): index of mode where state is prepared
+
+        """
+        with tf.name_scope('Prepare_state'):
             state = _maybe_unwrap(state)
             remapped_mode = self._remap_modes(mode)
-            self.circuit.prepare_pure_state(state, remapped_mode)
+            self.circuit.prepare_state(state, remapped_mode)
 
     def prepare_thermal_state(self, nbar, mode):
         """

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -225,7 +225,7 @@ class TFBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self._prepare_state(state, mode)
+        self._prepare_state(state, mode, len(state.shape) == 2)
 
     def prepare_dm_state(self, state, mode):
         """
@@ -237,9 +237,9 @@ class TFBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self._prepare_state(state, mode)
+        self._prepare_state(state, mode, len(state.shape) % 2 == 1)
 
-    def _prepare_state(self, state, mode):
+    def _prepare_state(self, state, mode, input_is_batched):
         """
         Prepare an arbitrary pure or mixed state on the specified mode.
         Note: this may convert the state representation to mixed.
@@ -252,7 +252,7 @@ class TFBackend(BaseFock):
         with tf.name_scope('Prepare_state'):
             state = _maybe_unwrap(state)
             remapped_mode = self._remap_modes(mode)
-            self.circuit.prepare_state(state, remapped_mode)
+            self.circuit.prepare_state(state, remapped_mode, input_is_batched)
 
     def prepare_thermal_state(self, nbar, mode):
         """

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -225,7 +225,7 @@ class TFBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self._prepare_state(state, mode, len(state.shape) == 2)
+        self._prepare_state(state, mode, True)
 
     def prepare_dm_state(self, state, mode):
         """
@@ -237,9 +237,9 @@ class TFBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self._prepare_state(state, mode, len(state.shape) % 2 == 1)
+        self._prepare_state(state, mode, False)
 
-    def _prepare_state(self, state, mode, input_is_batched):
+    def _prepare_state(self, state, mode, input_state_is_pure):
         """
         Prepare an arbitrary pure or mixed state on the specified mode.
         Note: this may convert the state representation to mixed.
@@ -252,7 +252,7 @@ class TFBackend(BaseFock):
         with tf.name_scope('Prepare_state'):
             state = _maybe_unwrap(state)
             remapped_mode = self._remap_modes(mode)
-            self.circuit.prepare_state(state, remapped_mode, input_is_batched)
+            self.circuit.prepare_state(state, remapped_mode, input_state_is_pure)
 
     def prepare_thermal_state(self, nbar, mode):
         """

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -277,7 +277,7 @@ class QReg(object):
                 displaced_squeezed = ops.displaced_squeezed(alpha, r, phi, D=self._cutoff_dim, pure=self._state_is_pure, batched=self._batched)
                 self._replace_and_update(displaced_squeezed, mode, self._state)
 
-    def prepare_state(self, state, mode, input_is_batched=False):
+    def prepare_state(self, state, mode, input_state_is_pure):
         """
              Traces out the state in 'mode' and replaces it with the state numerically defined by 'state'.
         """
@@ -286,6 +286,10 @@ class QReg(object):
                 state = tf.cast(tf.convert_to_tensor(state), ops.def_type)
                 # check whether state is a single (unbatched) vector
                 # or a batch of vectors
+                if input_state_is_pure:
+                    input_is_batched = state.shape.ndims == 2
+                else:
+                    input_is_batched = state.shape.ndims % 2 == 1
                 if self._batched and not input_is_batched:
                     state = tf.stack([state] * self._batch_size)
                 self._replace_and_update(state, mode, self._state)

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -277,13 +277,7 @@ class QReg(object):
                 displaced_squeezed = ops.displaced_squeezed(alpha, r, phi, D=self._cutoff_dim, pure=self._state_is_pure, batched=self._batched)
                 self._replace_and_update(displaced_squeezed, mode, self._state)
 
-    def prepare_pure_state(self, state, mode):
-        """
-             Traces out the state in 'mode' and replaces it with the state numerically defined by 'state'.
-        """
-        self.prepare_state(state, mode)
-
-    def prepare_state(self, state, mode):
+    def prepare_state(self, state, mode, input_is_batched=False):
         """
              Traces out the state in 'mode' and replaces it with the state numerically defined by 'state'.
         """
@@ -292,7 +286,7 @@ class QReg(object):
                 state = tf.cast(tf.convert_to_tensor(state), ops.def_type)
                 # check whether state is a single (unbatched) vector
                 # or a batch of vectors
-                if self._batched:
+                if self._batched and not input_is_batched:
                     state = tf.stack([state] * self._batch_size)
                 self._replace_and_update(state, mode, self._state)
 

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -281,12 +281,18 @@ class QReg(object):
         """
              Traces out the state in 'mode' and replaces it with the state numerically defined by 'state'.
         """
+        self.prepare_state(state, mode)
+
+    def prepare_state(self, state, mode):
+        """
+             Traces out the state in 'mode' and replaces it with the state numerically defined by 'state'.
+        """
         if self._valid_modes(mode):
             with self._graph.as_default():
                 state = tf.cast(tf.convert_to_tensor(state), ops.def_type)
                 # check whether state is a single (unbatched) vector
                 # or a batch of vectors
-                if self._batched and state.shape.ndims != 2:
+                if self._batched:
                     state = tf.stack([state] * self._batch_size)
                 self._replace_and_update(state, mode, self._state)
 

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -78,9 +78,22 @@ class FockBasisTests(FockBaseTest):
             state = self.circuit.state()
             self.assertAllAlmostEqual(state.fidelity(random_ket, 0), 1, delta=self.tol)
 
+    # TODO: Implement a meaningful test for batched state preparations.
+    #
+    # def test_prepare_batched_ket_state(self):
+    #     """Tests if a batch of ket states with arbitrary parameters is correctly prepared."""
+    #     random_kets = np.array([ (lambda ket: ket / np.linalg.norm(ket))(np.random.uniform(-1, 1, self.D) + 1j*np.random.uniform(-1, 1, self.D)) for _ in range(self.D+1)])
+    #     random_kets_mixture = sum(np.outer(np.conj(ket),ket) for ket in random_kets)
+
+    #     self.circuit.reset(pure=self.kwargs['pure'])
+    #     self.circuit.prepare_ket_state(random_kets, 0)
+    #     state = self.circuit.state()
+
+    #     self.assertAllAlmostEqual(state.fidelity(random_kets_mixture, 0), 1, delta=self.tol)
+
     def test_prepare_dm_state(self):
         """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
-        # first we test some rank tow states
+        # first we test some rank two states
         for _ in range(10):
             random_ket1 = np.random.uniform(-1, 1, self.D) + 1j*np.random.uniform(-1, 1, self.D)
             random_ket1 = random_ket1 / np.linalg.norm(random_ket1)

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -90,7 +90,6 @@ class FockBasisTests(FockBaseTest):
         self.circuit.prepare_ket_state(random_kets, 0)
         state = self.circuit.state()
         batched_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
-        print(batched_probs)
 
         individual_probs = []
         for random_ket in random_kets:
@@ -98,7 +97,6 @@ class FockBasisTests(FockBaseTest):
             self.circuit.prepare_ket_state(random_ket, 0)
             state = self.circuit.state()
             probs_for_this_ket = [state.fock_prob([n])[0] for n in range(self.D)]
-            print(probs_for_this_ket)
             individual_probs.append(probs_for_this_ket)
 
         individual_probs = np.array(individual_probs).T
@@ -147,7 +145,10 @@ class FockBasisTests(FockBaseTest):
         rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
 
         es, vs = np.linalg.eig(random_rho)
-        kets_mixed_probs = np.zeros([len(es)], dtype=complex)
+        if self.args.batched:
+            kets_mixed_probs = np.zeros([len(es), self.bsize], dtype=complex)
+        else:
+            kets_mixed_probs = np.zeros([len(es)], dtype=complex)
         for e, v in zip(es, vs.T.conj()):
             self.circuit.reset(pure=self.kwargs['pure'])
             self.circuit.prepare_ket_state(v, 0)

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -18,118 +18,118 @@ nbars = np.linspace(0, 5)
 ###################################################################
 
 class BasicTests(BaseTest):
-  """Basic implementation-independent tests."""
-  num_subsystems = 1
+    """Basic implementation-independent tests."""
+    num_subsystems = 1
 
-  def test_prepare_vac(self):
-    """Tests the ability to prepare vacuum states."""
-    self.circuit.prepare_vacuum_state(0)
-    self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+    def test_prepare_vac(self):
+        """Tests the ability to prepare vacuum states."""
+        self.circuit.prepare_vacuum_state(0)
+        self.assertAllTrue(self.circuit.is_vacuum(self.tol))
 
-  def test_fidelity_coherent(self):
-    """Tests if a range of coherent states have the correct fidelity."""
-    for mag_alpha in mag_alphas:
-      for phase_alpha in phase_alphas:
-        self.circuit.reset(pure=self.kwargs['pure'])
-        alpha = mag_alpha * np.exp(1j * phase_alpha)
-        self.circuit.prepare_coherent_state(alpha, 0)
-        state = self.circuit.state()
-        self.assertAllAlmostEqual(state.fidelity_coherent([alpha]), 1, delta=self.tol)
+    def test_fidelity_coherent(self):
+        """Tests if a range of coherent states have the correct fidelity."""
+        for mag_alpha in mag_alphas:
+            for phase_alpha in phase_alphas:
+                self.circuit.reset(pure=self.kwargs['pure'])
+                alpha = mag_alpha * np.exp(1j * phase_alpha)
+                self.circuit.prepare_coherent_state(alpha, 0)
+                state = self.circuit.state()
+                self.assertAllAlmostEqual(state.fidelity_coherent([alpha]), 1, delta=self.tol)
 
-  def test_prepare_thermal_state(self):
-    for nbar in nbars:
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_thermal_state(nbar, 0)
-      ref_probs = np.array([nbar ** n / (nbar + 1) ** (n + 1) for n in range(self.D)])
-      state = self.circuit.state()
-      state_probs = np.array([state.fock_prob([n]) for n in range(self.D)]).T # transpose needed for array broadcasting to work in batch mode
-      self.assertAllAlmostEqual(ref_probs, state_probs, delta=self.tol)
+    def test_prepare_thermal_state(self):
+        for nbar in nbars:
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_thermal_state(nbar, 0)
+            ref_probs = np.array([nbar ** n / (nbar + 1) ** (n + 1) for n in range(self.D)])
+            state = self.circuit.state()
+            state_probs = np.array([state.fock_prob([n]) for n in range(self.D)]).T # transpose needed for array broadcasting to work in batch mode
+            self.assertAllAlmostEqual(ref_probs, state_probs, delta=self.tol)
 
 class FockBasisTests(FockBaseTest):
-  """Tests for simulators that use Fock basis."""
-  num_subsystems = 1
+    """Tests for simulators that use Fock basis."""
+    num_subsystems = 1
 
-  def test_normalized_prepare_vac(self):
-    """Tests the ability to prepare vacuum states."""
-    self.circuit.prepare_vacuum_state(0)
-    state = self.circuit.state()
-    tr = state.trace()
-    self.assertAllAlmostEqual(tr, 1, delta=self.tol)
-
-  def test_normalized_coherent_state(self):
-    """Tests if a range of coherent states are normalized."""
-    for mag_alpha in mag_alphas:
-      for phase_alpha in phase_alphas:
-        alpha = mag_alpha * np.exp(1j * phase_alpha)
-        self.circuit.reset(pure=self.kwargs['pure'])
-        self.circuit.prepare_coherent_state(alpha, 0)
+    def test_normalized_prepare_vac(self):
+        """Tests the ability to prepare vacuum states."""
+        self.circuit.prepare_vacuum_state(0)
         state = self.circuit.state()
         tr = state.trace()
         self.assertAllAlmostEqual(tr, 1, delta=self.tol)
-        if alpha == 0.: break
 
-  def test_prepare_ket_state(self):
-    """Tests if a ket state with arbitrary parameters is correctly prepared."""
-    for _ in range(10):
-      random_ket = np.random.uniform(-1,1,self.D) + 1j*np.random.uniform(-1,1,self.D)
-      random_ket = random_ket / np.linalg.norm(random_ket)
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_ket_state(random_ket, 0)
-      state = self.circuit.state()
-      self.assertAllAlmostEqual(state.fidelity(random_ket, 0), 1, delta=self.tol)
+    def test_normalized_coherent_state(self):
+        """Tests if a range of coherent states are normalized."""
+        for mag_alpha in mag_alphas:
+            for phase_alpha in phase_alphas:
+                alpha = mag_alpha * np.exp(1j * phase_alpha)
+                self.circuit.reset(pure=self.kwargs['pure'])
+                self.circuit.prepare_coherent_state(alpha, 0)
+                state = self.circuit.state()
+                tr = state.trace()
+                self.assertAllAlmostEqual(tr, 1, delta=self.tol)
+                if alpha == 0.: break
 
-  def test_prepare_dm_state(self):
-    """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
-    # first we test some rank tow states
-    for _ in range(10):
-      random_ket1 = np.random.uniform(-1,1,self.D) + 1j*np.random.uniform(-1,1,self.D)
-      random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
-      random_ket2 = np.random.uniform(-1,1,self.D) + 1j*np.random.uniform(-1,1,self.D)
-      random_ket2 = random_ket2 / np.linalg.norm(random_ket2)
+    def test_prepare_ket_state(self):
+        """Tests if a ket state with arbitrary parameters is correctly prepared."""
+        for _ in range(10):
+            random_ket = np.random.uniform(-1, 1, self.D) + 1j*np.random.uniform(-1, 1, self.D)
+            random_ket = random_ket / np.linalg.norm(random_ket)
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_ket_state(random_ket, 0)
+            state = self.circuit.state()
+            self.assertAllAlmostEqual(state.fidelity(random_ket, 0), 1, delta=self.tol)
 
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_ket_state(random_ket1, 0)
-      state = self.circuit.state()
-      ket_probs1 = np.array([state.fock_prob([n]) for n in range(self.D)])
+    def test_prepare_dm_state(self):
+        """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
+        # first we test some rank tow states
+        for _ in range(10):
+            random_ket1 = np.random.uniform(-1, 1, self.D) + 1j*np.random.uniform(-1, 1, self.D)
+            random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
+            random_ket2 = np.random.uniform(-1, 1, self.D) + 1j*np.random.uniform(-1, 1, self.D)
+            random_ket2 = random_ket2 / np.linalg.norm(random_ket2)
 
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_ket_state(random_ket2, 0)
-      state = self.circuit.state()
-      ket_probs2 = np.array([state.fock_prob([n]) for n in range(self.D)])
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_ket_state(random_ket1, 0)
+            state = self.circuit.state()
+            ket_probs1 = np.array([state.fock_prob([n]) for n in range(self.D)])
 
-      ket_probs = 0.5*ket_probs1 + 0.5*ket_probs2
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_ket_state(random_ket2, 0)
+            state = self.circuit.state()
+            ket_probs2 = np.array([state.fock_prob([n]) for n in range(self.D)])
 
-      random_rho = 0.5*np.outer(np.conj(random_ket1),random_ket1) + 0.5*np.outer(np.conj(random_ket2),random_ket2)
+            ket_probs = 0.5*ket_probs1 + 0.5*ket_probs2
 
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_dm_state(random_rho, 0)
-      state = self.circuit.state()
-      rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
+            random_rho = 0.5*np.outer(np.conj(random_ket1), random_ket1) + 0.5*np.outer(np.conj(random_ket2), random_ket2)
 
-      self.assertAllAlmostEqual(state.trace(), 1, delta=self.tol)
-      self.assertAllAlmostEqual(rho_probs, ket_probs, delta=self.tol)
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_dm_state(random_rho, 0)
+            state = self.circuit.state()
+            rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
 
-    # now lets test the preparation of an arbitrary Haar random state
-    random_rho = np.random.normal(size=[self.D,self.D]) + 1j*np.random.normal(size=[self.D,self.D])
-    random_rho = np.dot(random_rho.conj().T,random_rho)
-    random_rho = random_rho/random_rho.trace()
-    self.circuit.reset(pure=self.kwargs['pure'])
-    self.circuit.prepare_dm_state(random_rho, 0)
-    rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
-    es, vs = np.linalg.eig(random_rho)
-    ket_probs = np.zeros([len(es)], dtype=complex)
-    for e,v in zip(es,vs):
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_ket_state(v, 0)
-      ket_probs += e*np.array([state.fock_prob([n]) for n in range(self.D)])
+            self.assertAllAlmostEqual(state.trace(), 1, delta=self.tol)
+            self.assertAllAlmostEqual(rho_probs, ket_probs, delta=self.tol)
 
-    self.assertAllAlmostEqual(rho_probs, ket_probs, delta=self.tol)
+        # now lets test the preparation of an arbitrary Haar random state
+        random_rho = np.random.normal(size=[self.D, self.D]) + 1j*np.random.normal(size=[self.D, self.D])
+        random_rho = np.dot(random_rho.conj().T, random_rho)
+        random_rho = random_rho/random_rho.trace()
+        self.circuit.reset(pure=self.kwargs['pure'])
+        self.circuit.prepare_dm_state(random_rho, 0)
+        rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
+        es, vs = np.linalg.eig(random_rho)
+        ket_probs = np.zeros([len(es)], dtype=complex)
+        for e, v in zip(es, vs):
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_ket_state(v, 0)
+            ket_probs += e*np.array([state.fock_prob([n]) for n in range(self.D)])
+
+        self.assertAllAlmostEqual(rho_probs, ket_probs, delta=self.tol)
 
 if __name__=="__main__":
-  # run the tests in this file
-  suite = unittest.TestSuite()
-  for t in (BasicTests,FockBasisTests):
-    ttt = unittest.TestLoader().loadTestsFromTestCase(t)
-    suite.addTests(ttt)
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    for t in (BasicTests, FockBasisTests):
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
 
-  unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -89,17 +89,17 @@ class FockBasisTests(FockBaseTest):
         self.circuit.reset(pure=self.kwargs['pure'])
         self.circuit.prepare_ket_state(random_kets, 0)
         state = self.circuit.state()
-        batched_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
+        batched_probs = np.array(state.all_fock_probs())
 
         individual_probs = []
         for random_ket in random_kets:
             self.circuit.reset(pure=self.kwargs['pure'])
             self.circuit.prepare_ket_state(random_ket, 0)
             state = self.circuit.state()
-            probs_for_this_ket = [state.fock_prob([n])[0] for n in range(self.D)]
-            individual_probs.append(probs_for_this_ket)
+            probs_for_this_ket = np.array(state.all_fock_probs())
+            individual_probs.append(probs_for_this_ket[0])
 
-        individual_probs = np.array(individual_probs).T
+        individual_probs = np.array(individual_probs)
 
         self.assertAllAlmostEqual(batched_probs, individual_probs, delta=self.tol)
 

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -142,18 +142,18 @@ class FockBasisTests(FockBaseTest):
         self.circuit.reset(pure=self.kwargs['pure'])
         self.circuit.prepare_dm_state(random_rho, 0)
         state = self.circuit.state()
-        rho_probs = np.array([state.fock_prob([n]) for n in range(self.D)])
+        rho_probs = np.array(state.all_fock_probs())
 
         es, vs = np.linalg.eig(random_rho)
         if self.args.batched:
-            kets_mixed_probs = np.zeros([len(es), self.bsize], dtype=complex)
+            kets_mixed_probs = np.zeros([self.bsize, len(es)], dtype=complex)
         else:
             kets_mixed_probs = np.zeros([len(es)], dtype=complex)
         for e, v in zip(es, vs.T.conj()):
             self.circuit.reset(pure=self.kwargs['pure'])
             self.circuit.prepare_ket_state(v, 0)
             state = self.circuit.state()
-            probs_for_this_v = np.array([state.fock_prob([n]) for n in range(self.D)])
+            probs_for_this_v = np.array(state.all_fock_probs())
             kets_mixed_probs += e*probs_for_this_v
 
         self.assertAllAlmostEqual(rho_probs, kets_mixed_probs, delta=self.tol)

--- a/tests/test_state_preparations.py
+++ b/tests/test_state_preparations.py
@@ -79,7 +79,7 @@ class FockBasisTests(FockBaseTest):
       self.assertAllAlmostEqual(state.fidelity(random_ket, 0), 1, delta=self.tol)
 
   def test_prepare_dm_state(self):
-    """Tests if a dm state with arbitrary parameters is correctly prepared."""
+    """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
     for _ in range(10):
       random_ket1 = np.random.uniform(-1,1,self.D) + 1j*np.random.uniform(-1,1,self.D)
       random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
@@ -98,7 +98,7 @@ class FockBasisTests(FockBaseTest):
 
       ket_probs = 0.5*ket_probs1 + 0.5*ket_probs2
 
-      random_rho = 0.5*np.kron(np.conj(random_ket1),random_ket1) + 0.5*np.kron(np.conj(random_ket2),random_ket2)
+      random_rho = 0.5*np.outer(np.conj(random_ket1),random_ket1) + 0.5*np.outer(np.conj(random_ket2),random_ket2)
 
       self.circuit.reset(pure=self.kwargs['pure'])
       self.circuit.prepare_dm_state(random_rho, 0)
@@ -107,7 +107,6 @@ class FockBasisTests(FockBaseTest):
 
       tr = state.trace()
       self.assertAllAlmostEqual(tr, 1, delta=self.tol)
-
       self.assertAllAlmostEqual(rho_probs, ket_probs, delta=self.tol)
 
 if __name__=="__main__":


### PR DESCRIPTION
**Description of the Change:**
Implementation of `prepare_dm_state()` and `prepare_ket_state()` for the fock and tf backend as well as of corresponding unit tests.
**Benefits:**
This allows the preparation of arbitrary pure and mixed states on single modes.
**Possible Drawbacks:**
No known drawbacks.
**Related GitHub Issues:**
This addresses the first half of #16