### PR TITLE
Renamed QReg in the Fock backends to Circuit

### DIFF
--- a/strawberryfields/backends/fockbackend/__init__.py
+++ b/strawberryfields/backends/fockbackend/__init__.py
@@ -24,12 +24,12 @@ Fock simulator backend
 
 The :class:`FockBackend` object implements a simulation of quantum optical circuits using
 `NumPy <http://www.numpy.org/>`_. The primary component of the FockBackend is a
-:class:`QReg` object which is used to simulate a multi-mode quantum optical system. The
+:class:`Circuit` object which is used to simulate a multi-mode quantum optical system. The
 :class:`FockBackend` provides the basic API-compatible interface to the simulator, while the
-:class:`QReg` object actually carries out the mathematical simulation.
+:class:`Circuit` object actually carries out the mathematical simulation.
 
 
-The :class:`QReg` simulator maintains an internal tensor representation of the quantum state of a multi-mode quantum optical system
+The :class:`Circuit` simulator maintains an internal tensor representation of the quantum state of a multi-mode quantum optical system
 using a (truncated) Fock basis representation. As its various state manipulation methods are called, the quantum state is updated
 to reflect these changes. The simulator will try to keep the internal state in a pure (vector) representation
 for as long as possible. Unitary gates will not change the type of representation, while state preparations and measurements will.

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -24,7 +24,7 @@ from cmath import phase
 import numpy as np
 
 from strawberryfields.backends import BaseFock, ModeMap
-from .circuit import QReg
+from .circuit import Circuit
 from ..states import BaseFockState
 
 indices = string.ascii_lowercase
@@ -80,7 +80,7 @@ class FockBackend(BaseFock):
             raise ValueError("Argument 'pure' must be either True or False")
 
         self._init_modes = num_subsystems
-        self.qreg = QReg(num_subsystems, cutoff_dim, hbar, pure)
+        self.circuit = Circuit(num_subsystems, cutoff_dim, hbar, pure)
         self._modemap = ModeMap(num_subsystems)
 
     def add_mode(self, n=1):
@@ -91,7 +91,7 @@ class FockBackend(BaseFock):
         Args:
             n (int): the number of modes to be added to the circuit
         """
-        self.qreg.alloc(n)
+        self.circuit.alloc(n)
         self._modemap.add(n)
 
     def del_mode(self, modes):
@@ -106,7 +106,7 @@ class FockBackend(BaseFock):
         remapped_modes = self._remap_modes(modes)
         if isinstance(remapped_modes, int):
             remapped_modes = [remapped_modes]
-        self.qreg.dealloc(remapped_modes)
+        self.circuit.dealloc(remapped_modes)
         self._modemap.delete(modes)
 
     def get_modes(self):
@@ -123,9 +123,9 @@ class FockBackend(BaseFock):
         Args:
             pure (bool): whether to use a pure state representation upon reset
         """
-        cutoff = kwargs.get('cutoff_dim', self.qreg._trunc)
+        cutoff = kwargs.get('cutoff_dim', self.circuit._trunc)
         self._modemap.reset()
-        self.qreg.reset(pure, num_subsystems=self._init_modes, cutoff_dim=cutoff)
+        self.circuit.reset(pure, num_subsystems=self._init_modes, cutoff_dim=cutoff)
 
     def prepare_vacuum_state(self, mode):
         """Prepare the vacuum state on the specified mode.
@@ -134,7 +134,7 @@ class FockBackend(BaseFock):
         Args:
             mode (int): index of mode where state is prepared
         """
-        self.qreg.prepare_mode_fock(0, self._remap_modes(mode))
+        self.circuit.prepare_mode_fock(0, self._remap_modes(mode))
 
     def prepare_coherent_state(self, alpha, mode):
         """Prepare a coherent state with parameter alpha on the specified mode.
@@ -144,7 +144,7 @@ class FockBackend(BaseFock):
             alpha (complex): coherent state displacement parameter
             mode (int): index of mode where state is prepared
         """
-        self.qreg.prepare_mode_coherent(alpha, self._remap_modes(mode))
+        self.circuit.prepare_mode_coherent(alpha, self._remap_modes(mode))
 
     def prepare_squeezed_state(self, r, phi, mode):
         r"""Prepare a squeezed vacuum state in the specified mode.
@@ -159,7 +159,7 @@ class FockBackend(BaseFock):
             phi (float): squeezing angle
             mode (int): which mode to prepare the squeezed state in
         """
