### PR TITLE
Extract methods

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.10.0.dev0 (developement)
+# Release 0.10.0.dev0 (development)
 
 ### New features
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,57 @@
+# Release 0.10.0.dev0 (developement)
+
+### New features
+
+- Added two new utility functions to extract a numerical representation of a circuit from an Engine object: `extract_unitary` and `extract_channel`.
+
+- Added support for an alternative form of Clements decomposition, where the local phases occur at the end rather than in the middle of the beamsplitter array. This decomposition is more symmetric than the intermediate one, which could make it more robust. This form also makes it easier to implement a tensor-network simulation of linear optics.
+
+- Adds the `GraphEmbed` quantum operation/decomposition to the Strawberry Fields frontend. This allows the embedding of an arbitrary (complex valued) weighted adjacency matrix into a Gaussian boson sampler.
+
+### Improvements
+
+- Linting improvements
+
+- Made corrections to the Clements decomposition documentation and docstring, and fixed the Clements unit tests to ensure they are deterministic
+
+## Bug fixes
+
+- Fixed Bloch-Messiah bug arising when singular values were degenerate. Previously, the Bloch-Messiah decomposition did not return matrices in the canonical symplectic form if one or more of the Bloch-Messiah singular values were degenerate.
+
+### Contributors
+
+This release contains contributions from:
+
+Filippo Miatto, Ish Dhand, Nicolás Quesada, Josh Izaac, Christian Gogolin, Shahnawaz Ahmed, and Nathan Killoran.
+
+
+# Release 0.9
+
+## Summary of changes from 0.8
+
+### New features
+
+- Updated the [Strawberry Fields gallery](https://strawberryfields.readthedocs.io/en/latest/gallery/gallery.html), featuring community-submitted content (tutorials, notebooks, repositories, blog posts, research papers, etc.) using Strawberry Fields
+
+- Added the `@operation` decorator, which allows commonly-used algorithms and subroutines to be declared in blackbird code as one-liner operations
+
+- Added a `ThermalLossChannel` to the Strawberry Fields API (currently supported by the Gaussian backend)
+
+- Added a `poly_quad_expectation` method to the `state` objects for Gaussian and Fock backends
+
+### Improvements
+
+- New and improved tests
+
+- Fixed typos in code/documentation
+
+### Contributors
+
+This release contains contributions from:
+
+Juan Leni, Arthur Pesah, Brianna Gopaul, Nicolás Quesada, Josh Izaac, and Nathan Killoran.
+
+
 # Release 0.8
 
 ## Summary of changes from 0.7

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Linting improvements
 
-- Made corrections to the Clements decomposition documentation and docstring, and fixed the Clements unit tests to ensure they are deterministic
+- Made corrections to the Clements decomposition documentation and docstring, and fixed the Clements unit tests to ensure they are deterministic.
 
 ## Bug fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added support for an alternative form of Clements decomposition, where the local phases occur at the end rather than in the middle of the beamsplitter array. This decomposition is more symmetric than the intermediate one, which could make it more robust. This form also makes it easier to implement a tensor-network simulation of linear optics.
 
-- Adds the `GraphEmbed` quantum operation/decomposition to the Strawberry Fields frontend. This allows the embedding of an arbitrary (complex valued) weighted adjacency matrix into a Gaussian boson sampler.
+- Adds the `GraphEmbed` quantum operation/decomposition to the Strawberry Fields frontend. This allows the embedding of an arbitrary (complex-valued) weighted adjacency matrix into a Gaussian boson sampler.
 
 ### Improvements
 

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.9.0'
+__version__ = '0.10.0.dev0'

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -850,7 +850,7 @@ def _interleaved_identities(num_subsystems: int, cutoff_dim: int):
 
 
 def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
-    """Doubles the number of modes of an engine objects and prepends to its command queue
+    """Doubles the number of modes of an engine object and prepends to its command queue
     the operation that creates the interleaved identities ket.
 
     Here, CJ is from Choi-Jamiolkowski, as under the hood we are expliting the CJ isomorphism.

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -963,7 +963,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
       - ``representation='choi'`` and ``representation='liouville'`` return an array
         with :math:`4N` indices
       - ``representation='kraus'`` returns an array of Kraus operators with :math:`2N` indices each,
-        where :math:`N` is the number of modes that the engine is created with.
+        where :math:`N` is the number of modes that the engine is created with
 
     Note that the Kraus representation automatically returns only the non-zero Kraus operators.
     One can reduce the number of operators by discarding Kraus operators with small norm (thus approximating the channel).

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -979,7 +979,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
             \mathcal{C}(\rho) = \mathrm{Tr}[(\rho_A^T\otimes\mathbb{1}_B)\Lambda_{AB}]
 
     The indices of the non-vectorized Choi operator match exactly those of the state, so that the action
-    of the channel can be computed as (e.g. for one mode or for ``vectorize_modes=True``):
+    of the channel can be computed as (e.g., for one mode or for ``vectorize_modes=True``):
 
     >>> rho_out = np.einsum('ab,abcd', rho_in, choi)
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -771,7 +771,7 @@ def _vectorize_dm(tensor):
 
     Raises:
         ValueError: if the input tensor's dimensions are not all equal or if the number
-            of its indices is not a multiple of 4.
+            of its indices is not a multiple of 4
     """
     dims = tensor.ndim
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1019,7 +1019,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     >>> rho_out = np.einsum('abcdefgh,fbhd->eagc', liouville, rho_in)
 
     The Liouville representation has the property that if the channel is unitary, the operator is separable.
-    Whereas even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
+    On the other hand, even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
 
     The choi and liouville operators in matrix form (i.e. with two indices) can be found as follows, where
     ``D`` is the dimension of each vectorized index (i.e. for :math:`N` modes, ``D=cutoff_dim**N``):

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -872,7 +872,7 @@ def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
 
 
 def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, backend: str = 'fock'):
-    r"""Returns the array representation of an queued unitary circuit
+    r"""Returns the array representation of a queued unitary circuit
     as an NumPy ndarray (``'fock'`` backend) or as a TensorFlow Tensor (``'tf'`` backend).
 
     Note that the circuit must only include operations of the :class:`strawberryfields.ops.Gate` class.

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -949,6 +949,8 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     The representation choices include the Choi state representation, the Liouville representation, and
     the Kraus representation.
 
+    .. note:: Channel extraction can currently only be performed using the ``'fock'`` backend.
+
     **Tensor shapes**
 
     * If ``vectorize_modes=True``:

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1070,7 +1070,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
     Returns:
         The numerical array of the channel, according to the specified representation
-        and vectorization options.
+        and vectorization options
 
     Raises:
         TypeError: if the gates used to construct the circuit are not all unitary or channels

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -996,7 +996,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     **Liouville operator**
 
     The Liouville operator is a partial transpose of the Choi operator, such that the first half of
-    consecutive index pairs are the output-input right modes (i.e. acting on the "bra" part of the state)
+    consecutive index pairs are the output-input right modes (i.e., acting on the "bra" part of the state)
     and the second half are the output-input left modes (i.e. acting on the "ket" part of the state).
 
     Therefore, the action of the Liouville operator (e.g. for one mode or for ``vectorize_modes=True``) is

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -690,9 +690,9 @@ def is_channel(engine):
     "Returns true if every command in the queue is either of type Gate or type Channel"
     return all(isinstance(cmd.op, (Channel, Gate)) for cmd in engine.cmd_queue)
 
-def vectorize_dm(tensor):
-    """Given a tensor with 4N indices each of dimension D each,
-    it returns the vectorized tensor with 4 indices of dimension D^N each.
+def _vectorize_dm(tensor):
+    """Given a tensor with 4N indices of dimension D each, it returns the vectorized
+    tensor with 4 indices of dimension D^N each.
 
     Args:
         tensor (array): a tensor with 4N indices of dimension D each
@@ -729,10 +729,10 @@ def vectorize_dm(tensor):
 
     return transposed_back
 
-def unvectorize_dm(tensor, num_subsystems):
+def _unvectorize_dm(tensor, num_subsystems):
     """Given a tensor with 4 indices, each of dimension D^N,
     return the unvectorized tensor with 4N indices of dimension D each.
-    (inverse of the procedure given by vectorize_dm)
+    (inverse of the procedure given by _vectorize_dm)
     """
     dims = tensor.ndim
     if dims != 4:
@@ -884,17 +884,17 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     backend = load_backend('fock')
     backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
     choi = _engine.run(backend, cutoff_dim=cutoff_dim).dm()
-    choi = np.einsum('abcd->cdab', vectorize_dm(choi))
+    choi = np.einsum('abcd->cdab', _vectorize_dm(choi))
 
     if representation.lower() == 'choi':
         result = choi
         if not vectorize_modes:
-            result = unvectorize_dm(result, N)
+            result = _unvectorize_dm(result, N)
 
     elif representation.lower() == 'liouville':
         result = np.einsum('abcd -> dbca', choi)
         if not vectorize_modes:
-            result = unvectorize_dm(result, N)
+            result = _unvectorize_dm(result, N)
 
     elif representation.lower() == 'kraus':
         eigvals, eigvecs = np.linalg.eig(np.einsum('abcd -> cadb', choi).reshape([cutoff_dim**(2*N), cutoff_dim**(2*N)]))

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -99,8 +99,8 @@ Code details
 import collections
 from inspect import signature
 
-import numpy as np
 import tensorflow as tf
+import numpy as np
 from numpy.random import randn
 from numpy.polynomial.hermite import hermval as H
 
@@ -693,7 +693,7 @@ def is_channel(engine):
 def vectorize_dm(tensor):
     """Given a tensor with 4N indices each of dimension D each,
     it returns the vectorized tensor with 4 indices of dimension D^N each.
-    
+
     Args:
         tensor (array): a tensor with 4N indices of dimension D each
     Returns:
@@ -760,7 +760,7 @@ def _interleaved_identities(num_subsystems: int, cutoff_dim: int):
 
 def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
     """Doubles the number of modes of an engine objects and prepends to its command queue
-    the operation that creates the interleaved identities ket. CJ is from Choi-Jamiolkowski, as 
+    the operation that creates the interleaved identities ket. CJ is from Choi-Jamiolkowski, as
     under the hood we are expliting the CJ isomorphism.
     """
     engine._add_subsystems(engine.init_num_subsystems)
@@ -824,7 +824,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     where N is the number of modes that the engine is created with.
     The Kraus representation automatically returns only the non-zero Kraus operators. One can reduce the number
     of operators by discarding Kraus operators with small norm (thus approximating the channel).
-    
+
     # Choi representation
     The indices of the non-vectorized Choi operator match exactly those of the state, so that the action
     of the channel can be computed as (e.g. for one mode or for `vectorize_modes = True`):
@@ -857,7 +857,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     of the channel can be written as (here for one mode or for vectorize_modes = True):
     `rho_out = np.einsum('abc,cd,aed->be', kraus, rho_in, np.conj(kraus))`
     Notice the transpose on the third index string (`aed` rather than `ade`), as the last operator should be the
-    conjugate transpose of the first, and we cannot just do `np.conj(kraus).T` because kraus has 3 indices and we 
+    conjugate transpose of the first, and we cannot just do `np.conj(kraus).T` because kraus has 3 indices and we
     just need to transpose the last two.
 
     Args:
@@ -887,25 +887,24 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     backend = load_backend('fock')
     backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
     choi = _engine.run(backend, cutoff_dim=cutoff_dim).dm()
-    choi = np.einsum('abcd->cdab',vectorize_dm(choi))
+    choi = np.einsum('abcd->cdab', vectorize_dm(choi))
 
     if representation.lower() == 'choi':
         result = choi
-        if vectorize_modes == False:
+        if not vectorize_modes:
             result = unvectorize_dm(result, N)
 
     elif representation.lower() == 'liouville':
         result = np.einsum('abcd -> dbca', choi)
-        if vectorize_modes == False:
+        if not vectorize_modes:
             result = unvectorize_dm(result, N)
-            pass
 
     elif representation.lower() == 'kraus':
         eigvals, eigvecs = np.linalg.eig(np.einsum('abcd -> cadb', choi).reshape([cutoff_dim**(2*N), cutoff_dim**(2*N)]))
         eigvecs = eigvecs[:, ~np.isclose(abs(eigvals), 0)]
         eigvals = eigvals[~np.isclose(abs(eigvals), 0)]
         result = np.einsum('abc->cab', np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs).reshape([cutoff_dim**N, cutoff_dim**N, -1]))
