### PR TITLE
Gaussian multimode

### DIFF
--- a/doc/conventions/decompositions.rst
+++ b/doc/conventions/decompositions.rst
@@ -74,7 +74,7 @@ Williamson decomposition
 
 .. tip::
 
-   *Implemented in Strawberry Fields as a state preparation decomposition by* :class:`strawberryfields.ops.CovarianceState`
+   *Implemented in Strawberry Fields as a state preparation decomposition by* :class:`strawberryfields.ops.Gaussian`
 
 
 The Williamson decomposition allows an arbitrary Gaussian covariance matrix to be decomposed into a symplectic transformation acting on the state described by the diagonal matrix :math:`D`.

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -644,21 +644,21 @@ class BaseGaussian(BaseBackend):
         """
         raise NotImplementedError
 
-    # def prepare_gaussian_state(self, r, V, modes):
-    #     r"""Prepare the given Gaussian state (via the provided vector of
-    #     means and the covariance matrix) in the specified modes.
+    def prepare_gaussian_state(self, r, V, modes):
+        r"""Prepare the given Gaussian state (via the provided vector of
+        means and the covariance matrix) in the specified modes.
 
-    #     The requested mode(s) is/are traced out and replaced with the given Gaussian state.
+        The requested mode(s) is/are traced out and replaced with the given Gaussian state.
 
-    #     Args:
-    #         r (array): the vector of means in xp ordering.
-    #         V (array): the covariance matrix in xp ordering.
-    #         modes (int or Sequence[int]): which mode to prepare the state in
-    #             If the modes are not sorted, this is take into account when preparing the state.
-    #             i.e., when a two mode state is prepared in modes=[3,1], then the first
-    #             mode of state goes into mode 3 and the second mode goes into mode 1 of the simulator.
-    #     """
-    #     raise NotImplementedError
+        Args:
+            r (array): the vector of means in xp ordering.
+            V (array): the covariance matrix in xp ordering.
+            modes (int or Sequence[int]): which mode to prepare the state in
+                If the modes are not sorted, this is take into account when preparing the state.
+                i.e., when a two mode state is prepared in modes=[3,1], then the first
+                mode of state goes into mode 3 and the second mode goes into mode 1 of the simulator.
+        """
+        raise NotImplementedError
 
     def get_cutoff_dim(self):
         # pylint: disable=unused-argument,missing-docstring

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Gaussian backend"""
-from numpy import empty, concatenate, array, identity, arctan2, angle, sqrt, dot
+from numpy import empty, concatenate, array, identity, arctan2, angle, sqrt, dot, vstack
 from numpy.linalg import inv
 
 from strawberryfields.backends import BaseGaussian
+from strawberryfields.backends.shared_ops import changebasis
 
 from .ops import xmat
 from .gaussiancircuit import GaussianModes
@@ -245,6 +246,38 @@ class GaussianBackend(BaseGaussian):
         self.circuit.post_select_heterodyne(mode, select)
 
         return res
+
+    def prepare_gaussian_state(self, r, V, modes):
+        r"""Prepare the given Gaussian state (via the provided vector of
+        means and the covariance matrix) in the specified modes.
+
+        The requested mode(s) is/are traced out and replaced with the given Gaussian state.
+
+        Args:
+            r (array): the vector of means in xp ordering.
+            V (array): the covariance matrix in xp ordering.
+            modes (int or Sequence[int]): which mode to prepare the state in
+                If the modes are not sorted, this is take into account when preparing the state.
+                i.e., when a two mode state is prepared in modes=[3,1], then the first
+                mode of state goes into mode 3 and the second mode goes into mode 1 of the simulator.
+        """
+        if isinstance(modes, int):
+            modes = [modes]
+
+        # make sure number of modes matches shape of r and V
+        N = len(modes)
+        if len(r) != 2*N:
+            raise ValueError("Length of means vector must be twice the number of modes.")
+        if V.shape != (2*N, 2*N):
+            raise ValueError("Shape of covariance matrix must be [2N, 2N], where N is the number of modes.")
+
+        # convert xp-ordering to symmetric ordering
+        means = vstack([r[:N], r[N:]]).reshape(-1, order='F')
+        C = changebasis(N)
+        cov = C.T @ V @ C
+
+        self.circuit.fromscovmat(cov, modes)
+        self.circuit.fromsmean(means, modes)
 
     def is_vacuum(self, tol=0.0, **kwargs):
         """

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -274,7 +274,7 @@ class GaussianBackend(BaseGaussian):
         # convert xp-ordering to symmetric ordering
         means = vstack([r[:N], r[N:]]).reshape(-1, order='F')
         C = changebasis(N)
-        cov = C.T @ V @ C
+        cov = C @ V @ C.T
 
         self.circuit.fromscovmat(cov, modes)
         self.circuit.fromsmean(means, modes)

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -267,7 +267,7 @@ class GaussianModes:
         r"""Instantiates an object when a standard covariance matrix is provided
 
         Args:
-            V (array): covariance matrix in xp-ordering
+            V (array): covariance matrix in symmetric ordering
             modes (Sequence): sequence of modes corresponding to the covariance matrix
         """
         if modes is None:
@@ -282,7 +282,7 @@ class GaussianModes:
             if n > self.nlen:
                 raise ValueError("Covariance matrix is larger than the number of subsystems.")
 
-        # convert to symmetric ordering
+        # convert to xp ordering
         rotmat = changebasis(n)
         VV = np.dot(np.dot(np.transpose(rotmat), V), rotmat)
 
@@ -291,7 +291,7 @@ class GaussianModes:
         C = VV[n:2*n, n:2*n]
         Bt = np.transpose(B)
 
-        if len(modes) < self.nlen:
+        if n < self.nlen:
             # reset modes to be prepared back to the vacuum state
             for mode in modes:
                 self.loss(0.0, mode)

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -264,7 +264,7 @@ class GaussianModes:
             self.mean[mode] = 0.5*(r[2*idx]+1j*r[2*idx+1])
 
     def fromscovmat(self, V, modes=None):
-        r"""Instantiates an object when a standard covariance matrix is provided
+        r"""Updates the circuit's state when a standard covariance matrix is provided.
 
         Args:
             V (array): covariance matrix in symmetric ordering

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -249,24 +249,57 @@ class GaussianModes:
             r[2*i+1] = 2*self.mean[i].imag
         return r
 
-    def __fromsmean(self, r):
-        for i in range(self.nlen):
-            self.mean[i] = 0.5*(r[2*i]+1j*r[2*i+1])
+    def fromsmean(self, r, modes=None):
+        r"""Populates the means from a provided vector of means with hbar=2 assumed.
 
-    def __fromscovmat(self, V):
-        """Instantiates an object when a standard covariance matrix is provided"""
-        n = int(len(V)/2)
-        if n != self.nlen:
-            raise ValueError("Covariance matrix is the incorrect size, does not match means vector")
+        Args:
+            r (array): vector of means in :math:`(x_1,p_1,x_2,p_2,\dots)` ordering
+            modes (Sequence): sequence of modes corresponding to the vector of means
+        """
+        mode_list = modes
+        if modes is None:
+            mode_list = range(self.nlen)
 
-        rotmat = changebasis(self.nlen)
+        for idx, mode in enumerate(mode_list):
+            self.mean[mode] = 0.5*(r[2*idx]+1j*r[2*idx+1])
+
+    def fromscovmat(self, V, modes=None):
+        r"""Instantiates an object when a standard covariance matrix is provided
+
+        Args:
+            V (array): covariance matrix in xp-ordering
+            modes (Sequence): sequence of modes corresponding to the covariance matrix
+        """
+        if modes is None:
+            n = len(V)//2
+            modes = np.arange(self.nlen)
+
+            if n != self.nlen:
+                raise ValueError("Covariance matrix is the incorrect size, does not match means vector.")
+        else:
+            n = len(modes)
+            modes = np.array(modes)
+            if n > self.nlen:
+                raise ValueError("Covariance matrix is larger than the number of subsystems.")
+
+        # convert to symmetric ordering
+        rotmat = changebasis(n)
         VV = np.dot(np.dot(np.transpose(rotmat), V), rotmat)
+
         A = VV[0:n, 0:n]
         B = VV[0:n, n:2*n]
         C = VV[n:2*n, n:2*n]
         Bt = np.transpose(B)
-        self.nmat = 0.25*(A+C+1j*(B-Bt)-2*np.identity(n))
-        self.mmat = 0.25*(A-C+1j*(B+Bt))
+
+        if len(modes) < self.nlen:
+            # reset modes to be prepared back to the vacuum state
+            for mode in modes:
+                self.loss(0.0, mode)
+
+        rows = modes.reshape(-1, 1)
+        cols = modes.reshape(1, -1)
+        self.nmat[rows, cols] = 0.25*(A+C+1j*(B-Bt)-2*np.identity(n))
+        self.mmat[rows, cols] = 0.25*(A-C+1j*(B+Bt))
 
     def qmat(self, modes=None):
         """ Construct the covariance matrix for the Q function"""
@@ -353,7 +386,7 @@ class GaussianModes:
         (A, B, C) = ops.chop_in_blocks(mp, expind)
         V = A-np.dot(np.dot(B, np.linalg.inv(C+covmat)), np.transpose(B))
         V1 = ops.reassemble(V, expind)
-        self.__fromscovmat(V1)
+        self.fromscovmat(V1)
 
         r = self.smean()
         (va, vc) = ops.chop_in_blocks_vector(r, expind)
@@ -361,7 +394,7 @@ class GaussianModes:
 
         va = va+np.dot(np.dot(B, np.linalg.inv(C+covmat)), vm-vc)
         va = ops.reassemble_vector(va, expind)
-        self.__fromsmean(va)
+        self.fromsmean(va)
         return vm
 
     def homodyne(self, n, eps=0.0002):
@@ -383,7 +416,7 @@ class GaussianModes:
         (A, B, C) = ops.chop_in_blocks(mp, expind)
         V = A-np.dot(np.dot(B, np.linalg.inv(C+covmat)), np.transpose(B))
         V1 = ops.reassemble(V, expind)
-        self.__fromscovmat(V1)
+        self.fromscovmat(V1)
 
         r = self.smean()
         (va, vc) = ops.chop_in_blocks_vector(r, expind)
@@ -391,7 +424,7 @@ class GaussianModes:
         vm = np.array([val, vm1])
         va = va+np.dot(np.dot(B, np.linalg.inv(C+covmat)), vm-vc)
         va = ops.reassemble_vector(va, expind)
-        self.__fromsmean(va)
+        self.fromsmean(va)
         return val
 
     def post_select_heterodyne(self, n, alpha_val):
@@ -406,14 +439,14 @@ class GaussianModes:
         (A, B, C) = ops.chop_in_blocks(mp, expind)
         V = A-np.dot(np.dot(B, np.linalg.inv(C+covmat)), np.transpose(B))
         V1 = ops.reassemble(V, expind)
-        self.__fromscovmat(V1)
+        self.fromscovmat(V1)
 
         r = self.smean()
         (va, vc) = ops.chop_in_blocks_vector(r, expind)
         vm = 2.0*np.array([np.real(alpha_val), np.imag(alpha_val)])
         va = va+np.dot(np.dot(B, np.linalg.inv(C+covmat)), vm-vc)
         va = ops.reassemble_vector(va, expind)
-        self.__fromsmean(va)
+        self.fromsmean(va)
         return alpha_val
 
     def apply_u(self, U):

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1666,10 +1666,9 @@ class Gaussian(Preparation, Decomposition):
 
     Args:
         V (array): the :math:`2N\times 2N` (real and positive definite) covariance matrix.
-            If None, then it is assumed that :math:`V=I`.
         r (array): a length :math:`2N` vector of means, of the
-            form :math:`(\x_0,\dots,\x_{N-1},\p_0,\dots,\p_{N-1})`. If None, it is
-            assumed that :math:`r=0`.
+            form :math:`(\x_0,\dots,\x_{N-1},\p_0,\dots,\p_{N-1})`.
+            If None, it is assumed that :math:`r=0`.
         decomp (bool): if False, no decomposition is applied, and the specified modes
             are explicity prepared in the provided Gaussian state.
         hbar (float): the value of :math:`\hbar` used in the definition of the :math:`\x`

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -906,7 +906,7 @@ class Ket(Preparation):
             if not state.is_pure:
                 raise ValueError("Provided Fock state is not pure.")
             super().__init__([state.ket()])
-        elif isinstance(state, BaseGaussian):
+        elif isinstance(state, BaseGaussianState):
             raise ValueError("Gaussian states are not supported for the Ket operation.")
         else:
             super().__init__([state])
@@ -938,7 +938,7 @@ class DensityMatrix(Preparation):
     def __init__(self, state):
         if isinstance(state, BaseFockState):
             super().__init__([state.dm()])
-        elif isinstance(state, BaseGaussian):
+        elif isinstance(state, BaseGaussianState):
             raise ValueError("Gaussian states are not supported for the Ket operation.")
         else:
             super().__init__([state])

--- a/tests/test_multimode_state_preparations.py
+++ b/tests/test_multimode_state_preparations.py
@@ -252,21 +252,21 @@ class GaussianMultimodeTests(GaussianBaseTest):
     def test_multimode_gaussian_state(self):
         """Test multimode Gaussian state preparation"""
         self.logTestName()
-        means = 2*np.random.random(size=[4])-1
-        cov = random_covariance(2, pure=self.kwargs['pure'])
-
-        a = 0.2+0.4j
-        r = 1
-        phi = 0
+        cov = np.diag(np.exp(2*np.array([-1, -1, 1, 1])))
+        means = np.zeros([4])
 
         self.circuit.reset(pure=self.kwargs['pure'])
 
-        # circuit is initially in displaced squeezed state
+        # prepare displaced squeezed states in all modes
+        a = 0.2+0.4j
+        r = 0.5
+        phi = 0.12
         for i in range(self.num_subsystems):
-            self.circuit.prepare_displaced_squeezed_state(a, r, phi, mode=i)
+            self.circuit.prepare_displaced_squeezed_state(a, r, phi, i)
 
-        # prepare Gaussian state in mode 1 and 3
+        # prepare new squeezed displaced state in mode 1 and 3
         self.circuit.prepare_gaussian_state(means, cov, modes=[1, 3])
+        state = self.circuit.state([1, 3])
 
         # test Gaussian state is correct
         state = self.circuit.state([1, 3])
@@ -279,6 +279,71 @@ class GaussianMultimodeTests(GaussianBaseTest):
             state = self.circuit.state([i])
             self.assertAllAlmostEqual(state.means(), ex_means, delta=self.tol)
             self.assertAllAlmostEqual(state.cov(), ex_V, delta=self.tol)
+
+    def test_full_mode_squeezed_state(self):
+        """Test full register Gaussian state preparation"""
+        self.logTestName()
+        cov = np.diag(np.exp(2*np.array([-1, -1, -1, -1, 1, 1, 1, 1])))
+        means = np.zeros([8])
+
+        self.circuit.reset(pure=self.kwargs['pure'])
+        self.circuit.prepare_gaussian_state(means, cov, modes=range(self.num_subsystems))
+        state = self.circuit.state()
+
+        # test Gaussian state is correct
+        state = self.circuit.state()
+        self.assertAllAlmostEqual(state.means(), means, delta=self.tol)
+        self.assertAllAlmostEqual(state.cov(), cov, delta=self.tol)
+
+    def test_multimode_gaussian_state_entangled(self):
+        """Test multimode Gaussian state preparation on an entangled state"""
+        self.logTestName()
+        means = 2*np.random.random(size=[2*self.num_subsystems])-1
+        cov = random_covariance(self.num_subsystems, pure=self.kwargs['pure'])
+
+        self.circuit.reset(pure=self.kwargs['pure'])
+
+        # circuit is initially in a random entangled state
+        self.circuit.prepare_gaussian_state(means, cov, modes=range(self.num_subsystems))
+
+        # test Gaussian state is correct
+        state = self.circuit.state()
+        self.assertAllAlmostEqual(state.means(), means, delta=self.tol)
+        self.assertAllAlmostEqual(state.cov(), cov, delta=self.tol)
+
+        # prepare Gaussian state in mode 2 and 1
+        means2 = 2*np.random.random(size=[4])-1
+        cov2 = random_covariance(2, pure=self.kwargs['pure'])
+        self.circuit.prepare_gaussian_state(means2, cov2, modes=[2, 1])
+
+        # test resulting Gaussian state is correct
+        state = self.circuit.state()
+
+        ex_means = np.array([means[0], means2[1], means2[0], means[3],
+                             means[4], means2[3], means2[2], means[7]])
+
+        ex_cov = np.zeros([8, 8])
+
+        # in the new covariance matrix, modes 0 and 3 remain unchanged
+        idx = np.array([0, 3, 4, 7])
+        rows = idx.reshape(-1, 1)
+        cols = idx.reshape(1, -1)
+        ex_cov[rows, cols] = cov[rows, cols]
+
+        # in the new covariance matrix, modes 1 and 2 have values given by
+        # rows 1 and 0 respectively from cov2
+        idx = np.array([1, 2, 5, 6])
+        rows = idx.reshape(-1, 1)
+        cols = idx.reshape(1, -1)
+
+        idx = np.array([1, 0, 3, 2])
+        rows2 = idx.reshape(-1, 1)
+        cols2 = idx.reshape(1, -1)
+
+        ex_cov[rows, cols] = cov2[rows2, cols2]
+
+        self.assertAllAlmostEqual(state.means(), ex_means, delta=self.tol)
+        self.assertAllAlmostEqual(state.cov(), ex_cov, delta=self.tol)
 
 
 class FrontendFockTests(FockBaseTest):

--- a/tests/test_multimode_state_preparations.py
+++ b/tests/test_multimode_state_preparations.py
@@ -295,15 +295,15 @@ class GaussianMultimodeTests(GaussianBaseTest):
         self.assertAllAlmostEqual(state.means(), means, delta=self.tol)
         self.assertAllAlmostEqual(state.cov(), cov, delta=self.tol)
 
-    def test_multimode_gaussian_state_entangled(self):
-        """Test multimode Gaussian state preparation on an entangled state"""
+    def test_multimode_gaussian_random_state(self):
+        """Test multimode Gaussian state preparation on a random state"""
         self.logTestName()
         means = 2*np.random.random(size=[2*self.num_subsystems])-1
         cov = random_covariance(self.num_subsystems, pure=self.kwargs['pure'])
 
         self.circuit.reset(pure=self.kwargs['pure'])
 
-        # circuit is initially in a random entangled state
+        # circuit is initially in a random state
         self.circuit.prepare_gaussian_state(means, cov, modes=range(self.num_subsystems))
 
         # test Gaussian state is correct
@@ -319,8 +319,11 @@ class GaussianMultimodeTests(GaussianBaseTest):
         # test resulting Gaussian state is correct
         state = self.circuit.state()
 
-        ex_means = np.array([means[0], means2[1], means2[0], means[3],
-                             means[4], means2[3], means2[2], means[7]])
+        # in the new means vector, the modes 0 and 3 remain unchanged
+        # Modes 1 and 2, however, now have values given from elements
+        # means2[1] and means2[0].
+        ex_means = np.array([means[0], means2[1], means2[0], means[3],  # position
+                             means[4], means2[3], means2[2], means[7]]) # momentum
 
         ex_cov = np.zeros([8, 8])
 


### PR DESCRIPTION
**Description of the Change:**

This pull request makes the following changes:

* Adds the `prepare_gaussian_state` BaseGaussian API method, and implements it in the Gaussian backend
* Adds a test for `prepare_gaussian_state`
* Changes the frontend operation `CovarianceState` to `Gaussian`, and provides the ability for `Gaussian` to also explicity prepare the Gaussian state, rather than perform the Williamson decomposition.

**Benefits:**

This puts the Gaussian backend on equal footing with the Fock backends, now all backends support multimode arbitrary state preparation.