-        self.qreg.prepare_mode_squeezed(r, phi, self._remap_modes(mode))
+        self.circuit.prepare_mode_squeezed(r, phi, self._remap_modes(mode))
 
     def prepare_displaced_squeezed_state(self, alpha, r, phi, mode):
         """Prepare a displaced squezed state with parameters (alpha, r, phi) on the specified mode.
@@ -172,7 +172,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self.qreg.prepare_mode_displaced_squeezed(alpha, r, phi, self._remap_modes(mode))
+        self.circuit.prepare_mode_displaced_squeezed(alpha, r, phi, self._remap_modes(mode))
 
     def prepare_thermal_state(self, nbar, mode):
         """Prepare the thermal state with mean photon number nbar on the specified mode.
@@ -182,7 +182,7 @@ class FockBackend(BaseFock):
             nbar (float): mean thermal population of the mode
             mode (int): which mode to prepare the thermal state in
         """
-        self.qreg.prepare_mode_thermal(nbar, self._remap_modes(mode))
+        self.circuit.prepare_mode_thermal(nbar, self._remap_modes(mode))
 
     def rotation(self, phi, mode):
         """Apply the phase-space rotation operation to the specified mode.
@@ -191,7 +191,7 @@ class FockBackend(BaseFock):
             phi (float): rotation angle
             mode (int): which mode to apply the rotation to
         """
-        self.qreg.phase_shift(phi, self._remap_modes(mode))
+        self.circuit.phase_shift(phi, self._remap_modes(mode))
 
     def displacement(self, alpha, mode):
         """Perform a displacement operation on the specified mode.
@@ -201,7 +201,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where operation is carried out
 
         """
-        self.qreg.displacement(alpha, self._remap_modes(mode))
+        self.circuit.displacement(alpha, self._remap_modes(mode))
 
     def squeeze(self, z, mode):
         """Perform a squeezing operation on the specified mode.
@@ -211,7 +211,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where operation is carried out
 
         """
-        self.qreg.squeeze(abs(z), phase(z), self._remap_modes(mode))
+        self.circuit.squeeze(abs(z), phase(z), self._remap_modes(mode))
 
     def beamsplitter(self, t, r, mode1, mode2):
         """Perform a beamsplitter operation on the specified modes.
@@ -223,7 +223,7 @@ class FockBackend(BaseFock):
             mode2 (int): index of second mode where operation is carried out
 
         """
-        self.qreg.beamsplitter(t, abs(r), phase(r), self._remap_modes(mode1), self._remap_modes(mode2))
+        self.circuit.beamsplitter(t, abs(r), phase(r), self._remap_modes(mode1), self._remap_modes(mode2))
 
     def kerr_interaction(self, kappa, mode):
         r"""Apply the Kerr interaction :math:`\exp{(i\kappa \hat{n}^2)}` to the specified mode.
@@ -232,7 +232,7 @@ class FockBackend(BaseFock):
             kappa (float): strength of the interaction
             mode (int): which mode to apply it to
         """
-        self.qreg.kerr_interaction(kappa, self._remap_modes(mode))
+        self.circuit.kerr_interaction(kappa, self._remap_modes(mode))
 
     def cross_kerr_interaction(self, kappa, mode1, mode2):
         r"""Apply the two mode cross-Kerr interaction :math:`\exp{(i\kappa \hat{n}_1\hat{n}_2)}` to the specified modes.
@@ -242,7 +242,7 @@ class FockBackend(BaseFock):
             mode1 (int): first mode that cross-Kerr interaction acts on
             mode2 (int): second mode that cross-Kerr interaction acts on
         """
-        self.qreg.cross_kerr_interaction(kappa, self._remap_modes(mode1), self._remap_modes(mode2))
+        self.circuit.cross_kerr_interaction(kappa, self._remap_modes(mode1), self._remap_modes(mode2))
 
     def cubic_phase(self, gamma, mode):
         r"""Apply the cubic phase operation to the specified mode.
