### PR TITLE
fixed beamsplitter such that t must be float

### DIFF
--- a/doc/gallery/gallery.rst
+++ b/doc/gallery/gallery.rst
@@ -57,19 +57,19 @@ In addition to the notebooks in the gallery, below are some external web resourc
 
 .. Add your external blog post/application/GitHub page below!
 
-* `Verifying continuous-variable Bell correlations <https://peterwittek.com/verifying-cv-bell-correlations.html>`_ by Peter Wittek
+* `Verifying continuous-variable Bell correlations <https://peterwittek.com/verifying-cv-bell-correlations.html>`_ - Peter Wittek
 
-  Explore how Strawberry Fields can be used to understand core concepts in quantum physics, such as the violation of the Bell inequalities.
-
-
-* `Getting Started with Quantum Programming <https://hackernoon.com/an-interactive-tutorial-on-quantum-programming-327da388f859>`_ by Tanisha Bassan
-
-  The timeless game of battleships has been updated for the 21st century; Quantum Battleships, powered by Strawberry Fields.
+  *Explore how Strawberry Fields can be used to understand core concepts in quantum physics, such as the violation of the Bell inequalities.*
 
 
-* `The World of Photonic Quantum Computing <https://medium.com/@briannagopaul/the-world-of-photonic-quantum-computing-4787a2b12649>`_ by Brianna Gopaul
+* `Getting Started with Quantum Programming <https://hackernoon.com/an-interactive-tutorial-on-quantum-programming-327da388f859>`_ - Tanisha Bassan
 
-  See how Strawberry Fields can be used to visualize how the elementary CV gate set transforms the vacuum state.
+  *The timeless game of battleships has been updated for the 21st century; Quantum Battleships, powered by Strawberry Fields.*
+
+
+* `The World of Photonic Quantum Computing <https://medium.com/@briannagopaul/the-world-of-photonic-quantum-computing-4787a2b12649>`_ - Brianna Gopaul
+
+  *See how Strawberry Fields can be used to visualize how the elementary CV gate set transforms the vacuum state.*
 
 
 

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -217,12 +217,14 @@ class FockBackend(BaseFock):
         """Perform a beamsplitter operation on the specified modes.
 
         Args:
-            t (complex): transmittivity parameter
+            t (float): transmittivity parameter
             r (complex): reflectivity parameter
             mode1 (int): index of first mode where operation is carried out
             mode2 (int): index of second mode where operation is carried out
 
         """
+        if isinstance(t, complex):
+            raise ValueError("Beamsplitter transmittivity t must be a float.")
         self.circuit.beamsplitter(t, abs(r), phase(r), self._remap_modes(mode1), self._remap_modes(mode2))
 
     def kerr_interaction(self, kappa, mode):

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -187,11 +187,13 @@ class GaussianBackend(BaseGaussian):
         It is assumed that :math:`|r|^2+|t|^2 = t^2+|r|^2=1`, i.e that t is real.
 
         Args:
-            t (complex): transmittivity parameter
+            t (float): transmittivity parameter
             r (complex): reflectivity parameter
             mode1 (int): index of first mode where operation is carried out
             mode2 (int): index of second mode where operation is carried out
         """
+        if isinstance(t, complex):
+            raise ValueError("Beamsplitter transmittivity t must be a float.")
         theta = arctan2(abs(r), t)
         phi = angle(r)
         self.circuit.beamsplitter(-theta, -phi, mode1, mode2)

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -296,13 +296,18 @@ class TFBackend(BaseFock):
         Perform a beamsplitter operation on the specified modes.
 
         Args:
-            t (complex): transmittivity parameter
+            t (float): transmittivity parameter
             r (complex): reflectivity parameter
             mode1 (int): index of first mode where operation is carried out
             mode2 (int): index of second mode where operation is carried out
 
         """
         with tf.name_scope('Beamsplitter'):
+            if isinstance(t, complex):
+                raise ValueError("Beamsplitter transmittivity t must be a float.")
+            if isinstance(t, tf.Tensor):
+                if t.dtype.is_complex:
+                    raise ValueError("Beamsplitter transmittivity t must be a float.")
             remapped_modes = self._remap_modes([mode1, mode2])
             self.circuit.beamsplitter(t, r, remapped_modes[0], remapped_modes[1])
 

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -293,7 +293,7 @@ def beamsplitter_matrix(t, r, D, batched=False, save=False, directory=None):
         r = tf.expand_dims(r, -1)
     t = tf.cast(tf.reshape(t, [-1, 1, 1, 1, 1, 1]), def_type)
     r = tf.cast(tf.reshape(r, [-1, 1, 1, 1, 1, 1]), def_type)
-    mag_t = tf.abs(t)
+    mag_t = tf.cast(t, tf.float32)
     mag_r = tf.abs(r)
     phase_r = tf.atan2(tf.imag(r), tf.real(r))
 

--- a/tests/test_beamsplitter_operation.py
+++ b/tests/test_beamsplitter_operation.py
@@ -17,7 +17,7 @@ from scipy.special import factorial
 from defaults import BaseTest, FockBaseTest
 
 phase_alphas = np.linspace(0, 2 * np.pi, 3, endpoint=False) + np.pi / 13
-t_values = np.linspace(0., 1., 3)
+t_values = np.linspace(-0.2, 1., 3)
 phase_r = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 
 ###################################################################
@@ -29,6 +29,15 @@ class BasicTests(BaseTest):
   def setUp(self):
     super().setUp()
     self.mag_alphas = np.linspace(0., self.args.alpha, 3)
+
+  def test_complex_t(self):
+    """Test exception raised if t is complex"""
+    self.logTestName()
+    t = 0.1 + 0.5j
+    r = np.exp(1j * 0.2) * np.sqrt(1. - np.abs(t) ** 2)
+    with self.assertRaisesRegex(ValueError, "must be a float"):
+      self.circuit.reset(pure=self.kwargs['pure'])
+      self.circuit.beamsplitter(t, r, 0, 1)
 
   def test_vacuum_beamsplitter(self):
     """Tests beamsplitter operation in some limiting cases where the output


### PR DESCRIPTION
**Description of the Change:**

Added a bugfix to ensure that the beamsplitter is consistent for negative values of transmittivity across all backends. The docstrings have been updated to specify `t (float)`, and a ValueError is now raised if `t` is complex.

In addition, `test_beamsplitter_operation.py` has been modified to take into account negative values of `t`, and an additional test has been included to ensure a ValueError is raised if `t` is complex.

**Benefits:**

The behaviour of the beamsplitter is now consistent across all backends for negative values of t.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

n/a
