### PR TITLE
Allow turning circuits into operators

### DIFF
--- a/examples/custom_operator.py
+++ b/examples/custom_operator.py
@@ -15,10 +15,13 @@ from strawberryfields.ops import *
 from strawberryfields.utils import operator
 
 
-@operator(ns=4)
-def prepare_op(q):
-    """
-    :param q: This operator is applied to 4 registers
+@operator(4)
+def prepare_squeezing(q):
+    """This operator prepares modes 0 to 4
+    as squeezed states with r = -1.
+
+    Args:
+        q (register): the qumode register.
     """
     S = Sgate(-1)
     S | q[0]
@@ -27,13 +30,14 @@ def prepare_op(q):
     S | q[3]
 
 
-@operator(ns=3)
+@operator(3)
 def circuit_op(v1, v2, q):
-    """
-    Some gates that are groups into a custom operator
-    :param v1: parameter for CZgate
-    :param v2: parameter for Vgate
-    :param q: it requires three registers to be passed
+    """Some gates that are groups into a custom operator.
+
+    Args:
+        v1 (float): parameter for CZgate
+        v2 (float): parameter for the cubic phase gate
+        q (register): the qumode register.
     """
     CZgate(v1) | (q[0], q[1])
     Vgate(v2) | q[2]
@@ -43,11 +47,11 @@ def circuit_op(v1, v2, q):
 eng, q = sf.Engine(4)
 
 with eng:
-    # operator without arguments
-    prepare_op() | q
+    # The following operator takes no arguments
+    prepare_squeezing() | q
 
     # another operator with 2 parameters that operates on three registers: 0, 1, 3
     circuit_op(0.5719, 2.0603) | (q[0], q[1], q[3])
 
 # run the engine
-eng.run("fock", cutoff_dim=5)
+state = eng.run("fock", cutoff_dim=5)

--- a/examples/custom_operator.py
+++ b/examples/custom_operator.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import strawberryfields as sf
+from strawberryfields.ops import *
+from strawberryfields.utils import operator
+
+
+@operator(ns=4)
+def prepare_op(q):
+    """
+    :param q: This operator is applied to 4 registers
+    """
+    S = Sgate(-1)
+    S | q[0]
+    S | q[1]
+    S | q[2]
+    S | q[3]
+
+
+@operator(ns=3)
+def circuit_op(v1, v2, q):
+    """
+    Some gates that are groups into a custom operator
+    :param v1: parameter for CZgate
+    :param v2: parameter for Vgate
+    :param q: it requires three registers to be passed
+    """
+    CZgate(v1) | (q[0], q[1])
+    Vgate(v2) | q[2]
+
+
+# initialise the engine and register
+eng, q = sf.Engine(4)
+
+with eng:
+    # operator without arguments
+    prepare_op() | q
+
+    # another operator with 2 parameters that operates on three registers: 0, 1, 3
+    circuit_op(0.5719, 2.0603) | (q[0], q[1], q[3])
+
+# run the engine
+eng.run("fock", cutoff_dim=5)

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -95,6 +95,7 @@ Code details
 ~~~~~~~~~~~~
 
 """
+import collections
 from inspect import signature
 
 import numpy as np
@@ -588,8 +589,14 @@ class operator:
         Returns:
             list[RegRef]: subsystem list as RegRefs
         """
+        if (not reg) or (not self.ns):
+            raise ValueError("Wrong number of subsystems")
 
-        if (not reg) or (not self.ns) or len(reg) != self.ns:
+        reg_len = 1
+        if isinstance(reg, collections.Sized):
+            reg_len = len(reg)
+
+        if reg_len != self.ns:
             raise ValueError("Wrong number of subsystems")
 
         return self._call_function(reg)

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -592,6 +592,18 @@ class operator:
         if (not reg) or (not self.ns) or len(reg) != self.ns:
             raise ValueError("Wrong number of subsystems")
 
+        return self._call_function(reg)
+
+    def _call_function(self, reg):
+        """
+        Executes wrapped function and passes the quantum registers
+
+        Args:
+            reg (RegRef, Sequence[RegRef]): subsystem(s) the operation is acting on
+
+        Returns:
+            list[RegRef]: subsystem list as RegRefs
+        """
         func_sig = signature(self.func)
         num_params = len(func_sig.parameters)
 
@@ -613,6 +625,9 @@ class operator:
         self.func = func
 
         def f_proxy(*args):
