### PR TITLE
New channels

### DIFF
--- a/doc/conventions/others.rst
+++ b/doc/conventions/others.rst
@@ -48,10 +48,10 @@ Loss is implemented by a CPTP map whose Kraus representation is
 .. admonition:: Definition
     :class: defn
 
-    Loss is implemented by coupling mode :math:`\a` to another bosonic mode prepared in the vacuum state, by using the following transformation
+    Loss is implemented by coupling mode :math:`\a` to another bosonic mode :math:`\hat{b}` prepared in the vacuum state, by using the following transformation
 
     .. math::
-       \a \to \sqrt{T} \a+\sqrt{1-T} c
+       \a \to \sqrt{T} \a+\sqrt{1-T} \hat{b}
 
     and then tracing it out. Here, :math:`T` is the *energy* transmissivity. For :math:`T = 0` the state is mapped to the vacuum state, and for :math:`T=1` one has the identity map.
 
@@ -67,6 +67,28 @@ One useful identity is
 
 In particular :math:`\mathcal{N}(T)\left\{\ket{0}\bra{0} \right\} =  \pr{0}`.
 
+
+.. _thermal_loss:
+
+Thermal loss channel
+---------------------------------------------
+
+.. admonition:: Definition
+    :class: defn
+
+    Thermal loss is implemented by coupling mode :math:`\a` to another bosonic mode :math:`\hat{b}` prepared in the thermal state :math:`\ket{\bar{n}}`, by using the following transformation
+
+    .. math::
+       \a \to \sqrt{T} \a+\sqrt{1-T} \hat{b}
+
+    and then tracing it out. Here, :math:`T` is the *energy* transmissivity. For :math:`T = 0` the state is mapped to the thermal state :math:`\ket{\bar{n}}`, and for :math:`T=1` one has the identity map.
+
+.. tip::
+
+   *Implemented in Strawberry Fields as a quantum channel by* :class:`strawberryfields.ops.ThermalLossChannel`
+
+
+Note that if :math:`\bar{n}=0`, the thermal loss channel is equivalent to the :ref:`loss channel <loss>`.
 
 
 Commutation relations

--- a/doc/conventions/others.rst
+++ b/doc/conventions/others.rst
@@ -81,7 +81,7 @@ Thermal loss channel
     .. math::
        \a \to \sqrt{T} \a+\sqrt{1-T} \hat{b}
 
-    and then tracing it out. Here, :math:`T` is the *energy* transmissivity. For :math:`T = 0` the state is mapped to the thermal state :math:`\ket{\bar{n}}`, and for :math:`T=1` one has the identity map.
+    and then tracing it out. Here, :math:`T` is the *energy* transmissivity. For :math:`T = 0` the state is mapped to the thermal state :math:`\ket{\bar{n}}` with mean photon number :math:`\bar{n}`, and for :math:`T=1` one has the identity map.
 
 .. tip::
 

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -73,6 +73,7 @@ Base backend
     squeeze
     beamsplitter
     loss
+    thermal_loss
     measure_homodyne
     state
     is_vacuum
@@ -432,6 +433,16 @@ class BaseBackend:
 
         Args:
             T (float): loss parameter, :math:`0\leq T\leq 1`.
+            mode (int): index of mode where operation is carried out
+        """
+        raise NotImplementedError
+
+    def thermal_loss(self, T, nbar, mode):
+        r"""Perform a thermal loss channel operation on the specified mode.
+
+        Args:
+            T (float): loss parameter, :math:`0\leq T\leq 1`.
+            nbar (float): mean photon number of the environment thermal state
             mode (int): index of mode where operation is carried out
         """
         raise NotImplementedError

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=too-many-public-methods
 """Gaussian backend"""
 from numpy import empty, concatenate, array, identity, arctan2, angle, sqrt, dot, vstack
 from numpy.linalg import inv
@@ -292,27 +293,23 @@ class GaussianBackend(BaseGaussian):
         return self.circuit.is_vacuum(tol)
 
     def loss(self, T, mode):
-        """
-        Perform a loss channel operation on the specified mode.
+        """Perform a loss channel operation on the specified mode.
 
         Args:
-            T: loss parameter
+            T (float): loss parameter
             mode (int): index of mode where operation is carried out
-
         """
         self.circuit.loss(T, mode)
 
-
-    def thermal_loss(self, T, nth, mode):
-        """
-        Perform a thermal loss channel operation on the specified mode.
+    def thermal_loss(self, T, nbar, mode):
+        """Perform a thermal loss channel operation on the specified mode.
 
         Args:
