### PR TITLE
Added the cross-Kerr interaction

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,28 +48,15 @@ MOCK_MODULES = [
     'numbers'
     ]
 
+from strawberryfields.parameters import np_math_fns
+
 mock_math_fn = Mock(__name__='foo')
-mock_fns = {"abs": mock_math_fn,
-            "sin": mock_math_fn,
-            "cos": mock_math_fn,
-            "exp": mock_math_fn,
-            "sqrt": mock_math_fn,
-            "arctan": mock_math_fn,
-            "arccosh": mock_math_fn,
-            "sign": mock_math_fn,
-            "arctan2": mock_math_fn,
-            "arcsinh": mock_math_fn,
-            "cosh": mock_math_fn,
-            "tanh": mock_math_fn,
-            "log": mock_math_fn,
-            "matmul": mock_math_fn,
-            "squeeze": mock_math_fn,
-            "expand_dims": mock_math_fn,
-            "transpose": mock_math_fn,
-            "Number": int,
-            "Tensor": list,
-            "Variable": list,
-            "ndarray": MagicMock}
+mock_fns = {i : mock_math_fn for i in np_math_fns.keys()}
+mock_fns.update({"pi": 3.0,
+                 "Number": int,
+                 "Tensor": list,
+                 "Variable": list,
+                 "ndarray": MagicMock})
 
 mock = Mock(**mock_fns)
 for mod_name in MOCK_MODULES:

--- a/doc/conventions/gates.rst
+++ b/doc/conventions/gates.rst
@@ -411,3 +411,28 @@ We can therefore define the Kerr gate, with parameter :math:`\kappa` as
 
 .. math::
    K(\kappa) = \exp{(i\kappa\hat{n}^2)}.
+
+
+.. _cross_kerr:
+
+Cross-Kerr interaction
+---------------------------------------------
+
+.. warning:: The cross-Kerr gate is **non-Gaussian**, and thus can only be used in the Fock backends, *not* the Gaussian backend.
+
+.. admonition:: Definition
+   :class: defn
+
+   The cross-Kerr interaction is given by the Hamiltonian
+
+   .. math::
+      H = \hat{n}_1\hat{n_2}
+
+   which is non-Gaussian and diagonal in the Fock basis.
+
+.. tip:: *Implemented in Strawberry Fields as a quantum gate by* :class:`strawberryfields.ops.CKgate`
+
+We can therefore define the cross-Kerr gate, with parameter :math:`\kappa` as
+
+.. math::
+   CK(\kappa) = \exp{(i\kappa\hat{n}_1\hat{n_2})}.

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -581,6 +581,16 @@ class BaseFock(BaseBackend):
         """
         raise NotImplementedError
 
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+
+        Args:
+            kappa (float): strength of the interaction
+            mode1 (int): first mode that cross-Kerr interaction acts on
+            mode2 (int): second mode that cross-Kerr interaction acts on
+        """
+        raise NotImplementedError
+
     def measure_fock(self, modes, select=None, **kwargs):
         """Measure the given modes in the Fock basis.
 

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -684,6 +684,10 @@ class BaseGaussian(BaseBackend):
         # pylint: disable=unused-argument,missing-docstring
         raise NotApplicableError
 
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        # pylint: disable=unused-argument,missing-docstring
+        raise NotApplicableError
+
     def measure_fock(self, modes, select=None):
         # pylint: disable=unused-argument,missing-docstring
         raise NotApplicableError

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -96,6 +96,7 @@ for quantum optical circuits.
     prepare_dm_state
     cubic_phase
     kerr_interaction
+    cross_kerr_interaction
     measure_fock
 
 Gaussian backends
@@ -573,7 +574,7 @@ class BaseFock(BaseBackend):
         raise NotImplementedError
 
     def kerr_interaction(self, kappa, mode):
-        r"""Apply the Kerr interaction :math:`exp{(i\kappa \hat{n}^2)}` to the specified mode.
+        r"""Apply the Kerr interaction :math:`\exp{(i\kappa \hat{n}^2)}` to the specified mode.
 
         Args:
             kappa (float): strength of the interaction
@@ -582,7 +583,7 @@ class BaseFock(BaseBackend):
         raise NotImplementedError
 
     def cross_kerr_interaction(self, kappa, mode1, mode2):
-        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+        r"""Apply the two mode cross-Kerr interaction :math:`\exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
 
         Args:
             kappa (float): strength of the interaction

--- a/strawberryfields/backends/fockbackend/__init__.py
+++ b/strawberryfields/backends/fockbackend/__init__.py
@@ -61,11 +61,13 @@ Basic quantum simulator methods
    prepare_displaced_squeezed_state
    prepare_fock_state
    prepare_ket_state
+   prepare_dm_state
    rotation
    displacement
    squeeze
    beamsplitter
    kerr_interaction
+   cross_kerr_interaction
    cubic_phase
    loss
    measure_fock

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -225,7 +225,6 @@ class FockBackend(BaseFock):
         """
         self.qreg.beamsplitter(t, abs(r), phase(r), self._remap_modes(mode1), self._remap_modes(mode2))
 
-
     def kerr_interaction(self, kappa, mode):
         r"""Apply the Kerr interaction :math:`exp{(i\kappa \hat{n}^2)}` to the specified mode.
 
@@ -234,6 +233,16 @@ class FockBackend(BaseFock):
             mode (int): which mode to apply it to
         """
         self.qreg.kerr_interaction(kappa, self._remap_modes(mode))
+
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+
+        Args:
+            kappa (float): strength of the interaction
+            mode1 (int): first mode that cross-Kerr interaction acts on
+            mode2 (int): second mode that cross-Kerr interaction acts on
+        """
+        self.qreg.cross_kerr_interaction(kappa, self._remap_modes(mode1), self._remap_modes(mode2))
 
     def cubic_phase(self, gamma, mode):
         r"""Apply the cubic phase operation to the specified mode.

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -226,7 +226,7 @@ class FockBackend(BaseFock):
         self.qreg.beamsplitter(t, abs(r), phase(r), self._remap_modes(mode1), self._remap_modes(mode2))
 
     def kerr_interaction(self, kappa, mode):
-        r"""Apply the Kerr interaction :math:`exp{(i\kappa \hat{n}^2)}` to the specified mode.
+        r"""Apply the Kerr interaction :math:`\exp{(i\kappa \hat{n}^2)}` to the specified mode.
 
         Args:
             kappa (float): strength of the interaction
@@ -235,7 +235,7 @@ class FockBackend(BaseFock):
         self.qreg.kerr_interaction(kappa, self._remap_modes(mode))
 
     def cross_kerr_interaction(self, kappa, mode1, mode2):
-        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+        r"""Apply the two mode cross-Kerr interaction :math:`\exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
 
         Args:
             kappa (float): strength of the interaction

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -377,6 +377,12 @@ class QReg():
         """
         self._apply_gate(ops.kerr(kappa, self._trunc), [mode])
 
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        """
+        Applies a cross-Kerr interaction gate.
+        """
+        self._apply_gate(ops.cross_kerr(kappa, self._trunc), [mode1, mode2])
+
     def cubic_phase_shift(self, gamma, mode):
         """
         Applies a cubic phase shift gate.

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -491,7 +491,20 @@ def kerr(kappa, trunc):
     r"""
     The Kerr interaction :math:`K(\kappa)`.
     """
