### PR TITLE
Better decompositions: Clements et al. (and possibly Reck?)

### DIFF
--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -15,7 +15,6 @@
 
 from itertools import groupby
 
-import math as mt
 import numpy as np
 from scipy.linalg import block_diag, sqrtm, polar, schur
 
@@ -216,7 +215,7 @@ def clements(V, tol=1e-11):
 
     return tilist, tlist, np.diag(localV)
 
-def clements_eq5(V, tol=11):
+def clements_phase_end(V, tol=1e-11):
     r"""Clements decomposition of unitary matrix
 
     See Clements et al. Optica 3, 1460 (2016) [10.1364/OPTICA.3.001460]
@@ -247,7 +246,7 @@ def clements_eq5(V, tol=11):
 
         # The new parameters required for D',T' st. T^(-1)D = D'T'
         new_theta = theta
-        new_phi = mt.fmod((alpha - beta + np.pi), 2*np.pi)
+        new_phi = np.fmod((alpha - beta + np.pi), 2*np.pi)
         new_alpha = beta - phi + np.pi
         new_beta = beta
 

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -168,7 +168,8 @@ def nullT(n, m, U):
 
 
 def clements(V, tol=1e-11):
-    r"""Performs the Clements decomposition of a Unitary complex matrix.
+    r"""Performs the Clements decomposition of a unitary complex matrix, with local
+    phase shifts applied between two interferometers.
 
     See Clements et al. Optica 3, 1460 (2016) [10.1364/OPTICA.3.001460]
     for more details.

--- a/tests/test_decompositions.py
+++ b/tests/test_decompositions.py
@@ -130,14 +130,14 @@ class DecompositionsModule(BaseTest):
         self.assertAlmostEqual(error.mean() , 0)
 
 
-    def test_clements_eq5_random_unitary(self):
+    def test_clements_phase_end_random_unitary(self):
         self.logTestName()
         error=np.empty(nsamples)
         for k in range(nsamples):
             n=20
             U=haar_measure(n)
 
-            new_tlist, new_diags = dec.clements_eq5(U)
+            new_tlist, new_diags = dec.clements_phase_end(U)
 
             U_rec=np.identity(n)
             for i in new_tlist:


### PR DESCRIPTION
Creating this pull request to get the conversation going about better support for linear optics decompositions. 

The first commits add support for the final form of the Clements et al. decomposition, i.e. having the phases at the end (as in Equation 5) rather than in the middle (as in Equation 4, which is the current implementation). This Equation 5 decomposition is more symmetric than the intermediate one, which could make it more robust. This form also makes it easier to implement a tensor-network simulation of linear optics. 

This new code is for now only in an additional function, but could replace the current function. As this is quite central to some of the sf functionality, it's better to be careful. Would love to learn more about what you folks think is the best way to go about this.

I also have code for the Reck et al. decomposition, which I could add if useful, e.g., for a temporal-mode implementation. What do you think?