-        if vectorize_modes == False:
+        if not vectorize_modes:
             result = np.einsum(np.reshape(result, [-1]+[cutoff_dim]*(2*N)), range(1+2*N), [0]+[2*n+1 for n in range(N)]+[2*n+2 for n in range(N)])
     else:
         raise ValueError('representation {} not supported'.format(representation))

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -803,13 +803,10 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
     if vectorize_modes:
         if backend == 'fock':
             return np.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
-        else:
-            return tf.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
-    else:
-        if backend == 'fock':
-            return np.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
-        else:
-            return tf.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
+        return tf.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
+    if backend == 'fock':
+        return np.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
+    return tf.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
 
 def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vectorize_modes: bool = False):
     """Returns a numerical array representation of a channel.

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -52,7 +52,7 @@ functions can be created using the :func:`strawberryfields.convert` decorator.
 
 
 NumPy state functions
------------------------------
+---------------------
 
 These functions allow the calculation of various quantum states in either the Fock
 basis (a one-dimensional array indexed by Fock state) or the Gaussian basis (returning
@@ -72,7 +72,7 @@ These are useful for generating states for use in calculating the fidelity of si
 
 
 Random functions
-------------------------
+----------------
 
 These functions generate random numbers and matrices corresponding to various
 quantum states and operations.
@@ -83,6 +83,7 @@ quantum states and operations.
    random_symplectic
    random_interferometer
 
+
 Decorators
 ----------
 
@@ -91,6 +92,20 @@ acting on a qumode to be used as an operation itself within an engine context.
 
 .. autosummary::
    operation
+
+
+Engine functions
+----------------
+
+These functions act on instances of a compiler :class:`~.strawberryfields.engine.Engine`, returning
+or extracting information from the queued engine operations.
+
+.. autosummary::
+    is_unitary
+    is_channel
+    extract_unitary
+    extract_channel
+
 
 Code details
 ~~~~~~~~~~~~
@@ -344,8 +359,9 @@ def squeezed_state(r, p, basis='fock', fock_dim=5, hbar=2.):
     phi = p
 
     if basis == 'fock':
-        def ket(n): return (np.sqrt(fac(2*n))/(2**n*fac(n))) * \
-                        (-np.exp(1j*phi)*np.tanh(r))**n
+        def ket(n):
+            return (np.sqrt(fac(2*n))/(2**n*fac(n))) * (-np.exp(1j*phi)*np.tanh(r))**n
+
         state = np.array([ket(n//2) if n %
                           2 == 0 else 0. for n in range(fock_dim)])
         state *= np.sqrt(1/np.cosh(r))
@@ -678,48 +694,68 @@ class operation:
 
 
 #=================================================
-# extract_xxx methods
+# Engine functions
 #=================================================
 
 
 def is_unitary(engine):
-    "Returns true if every command in the queue is of type Gate"
-    return all(isinstance(cmd.op, Gate) for cmd in engine.cmd_queue)
-
-def is_channel(engine):
-    "Returns true if every command in the queue is either of type Gate or type Channel"
-    return all(isinstance(cmd.op, (Channel, Gate)) for cmd in engine.cmd_queue)
-
-def _vectorize_dm(tensor):
-    """Given a tensor with 4N indices of dimension D each, it returns the vectorized
-    tensor with 4 indices of dimension D^N each.
+    """Returns True if every command in the queue is of type :class:`strawberryfields.ops.Gate`.
 
     Args:
-        tensor (array): a tensor with 4N indices of dimension D each
+        engine (Engine): a Strawberry Fields engine instance
+
     Returns:
-        array: a tensor with 4 indices of dimension D^N each
+        bool: returns True if all queued operations are unitary
+    """
+    return all(isinstance(cmd.op, Gate) for cmd in engine.cmd_queue)
+
+
+def is_channel(engine):
+    """Returns true if every command in the queue is either of type :class:`strawberryfields.ops.Gate`
+    or type :class:`strawberryfields.ops.Channel`.
+
+    Args:
+        engine (Engine): a Strawberry Fields engine instance
+
+    Returns:
+        bool: returns True if all queued operations are either a quantum gate or a channel
+    """
+    return all(isinstance(cmd.op, (Channel, Gate)) for cmd in engine.cmd_queue)
+
+
+def _vectorize_dm(tensor):
+    """Given a tensor with 4N indices of dimension :math:`D` each, it returns the vectorized
+    tensor with 4 indices of dimension :math:`D^N` each.
+
+    For example, :math:`N=2`,
+    ::
+        0 --|‾‾‾‾|-- 1
+        2 --|    |-- 3
+        4 --|    |-- 5
+        6 --|____|-- 7
+
+    goes to
+    ::
+        (0,2) --|‾‾‾‾|-- (1,3)
+        (4,6) --|____|-- (5,7)
+
+    Args:
+        tensor (array): a tensor with :math:`4N` indices of dimension :math:`D` each
+
+    Returns:
+        array: a tensor with 4 indices of dimension :math:`D^N` each
+
     Raises:
         ValueError: if the input tensor's dimensions are not all equal or if the number
             of its indices is not a multiple of 4.
-
-    Example:
-    For N=2
-         ____
-    0 --|    |-- 1
-    2 --|    |-- 3
-    4 --|    |-- 5
-    6 --|____|-- 7
-
-    goes to:
-             ____
-    (0,2) --|    |-- (1,3)
-    (4,6) --|____|-- (5,7)
-
     """
     dims = tensor.ndim
+
     if dims % 4 != 0:
         raise ValueError('Tensor must have a number of indices that is a multiple of 4, but it has {dims} indices'.format(dims=dims))
+
     shape = tensor.shape
+
     if len(set(shape)) != 1:
         raise ValueError('Tensor indices must have all the same dimension, but tensor has shape {shape}'.format(shape=shape))
 
@@ -729,15 +765,30 @@ def _vectorize_dm(tensor):
 
     return transposed_back
 
+
 def _unvectorize_dm(tensor, num_subsystems):
-    """Given a tensor with 4 indices, each of dimension D^N,
-    return the unvectorized tensor with 4N indices of dimension D each.
-    (inverse of the procedure given by _vectorize_dm)
+    """Given a tensor with 4 indices, each of dimension :math:`D^N`, return the unvectorized
+    tensor with 4N indices of dimension D each.
+
+    This is the inverse of the procedure given by :func:`_vectorize_dm`.
+
+    Args:
+        tensor (array): a tensor with :math:`4` indices of dimension :math:`D^N`
+
+    Returns:
+        array: a tensor with :math:`4N` indices of dimension :math:`D` each
+
+    Raises:
+        ValueError: if the input tensor's dimensions are not all equal or if the number
+            of its indices is not 4.
     """
     dims = tensor.ndim
+
     if dims != 4:
         raise ValueError('tensor must have 4 indices, but it has {dims} indices'.format(dims=dims))
+
     shape = tensor.shape
+
     if len(set(shape)) != 1:
         raise ValueError('tensor indices must have all the same dimension, but tensor has shape {shape}'.format(shape=shape))
 
@@ -747,49 +798,76 @@ def _unvectorize_dm(tensor, num_subsystems):
 
     return transposed_back
 
+
 def _interleaved_identities(num_subsystems: int, cutoff_dim: int):
-    """Returns the tensor product of `num_subsystems` copies of the identity matrix,
-    with the indices interleaved.
-    Example for num_subsystems = 3: make the tensor product of three identity matrices I_ijklmn
-    where ij, kl and mn are the three sets of indices, and return I_ikmjln.
+    """Returns the tensor product of ``num_subsystems`` copies of the identity matrix with the indices interleaved.
+
+    For example, when ``num_subsystems=3``, this function creates the tensor product of
+    three identity matrices :math:`I_{ijklmn}` (where :math:`ij`, :math:`kl`, and :math:`mn`
+    are the three sets of indices), and returns the tensor :math:`I_{ikmjln}`.
+
+    Args:
+        num_subsystems (int): number of subsystems to consider
+        cutoff_dim (int): the Fock basis truncation
+
+    Returns:
+        array: the resulting interleaved identity tensor product
     """
     I = np.identity(cutoff_dim)
     for _ in range(1, num_subsystems):
         I = np.tensordot(I, np.identity(cutoff_dim), axes=0)
+
     return np.einsum(I, [int(n) for n in np.arange(2*num_subsystems).reshape((2, num_subsystems)).T.reshape([-1])])