-    ret = np.diag([np.exp(1j * kappa * n ** 2) for n in range(trunc)])
+    n = np.arange(trunc)
+    ret = np.diag(np.exp(1j*kappa*n**2))
+    return ret
+
+
+@functools.lru_cache()
+def cross_kerr(kappa, trunc):
+    r"""
+    The cross-Kerr interaction :math:`CK(\kappa)`.
+    """
+    n1 = np.arange(trunc)[None, :]
+    n2 = np.arange(trunc)[:, None]
+    n1n2 = np.ravel(n1*n2)
+    ret = np.diag(np.exp(1j*kappa*n1n2)).reshape([trunc]*4).swapaxes(1, 2)
     return ret
 
 

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -73,12 +73,14 @@ vectors, they must have the same dimension as the declared batch size of the und
    prepare_displaced_squeezed_state
    prepare_fock_state
    prepare_ket_state
+   prepare_dm_state
    rotation
    displacement
    squeeze
    beamsplitter
    cubic_phase
    kerr_interaction
+   cross_kerr_interaction
    loss
    measure_fock
    measure_homodyne

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -335,7 +335,7 @@ class TFBackend(BaseFock):
             self.circuit.cubic_phase(gamma, remapped_mode)
 
     def kerr_interaction(self, kappa, mode):
-        r"""Apply the Kerr interaction :math:`exp{(i\kappa \hat{n}^2)}` to the specified mode.
+        r"""Apply the Kerr interaction :math:`\exp{(i\kappa \hat{n}^2)}` to the specified mode.
 
         Args:
             kappa (float): strength of the interaction
@@ -346,7 +346,7 @@ class TFBackend(BaseFock):
             self.circuit.kerr_interaction(kappa, remapped_mode)
 
     def cross_kerr_interaction(self, kappa, mode1, mode2):