@@ -255,7 +255,7 @@ class FockBackend(BaseFock):
             gamma (float): cubic phase shift
             mode (int): which mode to apply it to
         """
-        self.qreg.cubic_phase_shift(gamma, self._remap_modes(mode))
+        self.circuit.cubic_phase_shift(gamma, self._remap_modes(mode))
 
     def measure_homodyne(self, phi, mode, select=None, **kwargs):
         """Perform a homodyne measurement on the specified mode.
@@ -271,7 +271,7 @@ class FockBackend(BaseFock):
         Returns:
             float: measurement outcome
         """
-        return self.qreg.measure_homodyne(phi, self._remap_modes(mode), select=select, **kwargs)
+        return self.circuit.measure_homodyne(phi, self._remap_modes(mode), select=select, **kwargs)
 
     def loss(self, T, mode):
         """Perform a loss channel operation on the specified mode.
@@ -281,7 +281,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where operation is carried out
 
         """
-        self.qreg.loss(T, self._remap_modes(mode))
+        self.circuit.loss(T, self._remap_modes(mode))
 
     def is_vacuum(self, tol=0.0, **kwargs):
         r"""Test whether the current circuit state is in vacuum (up to tolerance tol).
@@ -292,7 +292,7 @@ class FockBackend(BaseFock):
         Returns:
             bool: True if vacuum state up to tolerance tol
         """
-        return self.qreg.is_vacuum(tol)
+        return self.circuit.is_vacuum(tol)
 
     def get_cutoff_dim(self):
         """Returns the Hilbert space cutoff dimension used.
@@ -300,7 +300,7 @@ class FockBackend(BaseFock):
         Returns:
             int: cutoff dimension
         """
-        return self.qreg._trunc
+        return self.circuit._trunc
 
 
     def state(self, modes=None, **kwargs):
@@ -312,7 +312,7 @@ class FockBackend(BaseFock):
         Returns:
             BaseFockState: an instance of the Strawberry Fields FockState class.
         """
-        s, pure = self.qreg.get_state()
+        s, pure = self.circuit.get_state()
 
         if modes is None:
             # reduced state is full state
@@ -361,8 +361,8 @@ class FockBackend(BaseFock):
             index_permutation = [2*x+i for x in mode_permutation for i in (0, 1)]
             red_state = np.transpose(red_state, np.argsort(index_permutation))
 
-        hbar = self.qreg._hbar
-        cutoff = self.qreg._trunc # pylint: disable=protected-access
+        hbar = self.circuit._hbar
+        cutoff = self.circuit._trunc # pylint: disable=protected-access
         mode_names = ["q[{}]".format(i) for i in np.array(self.get_modes())[modes]]
         state = BaseFockState(red_state, len(modes), pure, cutoff, hbar, mode_names)
         return state
@@ -380,7 +380,7 @@ class FockBackend(BaseFock):
             mode (int): index of mode where state is prepared
 
         """
-        self.qreg.prepare_mode_fock(n, self._remap_modes(mode))
+        self.circuit.prepare_mode_fock(n, self._remap_modes(mode))
 
     def prepare_ket_state(self, state, modes):
         """Prepare an arbitrary pure state on the specified mode.
@@ -390,7 +390,7 @@ class FockBackend(BaseFock):
             state (array): vector representation of ket state to prepare
             mode (int): index of mode where state is prepared
         """
-        self.qreg.prepare_multimode(state, self._remap_modes(modes))
+        self.circuit.prepare_multimode(state, self._remap_modes(modes))
 
     def prepare_dm_state(self, state, modes):
         """Prepare an arbitrary mixed state on the specified mode.
@@ -400,7 +400,7 @@ class FockBackend(BaseFock):
             state (array): density matrix representation of state to prepare
             mode (int): index of mode where state is prepared
         """
-        self.qreg.prepare_multimode(state, self._remap_modes(modes))
+        self.circuit.prepare_multimode(state, self._remap_modes(modes))
 
     def measure_fock(self, modes, select=None, **kwargs):
         """Perform a Fock measurement on the specified modes.