+            """
+            Proxy for function execution. Function will actually execute in __or__
+            """
             self.args = args
             return self
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for the :mod:`strawberryfields` operator decorator.
+"""
+
+import unittest
+
+from defaults import BaseTest, FockBaseTest, GaussianBaseTest, strawberryfields as sf
+from strawberryfields.ops import *
+from strawberryfields.utils import operator
+
+float_regex = r'(-)?(\d+\.\d+)'
+
+
+class TeleportationOperator(BaseTest):
+    """
+    Run a teleportation algorithm but split the circuit into operators.
+    Operators can be also methods of a class
+    """
+    num_subsystems = 3
+    delta = 0.1
+    cutoff = 10
+
+    def setUp(self):
+        super().setUp()
+        self.eng, q = sf.Engine(self.num_subsystems)
+        # attach the backend (NOTE: self.backend is shared between the tests, make sure it is reset before use!)
+        self.eng.backend = self.backend
+        self.backend.reset(cutoff_dim=self.cutoff)
+
+    @operator(1)
+    def prepare_state(self, v1, q):
+        Coherent(v1) | q
+
+    @operator(2)
+    def entangle_states(self, q):
+        Squeezed(-2) | q[0]
+        Squeezed(2) | q[1]
+        BSgate(pi / 4, 0) | (q[0], q[1])
+
+    def test_teleportation_fidelity(self):
+        self.logTestName()
+        q = self.eng.register
+
+        with self.eng:
+            self.prepare_state(0.5+0.2j) | q[0]
+
+            self.entangle_states() | (q[1], q[2])
+
+            BSgate(pi / 4, 0) | (q[0], q[1])
+            MeasureHomodyne(0, select=0) | q[0]
+            MeasureHomodyne(pi/2, select=0) | q[1]
+
+        state = self.eng.run()
+        fidelity = state.fidelity_coherent([0,0,0.5+0.2j])
+        self.assertAllAlmostEqual(fidelity, 1, delta=self.delta)
+
+
+if __name__ == '__main__':
+    print('Testing Strawberry Fields version ' + sf.version() + ', examples.')
+
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    tests = [
+        TeleportationOperator,
+    ]
+    for t in tests:
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
+
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -54,6 +54,26 @@ class TeleportationOperator(BaseTest):
         fidelity = state.fidelity_coherent([0,0,0.5+0.2j])
         self.assertAllAlmostEqual(fidelity, 1, delta=self.delta)
 
+    def test_validate_argument(self):
+        self.logTestName()
+
+        with self.assertRaises(ValueError):
+            self.prepare_state(1, 2, 3) | (1, 2)
+
+        with self.assertRaises(ValueError):
+            self.prepare_state(1) | (1, 2)
+
+        with self.assertRaises(ValueError):
+            self.prepare_state(1) | ()
+
+        with self.assertRaises(ValueError):
+            self.entangle_states() | (1, 2, 3)
+
+        with self.assertRaises(ValueError):
+            self.entangle_states() | (1)
+
+        with self.assertRaises(ValueError):
+            self.entangle_states() | 1
 
 if __name__ == '__main__':
     print('Testing Strawberry Fields version ' + sf.version() + ', examples.')

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -11,6 +11,18 @@ from strawberryfields.utils import operator
 float_regex = r'(-)?(\d+\.\d+)'
 
 
+@operator(1)
+def prepare_state(v1, q):
+    Coherent(v1) | q
+
+
+@operator(2)
+def entangle_states(q):
+    Squeezed(-2) | q[0]
+    Squeezed(2) | q[1]
+    BSgate(pi / 4, 0) | (q[0], q[1])
+
+
 class TeleportationOperator(BaseTest):
     """
     Run a teleportation algorithm but split the circuit into operators.
@@ -27,24 +39,14 @@ class TeleportationOperator(BaseTest):
         self.eng.backend = self.backend
         self.backend.reset(cutoff_dim=self.cutoff)
 
-    @operator(1)
-    def prepare_state(self, v1, q):
-        Coherent(v1) | q
-
-    @operator(2)
-    def entangle_states(self, q):
-        Squeezed(-2) | q[0]
-        Squeezed(2) | q[1]
-        BSgate(pi / 4, 0) | (q[0], q[1])
-
     def test_teleportation_fidelity(self):
         self.logTestName()
         q = self.eng.register
 
         with self.eng:
-            self.prepare_state(0.5+0.2j) | q[0]
+            prepare_state(0.5+0.2j) | q[0]
 
-            self.entangle_states() | (q[1], q[2])
+            entangle_states() | (q[1], q[2])
 
             BSgate(pi / 4, 0) | (q[0], q[1])
             MeasureHomodyne(0, select=0) | q[0]
@@ -58,22 +60,22 @@ class TeleportationOperator(BaseTest):
         self.logTestName()
 
         with self.assertRaises(ValueError):
-            self.prepare_state(1, 2, 3) | (1, 2)
+            prepare_state(1, 2, 3) | (1, 2)
 
         with self.assertRaises(ValueError):
-            self.prepare_state(1) | (1, 2)
+            prepare_state(1) | (1, 2)
 
         with self.assertRaises(ValueError):
-            self.prepare_state(1) | ()
+            prepare_state(1) | ()
 
         with self.assertRaises(ValueError):
-            self.entangle_states() | (1, 2, 3)
+            entangle_states() | (1, 2, 3)
 
         with self.assertRaises(ValueError):
-            self.entangle_states() | (1)
+            entangle_states() | (1)
 
         with self.assertRaises(ValueError):
-            self.entangle_states() | 1
+            entangle_states() | 1
 
 if __name__ == '__main__':
     print('Testing Strawberry Fields version ' + sf.version() + ', examples.')


### PR DESCRIPTION
I still need to add a couple of unit tests, etc. and but I thought it made sense to submit an early PR to check if the approach meets your expectations.

You can check `examples/custom_operator.py` to see how the new feature is supposed to be used.