-        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+        r"""Apply the two mode cross-Kerr interaction :math:`\exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
 
         Args:
             kappa (float): strength of the interaction

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -345,6 +345,18 @@ class TFBackend(BaseFock):
             remapped_mode = self._remap_modes(mode)
             self.circuit.kerr_interaction(kappa, remapped_mode)
 
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        r"""Apply the two mode cross-Kerr interaction :math:`exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
+
+        Args:
+            kappa (float): strength of the interaction
+            mode1 (int): first mode that cross-Kerr interaction acts on
+            mode2 (int): second mode that cross-Kerr interaction acts on
+        """
+        with tf.name_scope('Cross-Kerr_interaction'):
+            remapped_modes = self._remap_modes([mode1, mode2])
+            self.circuit.cross_kerr_interaction(kappa, remapped_modes[0], remapped_modes[1])
+
     def state(self, modes=None, **kwargs):
         r"""Returns the state of the quantum simulation, restricted to the subsystems defined by `modes`.
 

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -426,6 +426,16 @@ class QReg:
             new_state = ops.kerr_interaction(k, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched)
             self._update_state(new_state)
 
+    def cross_kerr_interaction(self, kappa, mode1, mode2):
+        """
+        Apply the cross-Kerr interaction operator to the specified mode.
+        """
+        with self._graph.as_default():
+            k = tf.cast(kappa, ops.def_type)
+            k = self._maybe_batch(k)
+            new_state = ops.cross_kerr_interaction(k, mode1, mode2, self._state, self._cutoff_dim, self._state_is_pure, self._batched)
+            self._update_state(new_state)
+
     def cubic_phase(self, gamma, mode):
         """
         Apply the cubic phase operator to the specified mode.

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -183,6 +183,18 @@ def kerr_interaction_matrix(kappa, D, batched=False):
     output = tf.matrix_diag(coeffs)
     return output
 
+def cross_kerr_interaction_matrix(kappa, D, batched=False):
+    """creates the two mode cross-Kerr interaction matrix"""
+    coeffs = [tf.exp(1j * kappa * n1 * n2) for n1 in range(D) for n2 in range(D)]
+    if batched:
+        coeffs = tf.stack(coeffs, axis=1)
+    output = tf.matrix_diag(coeffs)
+    if batched:
+        output = tf.transpose(tf.reshape(output, [-1] + [D]*4), [0, 1, 3, 2, 4])
+    else:
+        output = tf.transpose(tf.reshape(output, [D]*4), [0, 2, 1, 3])
+    return output
+
 def cubic_phase_matrix(gamma, D, hbar, batched=False, method="self_adjoint_eig"):
     """creates the single mode cubic phase matrix"""
     a, ad = ladder_ops(D)
@@ -581,6 +593,12 @@ def kerr_interaction(kappa, mode, in_modes, D, pure=True, batched=False):
     """returns Kerr unitary matrix on specified input modes"""
     matrix = kerr_interaction_matrix(kappa, D, batched)
     output = single_mode_gate(matrix, mode, in_modes, pure, batched)
+    return output
+
+def cross_kerr_interaction(kappa, mode1, mode2, in_modes, D, pure=True, batched=False):
+    """returns cross-Kerr unitary matrix on specified input modes"""
+    matrix = cross_kerr_interaction_matrix(kappa, D, batched)
+    output = two_mode_gate(matrix, mode1, mode2, in_modes, pure, batched)
     return output
 
 def cubic_phase(gamma, mode, in_modes, D, hbar=2, pure=True, batched=False, method="self_adjoint_eig"):

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -185,10 +185,12 @@ State preparation
    Coherent
    Squeezed
    DisplacedSqueezed
-   Fock
-   Ket
    Thermal
+   Fock
    Catstate
+   Ket
+   DensityMatrix
+   CovarianceState
 
 Measurements
 ------------
@@ -236,6 +238,7 @@ Two-mode gates
    S2gate
    CXgate
    CZgate
+   CKgate
 
 Meta-operations
 ---------------
@@ -413,7 +416,7 @@ class Operation:
 
         Returns:
             Operation, None: other * self. The return value None represents
-                the identity gate (doing nothing).
+            the identity gate (doing nothing).
 
         Raises:
             ~strawberryfields.engine.MergeFailure: if the two
@@ -905,6 +908,7 @@ class Ket(Preparation):
     Args:
         state (array or BaseFockState): state vector in the Fock basis.
             This can be provided as either:
+
             * a single ket vector, for single mode state preparation
             * a multimode ket, with one array dimension per mode
             * a :class:`BaseFockState` state object.
@@ -926,7 +930,7 @@ class Ket(Preparation):
 
 
 class DensityMatrix(Preparation):
-    r"""Prepare modes using the given density matrices in the Fock basis.
+    r"""Prepare mode(s) using the given density matrix in the Fock basis.
 
     The prepared modes are traced out and replaced with the given state
     (in the Fock basis). As a result, the overall state of system
@@ -938,6 +942,7 @@ class DensityMatrix(Preparation):
     Args:
         state (array or BaseFockState): density matrix in the Fock basis.
             This can be provided as either:
+
             * a single mode two-dimensional matrix :math:`\rho_{ij}`,
             * a multimode tensor :math:`\rho_{ij,kl,\dots,mn}`, with two indices per mode,
             * a :class:`BaseFockState` state object.
@@ -1364,6 +1369,25 @@ class CZgate(Gate):
             Command(CX, reg, decomp=True),
             Command(Rgate(pi/2), reg[1], decomp=True)
         ]
+
+
+class CKgate(Gate):
+    r""":ref:`Cross-Kerr <cross_kerr>` gate.
+
+    .. math::
+       CK(\kappa) = e^{i \kappa \hat{n}_1\hat{n}_2}
+
+    Args:
+        kappa (float): parameter
+    """
+    ns = 2
+
+    def __init__(self, kappa):
+        super().__init__([kappa])
+
+    def _apply(self, reg, backend, **kwargs):
+        p = _unwrap(self.p)
+        backend.cross_kerr_interaction(p[0], *reg)
 
 
 class Fouriergate(Gate):

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1782,7 +1782,7 @@ RR = RegRefTransform
 # here we list different classes of operations for unit testing purposes
 
 zero_args_gates = (Fourier,)  # all these are pre-constructed objects, not classes
-one_args_gates = (Xgate, Zgate, Rgate, Pgate, Vgate, Kgate, CXgate, CZgate)
+one_args_gates = (Xgate, Zgate, Rgate, Pgate, Vgate, Kgate, CXgate, CZgate, CKgate)
 two_args_gates = (Dgate, Sgate, BSgate, S2gate)
 gates = zero_args_gates + one_args_gates + two_args_gates
 

--- a/tests/test_nongaussian_gates.py
+++ b/tests/test_nongaussian_gates.py
@@ -15,7 +15,7 @@ kappas = np.linspace(0, 2 * np.pi, 7)
 
 ###################################################################
 
-class FockBasisTests(FockBaseTest):
+class FockBasisKerrTests(FockBaseTest):
   """Tests for simulators that use Fock basis."""
   num_subsystems = 1
 
@@ -35,10 +35,38 @@ class FockBasisTests(FockBaseTest):
         self.assertAllAlmostEqual(numer_state, ref_state, delta=self.tol)
 
 
+class FockBasisCrossKerrTests(FockBaseTest):
+  """Tests for simulators that use Fock basis."""
+  num_subsystems = 2
+
+  def test_cross_kerr_interaction(self):
+    """Tests if the Kerr interaction has the right effect on states in the Fock basis"""
+    self.logTestName()
+    for kappa in kappas:
+        self.circuit.reset(pure=self.kwargs['pure'])
+
+        ket1 = np.array([1.0 for n in range(self.D)])
+        ket1 /= np.linalg.norm(ket1)
+        ket = np.outer(ket1, ket1)
+
+        self.circuit.prepare_ket_state(ket, modes=[0, 1])
+        self.circuit.cross_kerr_interaction(kappa, 0, 1)
+        s = self.circuit.state()
+
+        if s.is_pure:
+          numer_state = s.ket()
+        else:
+          numer_state = s.dm()
+
+        ref_state = np.array([np.exp(1j*kappa*n1*n2) for n1 in range(self.D) for n2 in range(self.D)])/self.D
+        ref_state = np.reshape(ref_state, [self.D]*2)
+        self.assertAllAlmostEqual(numer_state, ref_state, delta=self.tol)
+
+
 if __name__=="__main__":
   # run the tests in this file
   suite = unittest.TestSuite()
-  for t in (FockBasisTests,):
+  for t in (FockBasisKerrTests, FockBasisCrossKerrTests):
     ttt = unittest.TestLoader().loadTestsFromTestCase(t)
     suite.addTests(ttt)
 

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -134,7 +134,7 @@ class BasicTests(BaseTest):
             test_gate(G)
 
         for G in one_args_gates:
-            if G in (Vgate, Kgate) and not self.args.fock_support:
+            if G in (Vgate, Kgate, CKgate) and not self.args.fock_support:
                 continue  # the V gate cannot be used on Gaussian backends
             # construct a random gate
             G = G(uniform(high=0.25))


### PR DESCRIPTION
**Description of the Change:**

This pull request adds the cross-Kerr interaction to Strawberry Fields. This is supported by both the Fock and Tensorflow backends, in numerical and symbolic mode, mixed and batched operation. A cross-Kerr test has been added to the file `test_non_gaussian_gates.py`, and a frontend quantum operation `CKgate` has been added.

In addition, a few small bugfixes were made to the documentation. In particular, Sphinx would not build ops.py and parameters.py as np.pi was not mocked out correctly.

**Benefits:**

Can now natively perform the cross-Kerr interaction in Strawberry Fields.

**Possible Drawbacks:**

None that I can think of.

**Related GitHub Issues:**

n/a