### PR TITLE
Fixed Bloch-Messiah bug arising when singular values were degenerate

### DIFF
--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -229,7 +229,7 @@ def williamson(V, tol=11):
     return Db, np.linalg.inv(S).T
 
 
-def bloch_messiah(S, tol=10):
+def bloch_messiah(S, tol=10, rounding = 9):
     r""" Performs the Bloch-Messiah decomposition of a symplectic matrix in terms of
     two symplectic unitaries and squeezing transformation.
 
@@ -240,6 +240,9 @@ def bloch_messiah(S, tol=10):
     ..math:: \Omega = \begin{bmatrix}0&I\\-I&0\end{bmatrix}
 
     where :math:`I` is the identity matrix and :math:`0` is the zero matrix.
+
+    As in the Takagi decomposition, the singular values of N are considered
+    equal if they are equal after np.round(values, rounding).
 
     For more info see:
     https://math.stackexchange.com/questions/1886038/finding-euler-decomposition-of-a-symplectic-matrix
@@ -282,7 +285,7 @@ def bloch_messiah(S, tol=10):
 
     # Identifying degenrate subspaces
     result = []
-    for _k, g in groupby(np.diag(st)[:n]):
+    for _k, g in groupby(np.round(np.diag(st), rounding)[:n]):
         result.append(list(g))
 
     stop_is = list(np.cumsum([len(res) for res in result]))

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -293,7 +293,7 @@ def bloch_messiah(S, tol=10):
     u_list, v_list = [], []
 
     for start_i, stop_i in zip(start_is, stop_is):
-        x = qomega[start_i: stop_i, n + start_i: n + stop_i]
+        x = qomega[start_i: stop_i, n + start_i: n + stop_i].real
         u_svd, _s_svd, v_svd = np.linalg.svd(x)
         u_list = u_list + [u_svd]
         v_list = v_list + [v_svd.T]

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -229,7 +229,7 @@ def williamson(V, tol=11):
     return Db, np.linalg.inv(S).T
 
 
-def bloch_messiah(S, tol=10, rounding = 9):
+def bloch_messiah(S, tol=10, rounding=9):
     r""" Performs the Bloch-Messiah decomposition of a symplectic matrix in terms of
     two symplectic unitaries and squeezing transformation.
 
@@ -283,7 +283,7 @@ def bloch_messiah(S, tol=10, rounding = 9):
     qomega = np.transpose(ut) @ (omega) @ ut
     st = pmat @ np.diag(ss) @ pmat
 
-    # Identifying degenrate subspaces
+    # Identifying degenerate subspaces
     result = []
     for _k, g in groupby(np.round(np.diag(st), rounding)[:n]):
         result.append(list(g))
@@ -292,7 +292,7 @@ def bloch_messiah(S, tol=10, rounding = 9):
     start_is = [0] + stop_is[:-1]
 
     # Rotation matrices (not permutations) based on svd.
-    # See Appending B2 of Serafini's book for more details.
+    # See Appendix B2 of Serafini's book for more details.
     u_list, v_list = [], []
 
     for start_i, stop_i in zip(start_is, stop_is):

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -294,7 +294,6 @@ def bloch_messiah(S, tol=10):
 
     for start_i, stop_i in zip(start_is, stop_is):
         x = qomega[start_i: stop_i, n + start_i: n + stop_i]
-        print(start_i, stop_i, x)
         u_svd, _s_svd, v_svd = np.linalg.svd(x)
         u_list = u_list + [u_svd]
         v_list = v_list + [v_svd.T]


### PR DESCRIPTION
**Description of the Change:**
Replaced the permutation matrix originally applied on output to permute it into canonical symplectic form with a rotation matrix that is constructed using SVD. The earlier approach did not return matrices in the canonical symplectic form if one or more of the Bloch-Messiah singular values were degenerate; this is fixed now.

**Benefits:**
Bloch-Messiah now works for input matrices with degenerate singular values.

**Related GitHub Issues:**
Fixes #14, which was an instance of degenerate singular values (both equal to the φ = 1.61803)