-            T: loss parameter
+            T (float): loss parameter
+            nbar (float): mean photon number of the environment thermal state
             mode (int): index of mode where operation is carried out
-
         """
-        self.circuit.thermal_loss(T, nth, mode)
+        self.circuit.thermal_loss(T, nbar, mode)
 
     def state(self, modes=None, **kwargs):
         """ Returns the vector of means and the covariance matrix of the specified modes.

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -357,15 +357,15 @@ class GaussianModes:
         self.mmat[:, k] = self.mmat[k]
         self.mean[k] = sqrtT*self.mean[k]
 
-    def thermal_loss(self, T, nth, k):
+    def thermal_loss(self, T, nbar, k):
         r""" Implements the thermal loss channel in mode k by amplitude loss amount \sqrt{T}
         unlike the loss channel, here the ancilliary mode that goes into the second arm of the
         beam splitter is prepared in a thermal state with mean photon number nth """
         if self.active[k] is None:
             raise ValueError("Cannot apply loss channel, mode does not exist")
-        
-        self.loss(T,k)
-        self.nmat += (1-T)*nth
+
+        self.loss(T, k)
+        self.nmat += (1-T)*nbar
 
     def init_thermal(self, population, mode):
         """ Initializes a state of mode in a thermal state with the given population"""

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -618,7 +618,7 @@ class Channel(Transformation):
     maps and transformations.
     """
     def merge(self, other):
-        # check that other an identical channel, and that
+        # check that other is an identical channel, and that there are
         # no extra dependencies <=> no RegRefTransform parameters
         if isinstance(other, self.__class__) \
         and len(self._extra_deps)+len(other._extra_deps) == 0:
@@ -1077,11 +1077,11 @@ class MeasureHeterodyne(Measurement):
 class LossChannel(Channel):
     r"""Perform a :ref:`loss channel <loss>` operation on the specified mode.
 
-    This channel couples mode :math:`a` to another bosonic mode :math:`b`
+    This channel couples mode :math:`\a` to another bosonic mode :math:`\hat{b}`
     prepared in the vacuum state using the following transformation:
 
     .. math::
-       a \mapsto \sqrt{T} a+\sqrt{1-T} b
+       \a \mapsto \sqrt{T} a+\sqrt{1-T} \hat{b}
 
     Args:
         T (float): the loss parameter :math:`0\leq T\leq 1`.