+
 
 def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
     """Doubles the number of modes of an engine objects and prepends to its command queue
-    the operation that creates the interleaved identities ket. CJ is from Choi-Jamiolkowski, as
-    under the hood we are expliting the CJ isomorphism.
+    the operation that creates the interleaved identities ket.
+
+    Here, CJ is from Choi-Jamiolkowski, as under the hood we are expliting the CJ isomorphism.
+
+    Args:
+        engine (Engine): a Strawberry Fields engine instance
+        cutoff_dim (int): the Fock basis truncation
+
+    Returns:
+        strawberryfields.engine.Engine: returns the same Engine instance, with the number of subsystems
+        increased and the interleaved identities ket prepended to the queue
+
     """
-    engine._add_subsystems(engine.init_num_subsystems)
-    I = _interleaved_identities(num_subsystems=engine.init_num_subsystems, cutoff_dim=cutoff_dim)
+    N = engine.init_num_subsystems
+    engine._add_subsystems(N) # pylint: disable=protected-access
+    I = _interleaved_identities(num_subsystems=N, cutoff_dim=cutoff_dim)
     engine.cmd_queue = [Command(Ket(I), list(engine.reg_refs.values()))] + engine.cmd_queue
     return engine
 
-def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, backend: str = 'fock'):
-    """Returns the array representation of a unitary circuit as an ndarray ('fock' backend)
-    or as a TensorFlow Tensor ('tf' backend).
 
-    The circuit must only include operations of the Gate class.
-    If `vectorize_modes` = True, it returns a matrix.
-    If `vectorize_modes` = False, it returns an operator with 2N indices,
-    where N is the number of modes that the engine is created with. Adjacent
-    indices correspond to output-input pairs of the same mode.
+def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, backend: str = 'fock'):
+    """Returns the array representation of an queued unitary circuit
+    as an NumPy ndarray (``'fock'`` backend) or as a TensorFlow Tensor (``'tf'`` backend).
+
+    Note that the circuit must only include operations of the :class:`strawberryfields.ops.Gate` class.
+
+    * If ``vectorize_modes=True``, it returns a matrix.
+    * If ``vectorize_modes=False``, it returns an operator with :math:`2N` indices,
+      where N is the number of modes that the engine is created with. Adjacent
+      indices correspond to output-input pairs of the same mode.
 
     Args:
         engine (Engine): the engine containing the circuit
         cutoff_dim (int): dimension of each index.
-        vectorize_modes (bool): if true, reshape input and output modes in order to return a matrix.
-        backend (str): the backend to build the unitary. 'fock' (default) and 'tf' are supported.
+        vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix.
+        backend (str): the backend to build the unitary. ``'fock'`` (default) and ``'tf'`` are supported.
+
     Returns:
         array: the numerical array of the unitary circuit
+
     Raises:
         TypeError: if the operations used to construct the circuit are not all unitary.
     """
     if not is_unitary(engine):
         raise TypeError("The circuit definition contains elements that are not of type Gate")
+
     if backend not in ('fock', 'tf'):
         raise ValueError("Only 'fock' and 'tf' backends are supported")
 
@@ -800,75 +878,110 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
     _backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
     result = _engine.run(_backend, cutoff_dim=cutoff_dim).ket()
 
+    N = _engine.init_num_subsystems
+
     if vectorize_modes:
         if backend == 'fock':
-            return np.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
-        return tf.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
+            return np.reshape(result, [cutoff_dim**N, cutoff_dim**N])
+
+        return tf.reshape(result, [cutoff_dim**N, cutoff_dim**N])
+
     if backend == 'fock':
-        return np.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
-    return tf.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
+        return np.transpose(result, [int(n) for n in np.arange(2*N).reshape((2, N)).T.reshape([-1])])
+
+    return tf.transpose(result, [int(n) for n in np.arange(2*N).reshape((2, N)).T.reshape([-1])])
+
 
 def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vectorize_modes: bool = False):
-    """Returns a numerical array representation of a channel.
-       The choices are among the Choi state representation, the Liouville representation and
-       the Kraus representation.
+    r"""Returns a numerical array representation of a channel from a queued Engine circuit.
 
-    # Tensor shapes
-    If `vectorize_modes=True`, `representation='choi'` and `representation='liouville'` return an array
-    with 4 indices, while `representation='kraus'` returns an array of Kraus operators in matrix form.
-    If `vectorize_modes=False`, `representation='choi'` and `representation='liouville'` return an array
-    with 4N indices, while `representation='kraus'` returns an array of Kraus operators with 2N indices each,
-    where N is the number of modes that the engine is created with.
-    The Kraus representation automatically returns only the non-zero Kraus operators. One can reduce the number
-    of operators by discarding Kraus operators with small norm (thus approximating the channel).
+    The representation choices include the Choi state representation, the Liouville representation, and
+    the Kraus representation.
 
-    # Choi representation
+    **Tensor shapes**
+
+    * If ``vectorize_modes=True``:
+
+      - ``representation='choi'`` and ``representation='liouville'`` returns an array
+        with 4 indices
+      - ``representation='kraus'`` returns an array of Kraus operators in matrix form.
+
+
+    * If ``vectorize_modes=False``:
+
+      - ``representation='choi'`` and ``representation='liouville'`` returns an array
+        with :math:`4N` indices
+      - ``representation='kraus'`` returns an array of Kraus operators with :math:`2N` indices each,
+        where :math:`N` is the number of modes that the engine is created with.
+
+    Note that the Kraus representation automatically returns only the non-zero Kraus operators.
+    One can reduce the number of operators by discarding Kraus operators with small norm (thus approximating the channel).
+
+    **Choi representation**
+
     The indices of the non-vectorized Choi operator match exactly those of the state, so that the action
-    of the channel can be computed as (e.g. for one mode or for `vectorize_modes = True`):
-    `rho_out = np.einsum('ab,abcd', rho_in, choi)`
-    or for two modes:
-    `rho_out = np.einsum('abcd,abcdefgh', rho_in, choi)`
-    Combining consecutive channels (in the order 1,2,3,...) is also straightforward with the Choi operator:
-    `choi_combined = np.einsum('abcd,cdef,efgh', choi_1, choi_2, choi_3)`
+    of the channel can be computed as (e.g. for one mode or for ``vectorize_modes=True``):
 
-    # Liouville operator
+    >>> rho_out = np.einsum('ab,abcd', rho_in, choi)
+
+    or for two modes:
+
+    >>> rho_out = np.einsum('abcd,abcdefgh', rho_in, choi)
+
+    Combining consecutive channels (in the order :math:`1,2,3,\dots`) is also straightforward with the Choi operator:
+
+    >>> choi_combined = np.einsum('abcd,cdef,efgh', choi_1, choi_2, choi_3)
+
+    **Liouville operator**
+
     The Liouville operator is a partial transpose of the Choi operator, such that the first half of
     consecutive index pairs are the output-input right modes (i.e. acting on the "bra" part of the state)
     and the second half are the output-input left modes (i.e. acting on the "ket" part of the state).
-    Therefore, the action of the Liouville operator (e.g. for one mode or for `vectorize_modes = True`) is
-    `rho_out = np.einsum('abcd,bd->ca', liouville, rho_in)`
-    notice that the state contracts with the second index of each pair and that we output the ket
+
+    Therefore, the action of the Liouville operator (e.g. for one mode or for ``vectorize_modes=True``) is
+
+    >>> rho_out = np.einsum('abcd,bd->ca', liouville, rho_in)
+
+    Notice that the state contracts with the second index of each pair and that we output the ket
     on the left (`c`) and the bra on the right (`a`).
+
     For two modes we have:
-    `rho_out = np.einsum('abcdefgh,fbhd->eagc', liouville, rho_in)`
+
+    >>> rho_out = np.einsum('abcdefgh,fbhd->eagc', liouville, rho_in)
+
     The Liouville representation has the property that if the channel is unitary, the operator is separable.
     Whereas even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
 
     The choi and liouville operators in _matrix_ form (i.e. with two indices) can be found as follows, where
-    D is the dimension of each vectorized index (i.e. for N modes D=cutoff_dim**N):
-    `choi_matrix = liouville.reshape(D**2, D**2).T`
-    `liouville_matrix = choi.reshape(D**2, D**2).T`
+    ``D`` is the dimension of each vectorized index (i.e. for :math:`N` modes, ``D=cutoff_dim**N``):
 
-    # Kraus representation
+    >>> choi_matrix = liouville.reshape(D**2, D**2).T
+    >>> liouville_matrix = choi.reshape(D**2, D**2).T
+
+    **Kraus representation**
+
     Adjacent indices of each Kraus operator correspond to output-input pairs of the same mode, so the action
-    of the channel can be written as (here for one mode or for vectorize_modes = True):
-    `rho_out = np.einsum('abc,cd,aed->be', kraus, rho_in, np.conj(kraus))`
-    Notice the transpose on the third index string (`aed` rather than `ade`), as the last operator should be the
-    conjugate transpose of the first, and we cannot just do `np.conj(kraus).T` because kraus has 3 indices and we
+    of the channel can be written as (here for one mode or for ``vectorize_modes=True``):
+
+    >>> rho_out = np.einsum('abc,cd,aed->be', kraus, rho_in, np.conj(kraus))
+
+    Notice the transpose on the third index string (``aed`` rather than ``ade``), as the last operator should be the
+    conjugate transpose of the first, and we cannot just do ``np.conj(kraus).T`` because ``kraus`` has 3 indices and we
     just need to transpose the last two.
 
     Args:
         engine (Engine): the engine containing the circuit
         cutoff_dim (int): dimension of each index
-        representation (str): choice between 'choi', 'liouville' or 'kraus'
+        representation (str): choice between ``'choi'``, ``'liouville'`` or ``'kraus'``
         vectorize_modes (bool): if True, reshapes the result into rank-4 tensor,
             otherwise it returns a rank-4N tensor, where N is the number of modes.
+
     Returns:
         The numerical array of the channel, according to the specified representation
         and vectorization options.
+
     Raises:
         TypeError: if the gates used to construct the circuit are not all unitary or channels.
-
     """
     # if is_unitary(engine):
     #     #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")
@@ -878,6 +991,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         raise TypeError("The circuit definition contains elements that are neither of type Gate nor of type Channel")
 
     from copy import deepcopy
+
     _engine = _engine_with_CJ_cmd_queue(deepcopy(engine), cutoff_dim=cutoff_dim)
     N = _engine.init_num_subsystems
 
@@ -901,6 +1015,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         eigvecs = eigvecs[:, ~np.isclose(abs(eigvals), 0)]
         eigvals = eigvals[~np.isclose(abs(eigvals), 0)]
         result = np.einsum('abc->cab', np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs).reshape([cutoff_dim**N, cutoff_dim**N, -1]))