@@ -413,4 +413,4 @@ class FockBackend(BaseFock):
         Returns:
             list[int]: measurement outcomes
         """
-        return self.qreg.measure_fock(self._remap_modes(modes), select=select)
+        return self.circuit.measure_fock(self._remap_modes(modes), select=select)

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -19,14 +19,14 @@ Fock backend proper
 Contains most of the code for managing the simulator state and offloading
 operations to the utilities in ops.
 
-Hyperlinks: :class:`QReg`
+Hyperlinks: :class:`Circuit`
 
 .. currentmodule:: strawberryfields.backends.fockbackend.circuit
 
 Contents
 ----------------------
 .. autosummary::
-     QReg
+     Circuit
 
 """
 # pylint: disable=too-many-arguments,len-as-condition,attribute-defined-outside-init
@@ -46,7 +46,7 @@ from . import ops
 indices = string.ascii_lowercase
 MAX_MODES = len(indices) - 3
 
-class QReg():
+class Circuit():
     """
     Class implementing a basic simulator for a collection of modes
     in the fock basis.

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -24,12 +24,12 @@ Tensorflow simulator backend
 
 The :class:`TFBackend` object implements a simulation of quantum optical circuits using
 `Tensorflow <http://www.Tensorflow.org/>`_. The primary component of the TFBackend is a
-:class:`QReg` object which is used to simulate a multi-mode quantum optical system. The
+:class:`Circuit` object which is used to simulate a multi-mode quantum optical system. The
 :class:`TFBackend` provides the basic API-compatible interface to the simulator, while the
-:class:`QReg` object actually carries out the mathematical simulation.
+:class:`Circuit` object actually carries out the mathematical simulation.
 
 
-The :class:`QReg` simulator maintains an internal tensor representation of the quantum state of a multi-mode quantum optical system
+The :class:`Circuit` simulator maintains an internal tensor representation of the quantum state of a multi-mode quantum optical system
 using a (truncated) Fock basis representation. As its various state manipulation methods are called, the quantum state is updated
 to reflect these changes. The simulator will try to keep the internal state in a pure (vector) representation
 for as long as possible. Unitary gates will not change the type of representation, while state preparations and measurements will.

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -22,7 +22,7 @@ import numpy as np
 import tensorflow as tf
 
 from strawberryfields.backends import BaseFock, ModeMap
-from .circuit import QReg
+from .circuit import Circuit
 from .ops import _check_for_eval, mixed, partial_trace, reorder_modes
 from .states import FockStateTF
 
@@ -95,7 +95,7 @@ class TFBackend(BaseFock):
                 raise ValueError("batch_size of 1 not supported, please use different batch_size or set batch_size=None")
             else:
                 self._modemap = ModeMap(num_subsystems)
-                circuit = QReg(self._graph, num_subsystems, cutoff_dim, hbar, pure, batch_size)
+                circuit = Circuit(self._graph, num_subsystems, cutoff_dim, hbar, pure, batch_size)
 
         self._init_modes = num_subsystems
         self.circuit = circuit

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -19,14 +19,14 @@ Tensorflow backend proper
 Contains most of the code for managing the simulator state and offloading
 operations to the utilities in ops.
 
-Hyperlinks: :class:`QReg`
+Hyperlinks: :class:`Circuit`
 
 .. currentmodule:: strawberryfields.backends.tfbackend.circuit
 
 Contents
 ----------------------
 .. autosummary::
-     QReg
+     Circuit
 
 """
 # pylint: disable=too-many-arguments,too-many-statements,too-many-branches,protected-access,attribute-defined-outside-init
@@ -41,7 +41,7 @@ import tensorflow as tf
 
 from . import ops
 
-class QReg:
+class Circuit:
     """Base class for representing and operating on a collection of
          CV quantum optics modes in the Fock basis.
          The modes are initialized in the (multimode) vacuum state,

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -17,7 +17,7 @@ Key mathematical operations used for tensorflow backend
 ======================
 
 Contains the basic linear algebraic utilities needed by the tensorflow simulator backend
-Hyperlinks: :class:`QReg`
+Hyperlinks: :class:`Circuit`
 
 .. currentmodule:: strawberryfields.backends.tfbackend.ops
 


### PR DESCRIPTION
**Description of the Change:**

As per the title, this pull request renames the `QReg` class to `Circuit`. 

**Benefits:**

The name now more closely corresponds to the file name `circuit.py`, and matches the Gaussian class `GaussianCircuit`.

**Possible Drawbacks:**

None as far as I can see.

**Related GitHub Issues:**

n/a