@@ -1097,12 +1097,12 @@ class LossChannel(Channel):
 class ThermalLossChannel(Channel):
     r"""Perform a :ref:`thermal loss channel <thermal_loss>` operation on the specified mode.
 
-    This channel couples mode :math:`a` to another bosonic mode :math:`b`
+    This channel couples mode :math:`\a` to another bosonic mode :math:`\hat{b}`
     prepared in a thermal state with mean photon number :math:`\bar{n}`,
     using the following transformation:
 
     .. math::
-       a \mapsto \sqrt{T} a+\sqrt{1-T} b
+       \a \mapsto \sqrt{T} a+\sqrt{1-T} \hat{b}
 
     Args:
         T (float): the loss parameter :math:`0\leq T\leq 1`.

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1820,6 +1820,6 @@ one_args_gates = (Xgate, Zgate, Rgate, Pgate, Vgate, Kgate, CXgate, CZgate, CKga
 two_args_gates = (Dgate, Sgate, BSgate, S2gate)
 gates = zero_args_gates + one_args_gates + two_args_gates
 
-channels = (LossChannel,)
+channels = (LossChannel, ThermalLossChannel)
 
 state_preparations = (Vacuum, Coherent, Squeezed, DisplacedSqueezed, Fock, Thermal, Catstate)

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -635,8 +635,8 @@ class Channel(Transformation):
 
             if len(self.p) == 1:
                 return self.__class__(T)
-            else:
-                return self.__class__(T, *self.p[1:])
+
+            return self.__class__(T, *self.p[1:])
         else:
             raise MergeFailure('Not the same operation family.')
 
@@ -1095,7 +1095,7 @@ class LossChannel(Channel):
 
 
 class ThermalLossChannel(Channel):
-    r"""Perform a thermal loss channel operation on the specified mode.
+    r"""Perform a :ref:`thermal loss channel <thermal_loss>` operation on the specified mode.
 
     This channel couples mode :math:`a` to another bosonic mode :math:`b`
     prepared in a thermal state with mean photon number :math:`\bar{n}`,

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -141,16 +141,33 @@ class GateTests(BaseTest):
             merge_gates(G)
 
 
-    def test_loss_merging(self):
-        "Nontrivial merging of loss."
+    def test_channel_merging(self):
+        "Nontrivial merging of channels."
         self.logTestName()
 
-        # test the merging of two gates (with default values for optional parameters)
+        # test the merging of two Loss channels (with default values for optional parameters)
         a, b = random(2)
         G = LossChannel(a)
         temp = G.merge(LossChannel(b))
         self.assertAlmostEqual(temp.p[0], a*b, delta=self.tol)
 
+        # test the merging of two thermal Loss channels with same nbar
+        a, b = random(2)
+        G = ThermalLossChannel(a, 0.54)
+        temp = G.merge(ThermalLossChannel(b, 0.54))
+        self.assertAlmostEqual(temp.p[0], a*b, delta=self.tol)
+
+        # test the merging of two thermal Loss channels with different nbar
+        a, b = random(2)
+        G = ThermalLossChannel(a, 0.54)
+        with self.assertRaises(MergeFailure):
+            temp = G.merge(ThermalLossChannel(b, 1.))
+
+        # test the merging of thermal Loss and loss channels
+        a, b = random(2)
+        G = ThermalLossChannel(a, 0.54)
+        with self.assertRaises(MergeFailure):
+            temp = G.merge(LossChannel(b))
 
     def test_dispatch(self):
         "Dispatching of gates to the engine."

--- a/tests/test_loss_channel.py
+++ b/tests/test_loss_channel.py
@@ -11,7 +11,7 @@ import unittest
 import numpy as np
 from scipy.special import factorial
 
-from defaults import BaseTest, FockBaseTest
+from defaults import BaseTest, GaussianBaseTest, FockBaseTest
 
 
 loss_Ts = np.linspace(0., 1., 3, endpoint=True)
@@ -20,97 +20,132 @@ phase_alphas = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 
 ###################################################################
 
+
 class BasicTests(BaseTest):
-  """Basic implementation-independent tests."""
-  num_subsystems = 1
+    """Basic implementation-independent tests."""
+    num_subsystems = 1
 
-  def test_loss_channel_on_vacuum(self):
-    """Tests loss channels on vacuum (result should be vacuum)."""
-    self.logTestName()
-    for T in loss_Ts:
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.loss(T, 0)
-      self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+    def test_loss_channel_on_vacuum(self):
+        """Tests loss channels on vacuum (result should be vacuum)."""
+        self.logTestName()
+        for T in loss_Ts:
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.loss(T, 0)
+            self.assertAllTrue(self.circuit.is_vacuum(self.tol))
 
-  def test_full_loss_channel_on_coherent_states(self):
-    """Tests the full-loss channel on various states (result should be vacuum)."""
-    self.logTestName()
-    T = 0.0
-    for mag_alpha in mag_alphas:
-      for phase_alpha in phase_alphas:
-        alpha = mag_alpha * np.exp(1j * phase_alpha)
-        self.circuit.reset(pure=self.kwargs['pure'])
-        self.circuit.displacement(alpha, 0)
-        self.circuit.loss(T, 0)
-        self.assertAllTrue(self.circuit.is_vacuum(self.tol))
-        if alpha==0.: break
+    def test_full_loss_channel_on_coherent_states(self):
+        """Tests the full-loss channel on various states (result should be vacuum)."""
+        self.logTestName()
+        T = 0.0
+        for mag_alpha in mag_alphas:
+            for phase_alpha in phase_alphas:
+                alpha = mag_alpha * np.exp(1j * phase_alpha)
+                self.circuit.reset(pure=self.kwargs['pure'])
+                self.circuit.displacement(alpha, 0)
+                self.circuit.loss(T, 0)
+                self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+                if alpha == 0.:
+                    break
+
+
+class GaussianBasisTests(GaussianBaseTest):
+    """Tests for the thermal loss channel (currently only
+    supported by the Gaussian backend"""
+    num_subsystems = 1
+
+    def test_thermal_loss_channel_on_vacuum(self):
+        """Tests loss channels on vacuum (result should be thermal state?)."""
+        self.logTestName()
+        nbar = 1.
+        for T in loss_Ts:
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.thermal_loss(T, nbar, 0)
+            self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+
+    def test_full_thermal_loss_channel_on_coherent_states(self):
+        """Tests the full thermal loss channel on various states (result should be thermal state?)."""
+        self.logTestName()
+        T = 0.0
+        nbar = 1.
+        for mag_alpha in mag_alphas:
+            for phase_alpha in phase_alphas:
+                alpha = mag_alpha * np.exp(1j * phase_alpha)
+                self.circuit.reset(pure=self.kwargs['pure'])
+                self.circuit.displacement(alpha, 0)
+                self.circuit.thermal_loss(T, nbar, 0)
+                self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+                if alpha == 0.:
+                    break
+
 
 class FockBasisTests(FockBaseTest):
-  """Tests for simulators that use Fock basis."""
-  num_subsystems = 1
+    """Tests for simulators that use Fock basis."""
+    num_subsystems = 1
 
-  def test_normalized_after_loss_channel_on_coherent_state(self):
-    """Tests if a range of loss states are normalized."""
-    self.logTestName()
-    for T in loss_Ts:
-      for mag_alpha in mag_alphas:
-        for phase_alpha in phase_alphas:
-          alpha = mag_alpha * np.exp(1j * phase_alpha)
-          self.circuit.reset(pure=self.kwargs['pure'])
-          self.circuit.prepare_coherent_state(alpha, 0)
-          self.circuit.loss(T, 0)
-          state = self.circuit.state()
-          tr = state.trace()
-          self.assertAllAlmostEqual(tr, 1, delta=self.tol)
+    def test_normalized_after_loss_channel_on_coherent_state(self):
+        """Tests if a range of loss states are normalized."""
+        self.logTestName()
+        for T in loss_Ts:
+            for mag_alpha in mag_alphas:
+                for phase_alpha in phase_alphas:
+                    alpha = mag_alpha * np.exp(1j * phase_alpha)
+                    self.circuit.reset(pure=self.kwargs['pure'])
+                    self.circuit.prepare_coherent_state(alpha, 0)
+                    self.circuit.loss(T, 0)
+                    state = self.circuit.state()
+                    tr = state.trace()
+                    self.assertAllAlmostEqual(tr, 1, delta=self.tol)
 
-  def test_normalized_after_loss_channel_on_fock_state(self):
-    """Tests if a range of loss states are normalized."""
-    self.logTestName()
-    for T in loss_Ts:
-      for n in range(self.D):
-        self.circuit.reset(pure=self.kwargs['pure'])
-        self.circuit.prepare_fock_state(n, 0)
-        self.circuit.loss(T, 0)
-        state = self.circuit.state()
-        tr = state.trace()
-        self.assertAllAlmostEqual(tr, 1, delta=self.tol)
+    def test_normalized_after_loss_channel_on_fock_state(self):
+        """Tests if a range of loss states are normalized."""
+        self.logTestName()
+        for T in loss_Ts:
+            for n in range(self.D):
+                self.circuit.reset(pure=self.kwargs['pure'])
+                self.circuit.prepare_fock_state(n, 0)
+                self.circuit.loss(T, 0)
+                state = self.circuit.state()
+                tr = state.trace()
+                self.assertAllAlmostEqual(tr, 1, delta=self.tol)
 
-  def test_full_loss_channel_on_fock_states(self):
-    """Tests the full-loss channel on various states (result should be vacuum)."""
-    self.logTestName()
-    T = 0.0
-    for n in range(self.D):
-      self.circuit.reset(pure=self.kwargs['pure'])
-      self.circuit.prepare_fock_state(n, 0)
-      self.circuit.loss(T, 0)
-      self.assertAllTrue(self.circuit.is_vacuum(self.tol))
+    def test_full_loss_channel_on_fock_states(self):
+        """Tests the full-loss channel on various states (result should be vacuum)."""
+        self.logTestName()
+        T = 0.0
+        for n in range(self.D):
+            self.circuit.reset(pure=self.kwargs['pure'])
+            self.circuit.prepare_fock_state(n, 0)
+            self.circuit.loss(T, 0)
+            self.assertAllTrue(self.circuit.is_vacuum(self.tol))
 
-  def test_loss_channel_on_coherent_states(self):
-    """Tests various loss channels on coherent states (result should be coherent state with amplitude weighted by \sqrt(T)."""
-    self.logTestName()
-    for T in loss_Ts:
-      for mag_alpha in mag_alphas:
-        for phase_alpha in phase_alphas:
-          alpha = mag_alpha * np.exp(1j * phase_alpha)
-          rootT_alpha = np.sqrt(T) * alpha
-          self.circuit.reset(pure=self.kwargs['pure'])
-          self.circuit.prepare_coherent_state(alpha, 0)
-          self.circuit.loss(T, 0)
-          s = self.circuit.state()
-          if s.is_pure:
-            numer_state = s.ket()
-          else:
-            numer_state = s.dm()
-          ref_state = np.array([np.exp(-0.5 * np.abs(rootT_alpha) ** 2) * rootT_alpha ** n / np.sqrt(factorial(n)) for n in range(self.D)])
-          ref_state = np.outer(ref_state, np.conj(ref_state))
-          self.assertAllAlmostEqual(numer_state, ref_state, delta=self.tol)
-          if alpha==0.: break
+    def test_loss_channel_on_coherent_states(self):
+        """Tests various loss channels on coherent states (result should be coherent state with amplitude weighted by \sqrt(T)."""
+        self.logTestName()
+        for T in loss_Ts:
+            for mag_alpha in mag_alphas:
+                for phase_alpha in phase_alphas:
+                    alpha = mag_alpha * np.exp(1j * phase_alpha)
+                    rootT_alpha = np.sqrt(T) * alpha
+                    self.circuit.reset(pure=self.kwargs['pure'])
+                    self.circuit.prepare_coherent_state(alpha, 0)
+                    self.circuit.loss(T, 0)
+                    s = self.circuit.state()
+                    if s.is_pure:
+                        numer_state = s.ket()
+                    else:
+                        numer_state = s.dm()
+                    ref_state = np.array([np.exp(-0.5 * np.abs(rootT_alpha) ** 2) * rootT_alpha ** n / np.sqrt(factorial(n)) for n in range(self.D)])
+                    ref_state = np.outer(ref_state, np.conj(ref_state))
+                    self.assertAllAlmostEqual(numer_state, ref_state, delta=self.tol)
+                    if alpha == 0.:
+                        break
+
 
 if __name__=="__main__":
-  # run the tests in this file
-  suite = unittest.TestSuite()
-  for t in (BasicTests, FockBasisTests):
-    ttt = unittest.TestLoader().loadTestsFromTestCase(t)
-    suite.addTests(ttt)
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    for t in (BasicTests, GaussianBasisTests, FockBasisTests):
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
 
-  unittest.TextTestRunner().run(suite)
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_loss_channel.py
+++ b/tests/test_loss_channel.py
@@ -95,6 +95,23 @@ class GaussianBasisTests(GaussianBaseTest):
             self.assertAllAlmostEqual(state1.means(), state2.means(), delta=self.tol)
             self.assertAllAlmostEqual(state1.cov(), state2.cov(), delta=self.tol)
 
+    def test_thermal_loss_channel_on_squeezed_state(self):
+        """Tests thermal loss channel on a squeezed state"""
+        self.logTestName()
+        r = 0.432
+        for T in loss_Ts:
+            for nbar in mag_alphas:
+                self.circuit.reset(pure=self.kwargs['pure'])
+                self.circuit.squeeze(r, 0)
+                self.circuit.thermal_loss(T, nbar, 0)
+                state = self.circuit.state()
+
+                res = state.cov()
+                exp = np.diag([T*np.exp(-2*r) + (1-T)*(2*nbar+1),
+                               T*np.exp(2*r) + (1-T)*(2*nbar+1)])
+
+                self.assertAllAlmostEqual(res, exp, delta=self.tol)
+
 
 class FockBasisTests(FockBaseTest):
     """Tests for simulators that use Fock basis."""

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -462,6 +462,10 @@ class BasicTests(BaseTest):
                 # catch unapplicable op/backend combinations here
                 logging.debug(err)
                 self.eng.reset_queue()  # unsuccessful run means the queue was not emptied.
+            except NotImplementedError as err:
+                # catch not yet implemented op/backend combinations here
+                logging.debug(err)
+                self.eng.reset_queue()  # unsuccessful run means the queue was not emptied.
 
         scalar_arg_preparations = (Coherent, Squeezed, DisplacedSqueezed, Thermal, Catstate)  # Fock requires an integer parameter
         testset = one_args_gates +two_args_gates +channels +scalar_arg_preparations


### PR DESCRIPTION
**Description of the Change:**

* Thermal loss channel is now implemented in the Gaussian backend
* Added `thermal_loss()` to `BaseBackend`. At the moment, since it is not implemented in the Fock backends, attempting to use it there will raise a `NotImplementedError`.
* Added `ThermalLossChannel` operation to `ops.py`, and moved the common channel merge method up to `Channel`.
* Added backend tests for `thermal_loss` to the `test_loss_channel.py` file.
* Added documentation for the thermal loss channel to `doc/conventions/others.rst`.

**Benefits:**

* The addition of another loss channel.

**Possible Drawbacks:**

* Currently not implemented in the Fock backends - a Kraus operator mapping will need to be implemented.

**Related GitHub Issues:**

* n/a