+
         if not vectorize_modes:
             result = np.einsum(np.reshape(result, [-1]+[cutoff_dim]*(2*N)), range(1+2*N), [0]+[2*n+1 for n in range(N)]+[2*n+2 for n in range(N)])
     else:

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -745,10 +745,10 @@ def is_channel(engine):
     return all(isinstance(cmd.op, (Channel, Gate)) for cmd in engine.cmd_queue)
 
 
-def _vectorize_dm(tensor):
+def _vectorize(tensor):
     """Given a tensor with 4N indices of dimension :math:`D` each, it returns the vectorized
     tensor with 4 indices of dimension :math:`D^N` each. This is the inverse of the procedure
-    given by :func:`_unvectorize_dm`.
+    given by :func:`_unvectorize`.
     Caution: this private method is intended to be used only for Choi and Liouville operators.
 
     For example, :math:`N=2`,
@@ -790,10 +790,10 @@ def _vectorize_dm(tensor):
     return transposed_back
 
 
-def _unvectorize_dm(tensor, num_subsystems):
+def _unvectorize(tensor, num_subsystems):
     """Given a tensor with 4 indices, each of dimension :math:`D^N`, return the unvectorized
     tensor with 4N indices of dimension D each. This is the inverse of the procedure
-    given by :func:`_vectorize_dm`.
+    given by :func:`_vectorize`.
     Caution: this private method is intended to be used only for Choi and Liouville operators.
 
     Args:
@@ -1090,17 +1090,17 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     backend = load_backend('fock')
     backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
     choi = _engine.run(backend, cutoff_dim=cutoff_dim).dm()
-    choi = np.einsum('abcd->cdab', _vectorize_dm(choi))
+    choi = np.einsum('abcd->cdab', _vectorize(choi))
 
     if representation.lower() == 'choi':
         result = choi
         if not vectorize_modes:
-            result = _unvectorize_dm(result, N)
+            result = _unvectorize(result, N)
 
     elif representation.lower() == 'liouville':
         result = np.einsum('abcd -> dbca', choi)
         if not vectorize_modes:
-            result = _unvectorize_dm(result, N)
+            result = _unvectorize(result, N)
 
     elif representation.lower() == 'kraus':
         # The liouville operator is the sum of a bipartite product of kraus matrices, so if we vectorize them we obtain

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -898,7 +898,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
      [0.5 0.  0. ]])
 
     Args:
-        engine (Engine): the engine containing the circuit
+        engine (Engine): the engine containing a queued circuit
         cutoff_dim (int): dimension of each index.
         vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix.
         backend (str): the backend to build the unitary. ``'fock'`` (default) and ``'tf'`` are supported.

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1021,7 +1021,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     The Liouville representation has the property that if the channel is unitary, the operator is separable.
     On the other hand, even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
 
-    The choi and liouville operators in matrix form (i.e. with two indices) can be found as follows, where
+    The choi and liouville operators in matrix form (i.e., with two indices) can be found as follows, where
     ``D`` is the dimension of each vectorized index (i.e. for :math:`N` modes, ``D=cutoff_dim**N``):
 
     >>> choi_matrix = liouville.reshape(D**2, D**2).T

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -381,6 +381,7 @@ def squeezed_state(r, p, basis='fock', fock_dim=5, hbar=2.):
 
     if basis == 'fock':
         def ket(n):
+            """Squeezed state kets"""
             return (np.sqrt(fac(2*n))/(2**n*fac(n))) * (-np.exp(1j*phi)*np.tanh(r))**n
 
         state = np.array([ket(n//2) if n %

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -983,7 +983,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
     >>> rho_out = np.einsum('ab,abcd', rho_in, choi)
 
-    notice that this respects the transpose operation.
+    Notice that this respects the transpose operation.
 
     For two modes:
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1115,7 +1115,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         # We rescale the eigenvectors with the sqrt of the eigenvalues (the other sqrt would rescale the right eigenvectors)
         rescaled_eigenvectors = np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs)
 
-        # Finally we reshape the eigenvectors to form matrices, i.e. the Kraus operators and we make the first index
+        # Finally we reshape the eigenvectors to form matrices, i.e., the Kraus operators and we make the first index
         # be the one that indexes the list of Kraus operators.
         result = np.einsum('abc->cab', rescaled_eigenvectors.reshape([cutoff_dim**N, cutoff_dim**N, -1]))
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -873,7 +873,7 @@ def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
 
 def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, backend: str = 'fock'):
     r"""Returns the array representation of a queued unitary circuit
-    as an NumPy ndarray (``'fock'`` backend) or as a TensorFlow Tensor (``'tf'`` backend).
+    as a NumPy ndarray (``'fock'`` backend) or as a TensorFlow Tensor (``'tf'`` backend).
 
     Note that the circuit must only include operations of the :class:`strawberryfields.ops.Gate` class.
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1066,7 +1066,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         cutoff_dim (int): dimension of each index
         representation (str): choice between ``'choi'``, ``'liouville'`` or ``'kraus'``
         vectorize_modes (bool): if True, reshapes the result into rank-4 tensor,
-            otherwise it returns a rank-4N tensor, where N is the number of modes.
+            otherwise it returns a rank-4N tensor, where N is the number of modes
 
     Returns:
         The numerical array of the channel, according to the specified representation

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -110,12 +110,12 @@ from scipy.special import factorial as fac
 from .engine import _convert
 from .backends import load_backend
 from .ops import Command, Gate, Channel, Ket
-
 # pylint: disable=abstract-method,ungrouped-imports,
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # RegRef convert functions                                              |
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
+
 
 @_convert
 def neg(x):
@@ -211,9 +211,10 @@ def power(x, a):
         return np.power(x, tmp)
     return rrt(x)
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # State functions - Fock basis and Gaussian basis                |
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
+
 
 def squeezed_cov(r, phi, hbar=2):
     r"""Returns the squeezed covariance matrix of a squeezed state
@@ -343,7 +344,7 @@ def squeezed_state(r, p, basis='fock', fock_dim=5, hbar=2.):
     phi = p
 
     if basis == 'fock':
-        ket = lambda n: (np.sqrt(fac(2*n))/(2**n*fac(n))) * \
+        def ket(n): return (np.sqrt(fac(2*n))/(2**n*fac(n))) * \
                         (-np.exp(1j*phi)*np.tanh(r))**n
         state = np.array([ket(n//2) if n %
                           2 == 0 else 0. for n in range(fock_dim)])
@@ -412,12 +413,14 @@ def displaced_squeezed_state(a, r, phi, basis='fock', fock_dim=5, hbar=2.):
                  for n in range(fock_dim)]
             )
 
-            vec = [H(gamma/np.sqrt(phase_factor*np.sinh(2*r)), row) for row in coeff]
+            vec = [H(gamma/np.sqrt(phase_factor*np.sinh(2*r)), row)
+                   for row in coeff]
 
             state = N*np.array(vec)
 
         else:
-            state = coherent_state(a, basis='fock', fock_dim=fock_dim) # pragma: no cover
+            state = coherent_state(
+                a, basis='fock', fock_dim=fock_dim)  # pragma: no cover
 
     elif basis == 'gaussian':
         means = np.array([a.real, a.imag]) * np.sqrt(2*hbar)
@@ -426,9 +429,9 @@ def displaced_squeezed_state(a, r, phi, basis='fock', fock_dim=5, hbar=2.):
     return state
 
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # State functions - Fock basis only                              |
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 
 
 def fock_state(n, fock_dim=5):
@@ -482,9 +485,9 @@ def cat_state(a, p=0, fock_dim=5):
     return ket
 
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # Random numbers and matrices                                           |
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 
 
 def randnc(*arg):
@@ -647,7 +650,8 @@ class operation:
         num_params = len(func_sig.parameters)
 
         if num_params == 0:
-            raise ValueError("Operation must receive the qumode register as an argument.")
+            raise ValueError(
+                "Operation must receive the qumode register as an argument.")
 
         if num_params != len(self.args) + 1:
             raise ValueError("Mismatch in the number of arguments")
@@ -671,7 +675,6 @@ class operation:
             return self
 
         return f_proxy
-
 
 
 #=================================================

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -953,7 +953,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
     * If ``vectorize_modes=True``:
 
-      - ``representation='choi'`` and ``representation='liouville'`` returns an array
+      - ``representation='choi'`` and ``representation='liouville'`` return an array
         with 4 indices
       - ``representation='kraus'`` returns an array of Kraus operators in matrix form
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -907,7 +907,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
         array: the numerical array of the unitary circuit
 
     Raises:
-        TypeError: if the operations used to construct the circuit are not all unitary.
+        TypeError: if the operations used to construct the circuit are not all unitary
     """
 
     if not is_unitary(engine):

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1022,7 +1022,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     On the other hand, even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
 
     The choi and liouville operators in matrix form (i.e., with two indices) can be found as follows, where
-    ``D`` is the dimension of each vectorized index (i.e. for :math:`N` modes, ``D=cutoff_dim**N``):
+    ``D`` is the dimension of each vectorized index (i.e., for :math:`N` modes, ``D=cutoff_dim**N``):
 
     >>> choi_matrix = liouville.reshape(D**2, D**2).T
     >>> liouville_matrix = choi.reshape(D**2, D**2).T

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1011,16 +1011,16 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
             result = _unvectorize_dm(result, N)
 
     elif representation.lower() == 'kraus':
-        # the liouville operator is the sum of a bipartite product of kraus matrices, so if we vectorize them we obtain
+        # The liouville operator is the sum of a bipartite product of kraus matrices, so if we vectorize them we obtain
         # a matrix whose eigenvectors are proportional to the vectorized kraus operators
         vectorized_liouville = np.einsum('abcd -> cadb', choi).reshape([cutoff_dim**(2*N), cutoff_dim**(2*N)])
         eigvals, eigvecs = np.linalg.eig(vectorized_liouville)
-        # we keep only those eigenvectors and correspond to non-zero eigenvalues
+        # We keep only those eigenvectors that correspond to non-zero eigenvalues
         eigvecs = eigvecs[:, ~np.isclose(abs(eigvals), 0)]
         eigvals = eigvals[~np.isclose(abs(eigvals), 0)]
-        # we rescale the eigenvectors with the sqrt of the eigenvalues (the other sqrt would rescale the right eigenvectors)
+        # We rescale the eigenvectors with the sqrt of the eigenvalues (the other sqrt would rescale the right eigenvectors)
         rescaled_eigenvectors = np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs)
-        # finally we reshape the eigenvectors to form matrices, i.e. the Kraus operators and we make the first index 
+        # Finally we reshape the eigenvectors to form matrices, i.e. the Kraus operators and we make the first index 
         # be the one that indexes the list of Kraus operators.
         result = np.einsum('abc->cab', rescaled_eigenvectors.reshape([cutoff_dim**N, cutoff_dim**N, -1]))
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1069,7 +1069,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
             otherwise it returns a rank-4N tensor, where N is the number of modes
 
     Returns:
-        The numerical array of the channel, according to the specified representation
+        the numerical array of the channel, according to the specified representation
         and vectorization options
 
     Raises:

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -955,7 +955,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
       - ``representation='choi'`` and ``representation='liouville'`` returns an array
         with 4 indices
-      - ``representation='kraus'`` returns an array of Kraus operators in matrix form.
+      - ``representation='kraus'`` returns an array of Kraus operators in matrix form
 
 
     * If ``vectorize_modes=False``:

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1077,10 +1077,6 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     Raises:
         TypeError: if the gates used to construct the circuit are not all unitary or channels
     """
-    # if is_unitary(engine):
-    #     #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")
-    #     pass
-
     if not is_channel(engine):
         raise TypeError("The circuit definition contains elements that are neither of type Gate nor of type Channel")
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -999,7 +999,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
     consecutive index pairs are the output-input right modes (i.e., acting on the "bra" part of the state)
     and the second half are the output-input left modes (i.e., acting on the "ket" part of the state).
 
-    Therefore, the action of the Liouville operator (e.g. for one mode or for ``vectorize_modes=True``) is
+    Therefore, the action of the Liouville operator (e.g., for one mode or for ``vectorize_modes=True``) is
 
     .. math::
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -100,6 +100,7 @@ import collections
 from inspect import signature
 
 import numpy as np
+import tensorflow as tf
 from numpy.random import randn
 from numpy.polynomial.hermite import hermval as H
 
@@ -107,13 +108,14 @@ import scipy as sp
 from scipy.special import factorial as fac
 
 from .engine import _convert
+from .backends import load_backend
+from .ops import Command, Gate, Channel, Ket
 
 # pylint: disable=abstract-method,ungrouped-imports,
 
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 # RegRef convert functions                                              |
-# ------------------------------------------------------------------------
-
+#------------------------------------------------------------------------
 
 @_convert
 def neg(x):
@@ -209,10 +211,9 @@ def power(x, a):
         return np.power(x, tmp)
     return rrt(x)
 
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 # State functions - Fock basis and Gaussian basis                |
-# ------------------------------------------------------------------------
-
+#------------------------------------------------------------------------
 
 def squeezed_cov(r, phi, hbar=2):
     r"""Returns the squeezed covariance matrix of a squeezed state
@@ -342,7 +343,7 @@ def squeezed_state(r, p, basis='fock', fock_dim=5, hbar=2.):
     phi = p
 
     if basis == 'fock':
-        def ket(n): return (np.sqrt(fac(2*n))/(2**n*fac(n))) * \
+        ket = lambda n: (np.sqrt(fac(2*n))/(2**n*fac(n))) * \
                         (-np.exp(1j*phi)*np.tanh(r))**n
         state = np.array([ket(n//2) if n %
                           2 == 0 else 0. for n in range(fock_dim)])
@@ -411,14 +412,12 @@ def displaced_squeezed_state(a, r, phi, basis='fock', fock_dim=5, hbar=2.):
                  for n in range(fock_dim)]
             )
 
-            vec = [H(gamma/np.sqrt(phase_factor*np.sinh(2*r)), row)
-                   for row in coeff]
+            vec = [H(gamma/np.sqrt(phase_factor*np.sinh(2*r)), row) for row in coeff]
 
             state = N*np.array(vec)
 
         else:
-            state = coherent_state(
-                a, basis='fock', fock_dim=fock_dim)  # pragma: no cover
+            state = coherent_state(a, basis='fock', fock_dim=fock_dim) # pragma: no cover
 
     elif basis == 'gaussian':
         means = np.array([a.real, a.imag]) * np.sqrt(2*hbar)
@@ -427,9 +426,9 @@ def displaced_squeezed_state(a, r, phi, basis='fock', fock_dim=5, hbar=2.):
     return state
 
 
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 # State functions - Fock basis only                              |
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 
 
 def fock_state(n, fock_dim=5):
@@ -483,9 +482,9 @@ def cat_state(a, p=0, fock_dim=5):
     return ket
 
 
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 # Random numbers and matrices                                           |
-# ------------------------------------------------------------------------
+#------------------------------------------------------------------------
 
 
 def randnc(*arg):
@@ -648,8 +647,7 @@ class operation:
         num_params = len(func_sig.parameters)
 
         if num_params == 0:
-            raise ValueError(
-                "Operation must receive the qumode register as an argument.")
+            raise ValueError("Operation must receive the qumode register as an argument.")
 
         if num_params != len(self.args) + 1:
             raise ValueError("Mismatch in the number of arguments")
@@ -673,3 +671,240 @@ class operation:
             return self
 
         return f_proxy
+
+
+
+#=================================================
+# extract_xxx methods
+#=================================================
+
+
+def is_unitary(engine):
+    "Returns true if every command in the queue is of type Gate"
+    return all(isinstance(cmd.op, Gate) for cmd in engine.cmd_queue)
+
+def is_channel(engine):
+    "Returns true if every command in the queue is either of type Gate or type Channel"
+    return all(isinstance(cmd.op, (Channel, Gate)) for cmd in engine.cmd_queue)
+
+def vectorize_dm(tensor):
+    """Given a tensor with 4N indices each of dimension D each,
+    it returns the vectorized tensor with 4 indices of dimension D^N each.
+    
+    Args:
+        tensor (array): a tensor with 4N indices of dimension D each
+    Returns:
+        array: a tensor with 4 indices of dimension D^N each
+    Raises:
+        ValueError: if the input tensor's dimensions are not all equal or if the number
+            of its indices is not a multiple of 4.
+
+    Example:
+    For N=2
+         ____
+    0 --|    |-- 1
+    2 --|    |-- 3
+    4 --|    |-- 5
+    6 --|____|-- 7
+
+    goes to:
+             ____
+    (0,2) --|    |-- (1,3)
+    (4,6) --|____|-- (5,7)
+
+    """
+    dims = tensor.ndim
+    if dims % 4 != 0:
+        raise ValueError(f'tensor must have a number of indices that is a multiple of 4, but it has {dims} indices')
+    shape = tensor.shape
+    if len(set(shape)) != 1:
+        raise ValueError(f'tensor indices must have all the same dimension, but tensor has shape {shape}')
+
+    transposed = np.einsum(tensor, [int(n) for n in np.arange(dims).reshape((2, dims//2)).T.reshape([-1])])
+    vectorized = np.reshape(transposed, [shape[0]**(dims//4)]*4)
+    transposed_back = np.einsum('abcd -> acbd', vectorized)
+
+    return transposed_back
+
+def unvectorize_dm(tensor, num_subsystems):
+    """Given a tensor with 4 indices, each of dimension D^N,
+    return the unvectorized tensor with 4N indices of dimension D each.
+    (inverse of the procedure given by vectorize_dm)
+    """
+    dims = tensor.ndim
+    if dims != 4:
+        raise ValueError(f'tensor must have 4 indices, but it has {dims} indices')
+    shape = tensor.shape
+    if len(set(shape)) != 1:
+        raise ValueError(f'tensor indices must have all the same dimension, but tensor has shape {shape}')
+
+    transposed = np.einsum('abcd -> acbd', tensor)
+    unvectorized = np.reshape(transposed, [int(shape[0]**(1/num_subsystems))]*(4*num_subsystems))
+    transposed_back = np.einsum(unvectorized, [int(n) for n in np.arange(4*num_subsystems).reshape((2*num_subsystems, 2)).T.reshape([-1])])
+
+    return transposed_back
+
+def _interleaved_identities(num_subsystems: int, cutoff_dim: int):
+    """Returns the tensor product of `num_subsystems` copies of the identity matrix,
+    with the indices interleaved.
+    Example for num_subsystems = 3: make the tensor product of three identity matrices I_ijklmn
+    where ij, kl and mn are the three sets of indices, and return I_ikmjln.
+    """
+    I = np.identity(cutoff_dim)
+    for _ in range(1, num_subsystems):
+        I = np.tensordot(I, np.identity(cutoff_dim), axes=0)
+    return np.einsum(I, [int(n) for n in np.arange(2*num_subsystems).reshape((2, num_subsystems)).T.reshape([-1])])
+
+def _engine_with_CJ_cmd_queue(engine, cutoff_dim: int):
+    """Doubles the number of modes of an engine objects and prepends to its command queue
+    the operation that creates the interleaved identities ket. CJ is from Choi-Jamiolkowski, as 
+    under the hood we are expliting the CJ isomorphism.
+    """
+    engine._add_subsystems(engine.init_num_subsystems)
+    I = _interleaved_identities(num_subsystems=engine.init_num_subsystems, cutoff_dim=cutoff_dim)
+    engine.cmd_queue = [Command(Ket(I), list(engine.reg_refs.values()))] + engine.cmd_queue
+    return engine
+
+def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, backend: str = 'fock'):
+    """Returns the array representation of a unitary circuit as an ndarray ('fock' backend)
+    or as a TensorFlow Tensor ('tf' backend).
+
+    The circuit must only include operations of the Gate class.
+    If `vectorize_modes` = True, it returns a matrix.
+    If `vectorize_modes` = False, it returns an operator with 2N indices,
+    where N is the number of modes that the engine is created with. Adjacent
+    indices correspond to output-input pairs of the same mode.
+
+    Args:
+        engine (Engine): the engine containing the circuit
+        cutoff_dim (int): dimension of each index.
+        vectorize_modes (bool): if true, reshape input and output modes in order to return a matrix.
+        backend (str): the backend to build the unitary. 'fock' (default) and 'tf' are supported.
+    Returns:
+        array: the numerical array of the unitary circuit
+    Raises:
+        TypeError: if the operations used to construct the circuit are not all unitary.
+    """
+    if not is_unitary(engine):
+        raise TypeError(f"The circuit definition contains elements that are not of type Gate")
+    if backend not in ('fock', 'tf'):
+        raise ValueError("Only 'fock' and 'tf' backends are supported")
+
+    from copy import deepcopy
+    _engine = _engine_with_CJ_cmd_queue(deepcopy(engine), cutoff_dim=cutoff_dim)
+
+    _backend = load_backend(backend) # (!) _backend is the object, backend is just its name
+    _backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
+    result = _engine.run(_backend, cutoff_dim=cutoff_dim).ket()
+
+    if vectorize_modes:
+        if backend == 'fock':
+            return np.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
+        else:
+            return tf.reshape(result, [cutoff_dim**_engine.init_num_subsystems, cutoff_dim**_engine.init_num_subsystems])
+    else:
+        if backend == 'fock':
+            return np.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
+        else:
+            return tf.transpose(result, [int(n) for n in np.arange(2*_engine.init_num_subsystems).reshape((2, _engine.init_num_subsystems)).T.reshape([-1])])
+
+def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vectorize_modes: bool = False):
+    """Returns a numerical array representation of a channel.
+       The choices are among the Choi state representation, the Liouville representation and
+       the Kraus representation.
+
+    # Tensor shapes
+    If `vectorize_modes=True`, `representation='choi'` and `representation='liouville'` return an array
+    with 4 indices, while `representation='kraus'` returns an array of Kraus operators in matrix form.
+    If `vectorize_modes=False`, `representation='choi'` and `representation='liouville'` return an array
+    with 4N indices, while `representation='kraus'` returns an array of Kraus operators with 2N indices each,
+    where N is the number of modes that the engine is created with.
+    The Kraus representation automatically returns only the non-zero Kraus operators. One can reduce the number
+    of operators by discarding Kraus operators with small norm (thus approximating the channel).
+    
+    # Choi representation
+    The indices of the non-vectorized Choi operator match exactly those of the state, so that the action
+    of the channel can be computed as (e.g. for one mode or for `vectorize_modes = True`):
+    `rho_out = np.einsum('ab,abcd', rho_in, choi)`
+    or for two modes:
+    `rho_out = np.einsum('abcd,abcdefgh', rho_in, choi)`
+    Combining consecutive channels (in the order 1,2,3,...) is also straightforward with the Choi operator:
+    `choi_combined = np.einsum('abcd,cdef,efgh', choi_1, choi_2, choi_3)`
+
+    # Liouville operator
+    The Liouville operator is a partial transpose of the Choi operator, such that the first half of
+    consecutive index pairs are the output-input right modes (i.e. acting on the "bra" part of the state)
+    and the second half are the output-input left modes (i.e. acting on the "ket" part of the state).
+    Therefore, the action of the Liouville operator (e.g. for one mode or for `vectorize_modes = True`) is
+    `rho_out = np.einsum('abcd,bd->ca', liouville, rho_in)`
+    notice that the state contracts with the second index of each pair and that we output the ket
+    on the left (`c`) and the bra on the right (`a`).
+    For two modes we have:
+    `rho_out = np.einsum('abcdefgh,fbhd->eagc', liouville, rho_in)`
+    The Liouville representation has the property that if the channel is unitary, the operator is separable.
+    Whereas even if the channel were the identity, the Choi operator would correspond to a maximally entangled state.
+
+    The choi and liouville operators in _matrix_ form (i.e. with two indices) can be found as follows, where
+    D is the dimension of each vectorized index (i.e. for N modes D=cutoff_dim**N):
+    `choi_matrix = liouville.reshape(D**2, D**2).T`
+    `liouville_matrix = choi.reshape(D**2, D**2).T`
+
+    # Kraus representation
+    Adjacent indices of each Kraus operator correspond to output-input pairs of the same mode, so the action
+    of the channel can be written as (here for one mode or for vectorize_modes = True):
+    `rho_out = np.einsum('abc,cd,aed->be', kraus, rho_in, np.conj(kraus))`
+    Notice the transpose on the third index string (`aed` rather than `ade`), as the last operator should be the
+    conjugate transpose of the first, and we cannot just do `np.conj(kraus).T` because kraus has 3 indices and we 
+    just need to transpose the last two.
+
+    Args:
+        engine (Engine): the engine containing the circuit
+        cutoff_dim (int): dimension of each index
+        representation (str): choice between 'choi', 'liouville' or 'kraus'
+        vectorize_modes (bool): if True, reshapes the result into rank-4 tensor,
+            otherwise it returns a rank-4N tensor, where N is the number of modes.
+    Returns:
+        The numerical array of the channel, according to the specified representation
+        and vectorization options.
+    Raises:
+        TypeError: if the gates used to construct the circuit are not all unitary or channels.
+
+    """
+    if is_unitary(engine):
+        #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")
+        pass
+
+    if not is_channel(engine):
+        raise TypeError("The circuit definition contains elements that are neither of type Gate nor of type Channel")
+
+    from copy import deepcopy
+    _engine = _engine_with_CJ_cmd_queue(deepcopy(engine), cutoff_dim=cutoff_dim)
+    N = _engine.init_num_subsystems
+
+    backend = load_backend('fock')
+    backend.begin_circuit(num_subsystems=_engine.num_subsystems, cutoff_dim=cutoff_dim, hbar=_engine.hbar, pure=True)
+    choi = _engine.run(backend, cutoff_dim=cutoff_dim).dm()
+    choi = np.einsum('abcd->cdab',vectorize_dm(choi))
+
+    if representation.lower() == 'choi':
+        result = choi
+        if vectorize_modes == False:
+            result = unvectorize_dm(result, N)
+
+    elif representation.lower() == 'liouville':
+        result = np.einsum('abcd -> dbca', choi)
+        if vectorize_modes == False:
+            result = unvectorize_dm(result, N)
+            pass
+
+    elif representation.lower() == 'kraus':
+        eigvals, eigvecs = np.linalg.eig(np.einsum('abcd -> cadb', choi).reshape([cutoff_dim**(2*N), cutoff_dim**(2*N)]))
+        eigvecs = eigvecs[:, ~np.isclose(abs(eigvals), 0)]
+        eigvals = eigvals[~np.isclose(abs(eigvals), 0)]
+        result = np.einsum('abc->cab', np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs).reshape([cutoff_dim**N, cutoff_dim**N, -1]))
+        if vectorize_modes == False:
+            result = np.einsum(np.reshape(result, [-1]+[cutoff_dim]*(2*N)), range(1+2*N), [0]+[2*n+1 for n in range(N)]+[2*n+2 for n in range(N)])
+    else:
+        raise ValueError(f'representation {representation} not supported')
+
+    return result

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -901,7 +901,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
         engine (Engine): the engine containing a queued circuit
         cutoff_dim (int): dimension of each index
         vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix
-        backend (str): the backend to build the unitary. ``'fock'`` (default) and ``'tf'`` are supported.
+        backend (str): the backend to build the unitary; ``'fock'`` (default) and ``'tf'`` are supported
 
     Returns:
         array: the numerical array of the unitary circuit

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -804,7 +804,7 @@ def _unvectorize_dm(tensor, num_subsystems):
 
     Raises:
         ValueError: if the input tensor's dimensions are not all equal or if the number
-            of its indices is not 4.
+            of its indices is not 4
     """
     dims = tensor.ndim
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1020,7 +1020,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         eigvals = eigvals[~np.isclose(abs(eigvals), 0)]
         # We rescale the eigenvectors with the sqrt of the eigenvalues (the other sqrt would rescale the right eigenvectors)
         rescaled_eigenvectors = np.einsum('b,ab->ab', np.sqrt(eigvals), eigvecs)
-        # Finally we reshape the eigenvectors to form matrices, i.e. the Kraus operators and we make the first index 
+        # Finally we reshape the eigenvectors to form matrices, i.e. the Kraus operators and we make the first index
         # be the one that indexes the list of Kraus operators.
         result = np.einsum('abc->cab', rescaled_eigenvectors.reshape([cutoff_dim**N, cutoff_dim**N, -1]))
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -899,7 +899,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
 
     Args:
         engine (Engine): the engine containing a queued circuit
-        cutoff_dim (int): dimension of each index.
+        cutoff_dim (int): dimension of each index
         vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix.
         backend (str): the backend to build the unitary. ``'fock'`` (default) and ``'tf'`` are supported.
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -900,7 +900,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
     Args:
         engine (Engine): the engine containing a queued circuit
         cutoff_dim (int): dimension of each index
-        vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix.
+        vectorize_modes (bool): if True, reshape input and output modes in order to return a matrix
         backend (str): the backend to build the unitary. ``'fock'`` (default) and ``'tf'`` are supported.
 
     Returns:

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -1073,7 +1073,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         and vectorization options.
 
     Raises:
-        TypeError: if the gates used to construct the circuit are not all unitary or channels.
+        TypeError: if the gates used to construct the circuit are not all unitary or channels
     """
     # if is_unitary(engine):
     #     #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -960,7 +960,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
     * If ``vectorize_modes=False``:
 
-      - ``representation='choi'`` and ``representation='liouville'`` returns an array
+      - ``representation='choi'`` and ``representation='liouville'`` return an array
         with :math:`4N` indices
       - ``representation='kraus'`` returns an array of Kraus operators with :math:`2N` indices each,
         where :math:`N` is the number of modes that the engine is created with.

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -718,10 +718,10 @@ def vectorize_dm(tensor):
     """
     dims = tensor.ndim
     if dims % 4 != 0:
-        raise ValueError(f'tensor must have a number of indices that is a multiple of 4, but it has {dims} indices')
+        raise ValueError('Tensor must have a number of indices that is a multiple of 4, but it has {dims} indices'.format(dims=dims))
     shape = tensor.shape
     if len(set(shape)) != 1:
-        raise ValueError(f'tensor indices must have all the same dimension, but tensor has shape {shape}')
+        raise ValueError('Tensor indices must have all the same dimension, but tensor has shape {shape}'.format(shape=shape))
 
     transposed = np.einsum(tensor, [int(n) for n in np.arange(dims).reshape((2, dims//2)).T.reshape([-1])])
     vectorized = np.reshape(transposed, [shape[0]**(dims//4)]*4)
@@ -736,10 +736,10 @@ def unvectorize_dm(tensor, num_subsystems):
     """
     dims = tensor.ndim
     if dims != 4:
-        raise ValueError(f'tensor must have 4 indices, but it has {dims} indices')
+        raise ValueError('tensor must have 4 indices, but it has {dims} indices'.format(dims=dims))
     shape = tensor.shape
     if len(set(shape)) != 1:
-        raise ValueError(f'tensor indices must have all the same dimension, but tensor has shape {shape}')
+        raise ValueError('tensor indices must have all the same dimension, but tensor has shape {shape}'.format(shape=shape))
 
     transposed = np.einsum('abcd -> acbd', tensor)
     unvectorized = np.reshape(transposed, [int(shape[0]**(1/num_subsystems))]*(4*num_subsystems))
@@ -789,7 +789,7 @@ def extract_unitary(engine, cutoff_dim: int, vectorize_modes: bool = False, back
         TypeError: if the operations used to construct the circuit are not all unitary.
     """
     if not is_unitary(engine):
-        raise TypeError(f"The circuit definition contains elements that are not of type Gate")
+        raise TypeError("The circuit definition contains elements that are not of type Gate")
     if backend not in ('fock', 'tf'):
         raise ValueError("Only 'fock' and 'tf' backends are supported")
 
@@ -873,9 +873,9 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         TypeError: if the gates used to construct the circuit are not all unitary or channels.
 
     """
-    if is_unitary(engine):
-        #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")
-        pass
+    # if is_unitary(engine):
+    #     #raise Warning(f"This circuit is unitary and you could use extract_unitary for a more compact representation")
+    #     pass
 
     if not is_channel(engine):
         raise TypeError("The circuit definition contains elements that are neither of type Gate nor of type Channel")
@@ -908,6 +908,6 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
         if vectorize_modes == False:
             result = np.einsum(np.reshape(result, [-1]+[cutoff_dim]*(2*N)), range(1+2*N), [0]+[2*n+1 for n in range(N)]+[2*n+2 for n in range(N)])
     else:
-        raise ValueError(f'representation {representation} not supported')
+        raise ValueError('representation {} not supported'.format(representation))
 
     return result

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -997,7 +997,7 @@ def extract_channel(engine, cutoff_dim: int, representation: str = 'choi', vecto
 
     The Liouville operator is a partial transpose of the Choi operator, such that the first half of
     consecutive index pairs are the output-input right modes (i.e., acting on the "bra" part of the state)
-    and the second half are the output-input left modes (i.e. acting on the "ket" part of the state).
+    and the second half are the output-input left modes (i.e., acting on the "ket" part of the state).
 
     Therefore, the action of the Liouville operator (e.g. for one mode or for ``vectorize_modes=True``) is
 

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -203,3 +203,8 @@ class TFBackendTest(FockBaseTest):
         super().setUp()
         if not isinstance(self.backend, backends.TFBackend):
             raise unittest.SkipTest('Test is only relevant for the Tensorflow backend.')
+
+class ExtractChannelTest(BaseTest):
+    """ABC for ExtractChannel dependent tests."""
+    def setUp(self):
+        super().setUp()

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -203,8 +203,3 @@ class TFBackendTest(FockBaseTest):
         super().setUp()
         if not isinstance(self.backend, backends.TFBackend):
             raise unittest.SkipTest('Test is only relevant for the Tensorflow backend.')
-
-class ExtractChannelTest(BaseTest):
-    """ABC for ExtractChannel dependent tests."""
-    def setUp(self):
-        super().setUp()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,8 +292,6 @@ class RandomStates(BaseTest):
         self.assertAllAlmostEqual(U @ U.conj().T, np.identity(self.M), delta=self.tol)
 
 
-
-
 class ExtractChannel(ExtractChannelTest):
     num_subsystems = 3
 
@@ -491,12 +489,6 @@ class ExtractChannel(ExtractChannelTest):
 
         III = _interleaved_identities(num_subsystems=3, cutoff_dim=5)
         self.assertAllAlmostEqual(np.einsum('abcabc', III), 5**3, delta=defaults.TOLERANCE)
-
-
-
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import defaults
 from defaults import BaseTest, FockBaseTest, ExtractChannelTest, GaussianBaseTest, strawberryfields as sf
 from strawberryfields.ops import *
 from strawberryfields.utils import *
+from strawberryfields.utils import _interleaved_identities, _vectorize_dm, _unvectorize_dm
 from strawberryfields.backends.shared_ops import sympmat
 
 
@@ -481,10 +482,15 @@ class ExtractChannel(ExtractChannelTest):
         cutoff_dim = 4
         dm = np.random.rand(*[cutoff_dim]*8) + 1j*np.random.rand(*[cutoff_dim]*8) # 4^8 -> (4^2)^4 -> 4^8
         dm2 = np.random.rand(*[cutoff_dim]*4) + 1j*np.random.rand(*[cutoff_dim]*4) # (2^2)^4 -> 2^8 -> (2^2)^4
-        self.assertAllAlmostEqual(dm, unvectorize_dm(vectorize_dm(dm), 2), delta=defaults.TOLERANCE)
-        self.assertAllAlmostEqual(dm2, vectorize_dm(unvectorize_dm(dm2, 2)), delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(dm, _unvectorize_dm(_vectorize_dm(dm), 2), delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(dm2, _vectorize_dm(_unvectorize_dm(dm2, 2)), delta=defaults.TOLERANCE)
 
+    def test_interleaved_identities(self):
+        II = _interleaved_identities(num_subsystems=2, cutoff_dim=3)
+        self.assertAllAlmostEqual(np.einsum('abab', II), 3**2, delta=defaults.TOLERANCE)
 
+        III = _interleaved_identities(num_subsystems=3, cutoff_dim=5)
+        self.assertAllAlmostEqual(np.einsum('abcabc', III), 5**3, delta=defaults.TOLERANCE)
 
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import unittest
 
 import numpy as np
 from numpy import pi
+np.random.seed(42)
 
 import tensorflow as tf
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,8 @@ import unittest
 import numpy as np
 from numpy import pi
 
-from defaults import BaseTest, FockBaseTest, GaussianBaseTest, strawberryfields as sf
+import defaults
+from defaults import BaseTest, FockBaseTest, ExtractChannelTest, GaussianBaseTest, strawberryfields as sf
 from strawberryfields.ops import *
 from strawberryfields.utils import *
 from strawberryfields.backends.shared_ops import sympmat
@@ -291,12 +292,212 @@ class RandomStates(BaseTest):
 
 
 
+
+class ExtractChannel(ExtractChannelTest):
+    num_subsystems = 3
+
+    def setUp(self):
+        super().setUp()
+
+    def test_extract_unitary_1_mode(self):
+        num_subsystems = 1
+
+        eng_sf, q_sf = sf.Engine(num_subsystems=num_subsystems)
+        eng_extract, q_extract = sf.Engine(num_subsystems=num_subsystems)
+
+        cutoff_dim = 10
+
+        S = sf.ops.Sgate(0.4,-1.2)
+        D = sf.ops.Dgate(2, 0.9)
+        K = sf.ops.Kgate(-1.5)
+
+        initial_state = np.complex64(np.random.rand(cutoff_dim) + 1j*np.random.rand(cutoff_dim)) # not a state but it doesn't matter
+
+        with eng_sf:
+            sf.ops.Ket(initial_state) | q_sf
+            S | q_sf
+            D | q_sf
+            K | q_sf
+
+        with eng_extract:
+            S | q_extract
+            D | q_extract
+            K | q_extract
+
+        matrix_extract = extract_unitary(eng_extract, cutoff_dim=cutoff_dim)
+        matrix_extract_tf_backend = extract_unitary(eng_extract, cutoff_dim=cutoff_dim, backend='tf')
+        with tf.Session() as sess:
+            sess.run(tf.global_variables_initializer())
+            final_state_tf_backend = sess.run(tf.einsum('ab,b', matrix_extract_tf_backend, tf.constant(initial_state.reshape([-1]))))
+        final_state_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).ket().reshape([-1])
+        final_state_extract = matrix_extract.dot(initial_state)
+        final_state_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).ket()
+
+        self.assertAllAlmostEqual(final_state_extract, final_state_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_state_tf_backend, final_state_sf, delta=defaults.TOLERANCE)
+
+    def test_extract_unitary_2_modes(self):
+        num_subsystems = 2
+
+        eng_sf, q_sf = sf.Engine(num_subsystems=num_subsystems)
+        eng_extract, q_extract = sf.Engine(num_subsystems=num_subsystems)
+
+        cutoff_dim = 4
+
+        S = sf.ops.Sgate(2)
+        B = sf.ops.BSgate(2.234, -1.165)
+
+        initial_state = np.complex64(np.random.rand(cutoff_dim, cutoff_dim) + 1j*np.random.rand(cutoff_dim, cutoff_dim))
+
+        with eng_sf:
+            sf.ops.Ket(initial_state) | (q_sf[0], q_sf[1])
+            S | q_sf[0]
+            B | q_sf
+            S | q_sf[1]
+            B | q_sf
+
+        with eng_extract:
+            S | q_extract[0]
+            B | q_extract
+            S | q_extract[1]
+            B | q_extract
+
+        # calculate final states for vectorize_mode= True
+        matrix_extract = extract_unitary(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True)
+        matrix_extract_tf_backend = extract_unitary(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, backend='tf')
+        final_state_extract = matrix_extract.dot(initial_state.reshape([-1]))
+        with tf.Session() as sess:
+            sess.run(tf.global_variables_initializer())
+            final_state_tf_backend = sess.run(tf.einsum('ab,b', matrix_extract_tf_backend, tf.constant(initial_state.reshape([-1]))))
+        final_state_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).ket().reshape([-1])
+
+        # calculate final states for vectorize_mode= False
+        array_extract = extract_unitary(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=False)
+        final_array_extract = np.einsum("abcd,bd->ac", array_extract, initial_state)
+        final_array_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).ket()
+
+        self.assertAllAlmostEqual(final_state_extract, final_state_sf, delta = defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_state_tf_backend, final_state_sf, delta = defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_array_extract, final_array_sf, delta = defaults.TOLERANCE)
+
+    def test_extract_channel_1_mode(self):
+        num_subsystems = 1
+        eng_sf, q_sf = sf.Engine(num_subsystems=num_subsystems)
+        eng_extract, q_extract = sf.Engine(num_subsystems=num_subsystems)
+
+        cutoff_dim = 3
+
+        S = sf.ops.Sgate(1.1, -1.4)
+        L = sf.ops.LossChannel(0.45)
+
+        initial_state = np.random.rand(cutoff_dim, cutoff_dim)
+
+        with eng_sf:
+            sf.ops.DensityMatrix(initial_state) | q_sf
+            S | q_sf
+            L | q_sf
+
+        with eng_extract:
+            S | q_extract
+            L | q_extract
+
+        choi = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='choi')
+        liouville = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='liouville')
+        kraus = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='kraus')
+
+        final_rho_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).dm()
+        
+        final_rho_choi = np.einsum('abcd,ab -> cd', choi, initial_state)
+        final_rho_liouville = np.einsum('abcd,db -> ca', liouville, initial_state)
+        final_rho_kraus = np.einsum('abc,cd,aed -> be', kraus, initial_state, np.conj(kraus))
+
+        self.assertAllAlmostEqual(final_rho_choi, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_liouville, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_kraus, final_rho_sf, delta=defaults.TOLERANCE)
+
+    def test_extract_channel_2_modes(self):
+        num_subsystems = 2
+
+        eng_sf, q_sf = sf.Engine(num_subsystems=num_subsystems)
+        eng_extract, q_extract = sf.Engine(num_subsystems=num_subsystems)
+
+        cutoff_dim = 2
+
+        S = sf.ops.Sgate(2) 
+        B = sf.ops.BSgate(2.234, -1.165)
+
+        initial_state = np.random.rand(cutoff_dim, cutoff_dim, cutoff_dim, cutoff_dim) + 1j*np.random.rand(cutoff_dim, cutoff_dim, cutoff_dim, cutoff_dim)
+
+
+        with eng_sf:
+            sf.ops.DensityMatrix(initial_state) | (q_sf[0], q_sf[1])
+            S | q_sf[0]
+            B | q_sf
+            S | q_sf[1]
+            B | q_sf
+
+        with eng_extract:
+            S | q_extract[0]
+            B | q_extract
+            S | q_extract[1]
+            B | q_extract
+
+        #vectorize = false
+        choi = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=False, representation='choi')
+        liouville = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=False, representation='liouville')
+        kraus = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=False, representation='kraus')
+
+        final_rho_sf = eng_sf.run("fock", cutoff_dim=cutoff_dim).dm()
+
+        final_rho_choi = np.einsum('abcdefgh,abcd -> efgh', choi, initial_state)
+        final_rho_liouville = np.einsum('abcdefgh,fbhd -> eagc', liouville, initial_state)
+        final_rho_kraus = np.einsum('abcde,cfeg,ahfig -> bhdi', kraus, initial_state, np.conj(kraus))
+
+
+        self.assertAllAlmostEqual(final_rho_choi, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_liouville, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_kraus, final_rho_sf, delta=defaults.TOLERANCE)
+
+
+        #vectorize = true
+        choi = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='choi')
+        liouville = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='liouville')
+        kraus = extract_channel(eng_extract, cutoff_dim=cutoff_dim, vectorize_modes=True, representation='kraus')
+
+        final_rho_sf = np.einsum('abcd->acbd', final_rho_sf).reshape(cutoff_dim**2,cutoff_dim**2)
+        initial_state = np.einsum('abcd->acbd', initial_state).reshape(cutoff_dim**2,cutoff_dim**2)
+
+        final_rho_choi = np.einsum('abcd,ab -> cd', choi, initial_state)
+        final_rho_liouville = np.einsum('abcd,db -> ca', liouville, initial_state)
+        final_rho_kraus = np.einsum('abc,cd,aed -> be', kraus, initial_state, np.conj(kraus))
+
+        self.assertAllAlmostEqual(final_rho_choi, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_liouville, final_rho_sf, delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(final_rho_kraus, final_rho_sf, delta=defaults.TOLERANCE)
+
+        
+    def test_vectorize_unvectorize(self):
+        cutoff_dim = 4
+        dm = np.random.rand(*[cutoff_dim]*8) + 1j*np.random.rand(*[cutoff_dim]*8) # 4^8 -> (4^2)^4 -> 4^8
+        dm2 = np.random.rand(*[cutoff_dim]*4) + 1j*np.random.rand(*[cutoff_dim]*4) # (2^2)^4 -> 2^8 -> (2^2)^4
+        self.assertAllAlmostEqual(dm, unvectorize_dm(vectorize_dm(dm), 2), delta=defaults.TOLERANCE)
+        self.assertAllAlmostEqual(dm2, vectorize_dm(unvectorize_dm(dm2, 2)), delta=defaults.TOLERANCE)
+
+
+
+
+
+
+
+
+
+
 if __name__ == '__main__':
     print('Testing Strawberry Fields version ' + sf.version() + ', Utils.')
 
     # run the tests in this file
     suite = unittest.TestSuite()
-    tests = [InitialStates, FockInitialStates, ConvertFunctions, RandomStates]
+    tests = [ExtractChannel, InitialStates, FockInitialStates, ConvertFunctions, RandomStates]
     for t in tests:
         ttt = unittest.TestLoader().loadTestsFromTestCase(t)
         suite.addTests(ttt)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ import unittest
 import numpy as np
 from numpy import pi
 
+import tensorflow as tf
+
 import defaults
 from defaults import BaseTest, FockBaseTest, GaussianBaseTest, strawberryfields as sf
 from strawberryfields.ops import *
@@ -14,6 +16,7 @@ from strawberryfields.utils import *
 from strawberryfields.utils import _interleaved_identities, _vectorize_dm, _unvectorize_dm
 from strawberryfields.backends.shared_ops import sympmat
 
+from strawberryfields import backends
 from strawberryfields.backends.fockbackend.ops import squeezing as sq_U
 from strawberryfields.backends.fockbackend.ops import displacement as disp_U
 from strawberryfields.backends.fockbackend.ops import beamsplitter as bs_U
@@ -309,20 +312,25 @@ class ExtractOneMode(FockBaseTest):
     def test_extract_kerr(self):
         """test that kerr gate is correctly extracted"""
         self.logTestName()
+        self.eng_sf.backend = None
 
         kappa = 0.432
 
         with self.eng_sf:
             Kgate(kappa) | self.q_sf
 
-        U = extract_unitary(self.eng_sf, cutoff_dim=self.D)
+        U = extract_unitary(self.eng_sf, cutoff_dim=self.D, backend=self.backend_name)
         expected = np.diag(np.exp(1j*kappa*np.arange(self.D)**2))
+
+        if isinstance(U, tf.Tensor):
+            U = tf.Session().run(U)
 
         self.assertAllAlmostEqual(U, expected, delta=self.tol)
 
     def test_extract_squeezing(self):
         """test that squeezing gate is correctly extracted"""
         self.logTestName()
+        self.eng_sf.backend = None
 
         r = 0.432
         phi = -0.96543
@@ -330,22 +338,29 @@ class ExtractOneMode(FockBaseTest):
         with self.eng_sf:
             Sgate(r, phi) | self.q_sf
 
-        U = extract_unitary(self.eng_sf, cutoff_dim=self.D)
+        U = extract_unitary(self.eng_sf, cutoff_dim=self.D, backend=self.backend_name)
         expected = sq_U(r, phi, self.D)
+
+        if isinstance(U, tf.Tensor):
+            U = tf.Session().run(U)
 
         self.assertAllAlmostEqual(U, expected, delta=self.tol)
 
     def test_extract_displacement(self):
         """test that displacement gate is correctly extracted"""
         self.logTestName()
+        self.eng_sf.backend = None
 
         alpha = 0.432-0.8543j
 
         with self.eng_sf:
             Dgate(alpha) | self.q_sf
 
-        U = extract_unitary(self.eng_sf, cutoff_dim=self.D)
+        U = extract_unitary(self.eng_sf, cutoff_dim=self.D, backend=self.backend_name)
         expected = disp_U(alpha, self.D)
+
+        if isinstance(U, tf.Tensor):
+            U = tf.Session().run(U)
 
         self.assertAllAlmostEqual(U, expected, delta=self.tol)
 
@@ -478,6 +493,7 @@ class ExtractTwoModes(FockBaseTest):
     def test_extract_beamsplitter(self):
         """test that BSgate is correctly extracted"""
         self.logTestName()
+        self.eng_sf.backend = None
 
         theta = 0.432
         phi = 0.765
@@ -485,8 +501,11 @@ class ExtractTwoModes(FockBaseTest):
         with self.eng_sf:
             BSgate(theta, phi) | self.q_sf
 
-        U = extract_unitary(self.eng_sf, cutoff_dim=self.D)
+        U = extract_unitary(self.eng_sf, cutoff_dim=self.D, backend=self.backend_name)
         expected = bs_U(np.cos(theta), np.sin(theta), phi, self.D)
+
+        if isinstance(U, tf.Tensor):
+            U = tf.Session().run(U)
 
         self.assertAllAlmostEqual(U, expected, delta=self.tol)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import defaults
 from defaults import BaseTest, FockBaseTest, GaussianBaseTest, strawberryfields as sf
 from strawberryfields.ops import *
 from strawberryfields.utils import *
-from strawberryfields.utils import _interleaved_identities, _vectorize_dm, _unvectorize_dm
+from strawberryfields.utils import _interleaved_identities, _vectorize, _unvectorize
 from strawberryfields.backends.shared_ops import sympmat
 
 from strawberryfields import backends
@@ -466,8 +466,8 @@ class ExtractOneMode(FockBaseTest):
 
         dm = np.random.rand(*[cutoff]*8) + 1j*np.random.rand(*[cutoff]*8) # 4^8 -> (4^2)^4 -> 4^8
         dm2 = np.random.rand(*[cutoff]*4) + 1j*np.random.rand(*[cutoff]*4) # (2^2)^4 -> 2^8 -> (2^2)^4
-        self.assertAllAlmostEqual(dm, _unvectorize_dm(_vectorize_dm(dm), 2), delta=self.tol)
-        self.assertAllAlmostEqual(dm2, _vectorize_dm(_unvectorize_dm(dm2, 2)), delta=self.tol)
+        self.assertAllAlmostEqual(dm, _unvectorize(_vectorize(dm), 2), delta=self.tol)
+        self.assertAllAlmostEqual(dm2, _vectorize(_unvectorize(dm2, 2)), delta=self.tol)
 
     def test_interleaved_identities(self):
         """Test interleaved utility function"""


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Description of the Change:**
Added two new utilities to extract a numerical representation of a circuit from an Engine object: `extract_unitary` and `extract_channel`.
The first returns a numerical array that represents a unitary transformation (and it's applicable to the case where in the circuit specification there are only ops of type `Gate`).
The second returns a numerical array that represents a channel (and it's applicable to the case where in the circuit specification there are only ops of type `Gate` or `Channel`).

Both functions support an option to vectorise the indices that correspond to different modes. This makes `extract_unitary` return a matrix, and `extract_channel` return a rank-4 tensor (if the option `representation` is 'choi' or 'liouville') or a rank-3 tensor (if the option `representation` is 'kraus')

`extract_unitary` also supports the option `backend` which can take the value 'fock' (default), which results in a numpy array output, or 'tf' which results in a TensorFlow tensor output.


**Benefits:**
Now a user can specify a circuit and ask for a numerical representation of the transformation that it represents.

**Possible Drawbacks:**
What drawbacks? xD

**Related GitHub Issues:**
None (that I know of)