### PR TITLE
Added pytest boilerplate to the fock backend (50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/*ipynp*
 coverage_html_report/*
 notebooks/*
 examples/.ipynb_checkpoints/*
+.pytest_cache/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
     - LOGGING=info
 matrix:
   include:
-    - install: pip install -r requirements.txt
-      before_script: pip install pytest pytest-cov --upgrade
+    - before_script: pip install pytest pytest-cov --upgrade
       script: cd strawberryfields/backends && python3 -m pytest fockbackend/tests --cov=fockbackend
       after_success: true
     - env: BACKEND=gaussian

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,15 @@ matrix:
       sudo: required
     - env: BACKEND=tf MIXED=1 BATCHED=1
       sudo: required
-    - env: PYTEST=1
+    - script: cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
+      after_success: true
 install:
   - pip install -r requirements.txt
   - pip install wheel codecov
   - python3 setup.py bdist_wheel
   - pip install dist/StrawberryFields*.whl
 script:
-  - |
-    if [ $PYTEST == 1 ]; then
-      cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
-    else
-      coverage3 run -m unittest discover tests
-    fi
+  - coverage3 run -m unittest discover tests
 after_success:
   - codecov -F $BACKEND,m$MIXED,b$BATCHED
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
     - LOGGING=info
 matrix:
   include:
+    - before_script: pip install pytest pytest-cov --upgrade
+      script: cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
+      after_success: true
     - env: BACKEND=gaussian
     - env: BACKEND=gaussian MIXED=1
     - env: BACKEND=fock
@@ -23,8 +26,6 @@ matrix:
       sudo: required
     - env: BACKEND=tf MIXED=1 BATCHED=1
       sudo: required
-    - script: cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
-      after_success: true
 install:
   - pip install -r requirements.txt
   - pip install wheel codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,19 @@ matrix:
       sudo: required
     - env: BACKEND=tf MIXED=1 BATCHED=1
       sudo: required
+    - env: PYTEST=1
 install:
   - pip install -r requirements.txt
   - pip install wheel codecov
   - python3 setup.py bdist_wheel
   - pip install dist/StrawberryFields*.whl
 script:
-  - coverage3 run -m unittest discover tests
+  - |
+    if [ $PYTEST == 1 ]; then
+      cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
+    else
+      coverage3 run -m unittest discover tests
+    fi
 after_success:
   - codecov -F $BACKEND,m$MIXED,b$BATCHED
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ env:
     - LOGGING=info
 matrix:
   include:
-    - before_script: pip install pytest pytest-cov --upgrade
-      script: cd strawberryfields/backends && pytest fockbackend/tests --cov=fockbackend
+    - install: pip install -r requirements.txt
+      before_script: pip install pytest pytest-cov --upgrade
+      script: cd strawberryfields/backends && python3 -m pytest fockbackend/tests --cov=fockbackend
       after_success: true
     - env: BACKEND=gaussian
     - env: BACKEND=gaussian MIXED=1

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -24,8 +24,9 @@ from cmath import phase
 import numpy as np
 
 from strawberryfields.backends import BaseFock, ModeMap
-from .circuit import Circuit
 from strawberryfields.backends.states import BaseFockState
+
+from .circuit import Circuit
 
 indices = string.ascii_lowercase
 

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from strawberryfields.backends import BaseFock, ModeMap
 from .circuit import Circuit
-from ..states import BaseFockState
+from strawberryfields.backends.states import BaseFockState
 
 indices = string.ascii_lowercase
 

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -98,7 +98,7 @@ from numpy.polynomial.hermite import hermval as H
 from scipy.special import factorial as fac
 from scipy.linalg import expm as matrixExp
 
-from .. import shared_ops as so
+from strawberryfields.backends import shared_ops as so
 
 
 def_type = np.complex128

--- a/strawberryfields/backends/fockbackend/tests/conftest.py
+++ b/strawberryfields/backends/fockbackend/tests/conftest.py
@@ -32,37 +32,37 @@ BATCHED = False
 @pytest.fixture
 def tol():
     """Numerical tolerance for equality tests."""
-    return os.environ.get("TOL", TOL)
+    return float(os.environ.get("TOL", TOL))
 
 
 @pytest.fixture
 def cutoff():
     """Fock state cutoff"""
-    return os.environ.get("CUTOFF", CUTOFF)
+    return int(os.environ.get("CUTOFF", CUTOFF))
 
 
 @pytest.fixture
 def alpha():
     """Maximum magnitude of coherent states used in tests"""
-    return os.environ.get("ALPHA", ALPHA)
+    return float(os.environ.get("ALPHA", ALPHA))
 
 
 @pytest.fixture
 def hbar():
     """The value of hbar"""
-    return os.environ.get("HBAR", HBAR)
+    return float(os.environ.get("HBAR", HBAR))
 
 
 @pytest.fixture
 def pure():
     """Whether to run the backend in pure or mixed state mode"""
-    return os.environ.get("PURE", PURE)
+    return bool(int(os.environ.get("PURE", PURE)))
 
 
 @pytest.fixture
 def batched():
     """Whether to run the backend in batched mode"""
-    return os.environ.get("BATCHED", BATCHED)
+    return bool(int(os.environ.get("BATCHED", BATCHED)))
 
 
 @pytest.fixture

--- a/strawberryfields/backends/fockbackend/tests/conftest.py
+++ b/strawberryfields/backends/fockbackend/tests/conftest.py
@@ -31,37 +31,45 @@ BATCHED = False
 
 @pytest.fixture
 def tol():
+    """Numerical tolerance for equality tests."""
     return os.environ.get("TOL", TOL)
 
 
 @pytest.fixture
 def cutoff():
+    """Fock state cutoff"""
     return os.environ.get("CUTOFF", CUTOFF)
 
 
 @pytest.fixture
 def alpha():
+    """Maximum magnitude of coherent states used in tests"""
     return os.environ.get("ALPHA", ALPHA)
 
 
 @pytest.fixture
 def hbar():
+    """The value of hbar"""
     return os.environ.get("HBAR", HBAR)
 
 
 @pytest.fixture
 def pure():
+    """Whether to run the backend in pure or mixed state mode"""
     return os.environ.get("PURE", PURE)
 
 
 @pytest.fixture
 def batched():
+    """Whether to run the backend in batched mode"""
     return os.environ.get("BATCHED", BATCHED)
 
 
 @pytest.fixture
-def begin_circuit(cutoff, hbar, pure):
+def begin_circuit(cutoff, hbar, pure): #pylint: disable=redefined-outer-name
+    """Parameterized fixture, used to automatically create a backend of certain number of modes"""
     def create_backend(num_subsystems):
+        """Factory function"""
         backend = FockBackend()
         backend.begin_circuit(num_subsystems=num_subsystems, cutoff_dim=cutoff, hbar=hbar, pure=pure)
         return backend

--- a/strawberryfields/backends/fockbackend/tests/conftest.py
+++ b/strawberryfields/backends/fockbackend/tests/conftest.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Default parameters, commandline arguments and common routines for the Fock backend unit tests.
+"""
+import os
+import pytest
+
+from fockbackend import FockBackend
+
+
+# defaults
+TOL = 1e-3
+CUTOFF = 6
+ALPHA = 0.1
+HBAR = 2
+PURE = True
+BATCHED = False
+
+
+@pytest.fixture
+def tol():
+    return os.environ.get("TOL", TOL)
+
+
+@pytest.fixture
+def cutoff():
+    return os.environ.get("CUTOFF", CUTOFF)
+
+
+@pytest.fixture
+def alpha():
+    return os.environ.get("ALPHA", ALPHA)
+
+
+@pytest.fixture
+def hbar():
+    return os.environ.get("HBAR", HBAR)
+
+
+@pytest.fixture
+def pure():
+    return os.environ.get("PURE", PURE)
+
+
+@pytest.fixture
+def batched():
+    return os.environ.get("BATCHED", BATCHED)
+
+
+@pytest.fixture
+def begin_circuit(cutoff, hbar, pure):
+    def create_backend(num_subsystems):
+        backend = FockBackend()
+        backend.begin_circuit(num_subsystems=num_subsystems, cutoff_dim=cutoff, hbar=hbar, pure=pure)
+        return backend
+    return create_backend

--- a/strawberryfields/backends/fockbackend/tests/test_displacement.py
+++ b/strawberryfields/backends/fockbackend/tests/test_displacement.py
@@ -17,6 +17,7 @@ Convention: The displacement unitary is fixed to be
 U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
 where \hat{a}^\dagger is the photon creation operator.
 """
+#pylint: disable=too-many-arguments
 import pytest
 
 import numpy as np
@@ -52,7 +53,7 @@ def test_fidelity_coherent(begin_circuit, r, p, tol):
 
 @pytest.mark.parametrize("r", MAG_ALPHAS)
 @pytest.mark.parametrize("p", PHASE_ALPHAS)
-def test_normalized_displaced_state(begin_circuit, r, p, cutoff, pure, tol):
+def test_normalized_displaced_state(begin_circuit, r, p, tol):
     """Tests if a range of displaced states are normalized."""
     alpha = r*np.exp(1j*p)
 

--- a/strawberryfields/backends/fockbackend/tests/test_displacement.py
+++ b/strawberryfields/backends/fockbackend/tests/test_displacement.py
@@ -1,0 +1,89 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Unit tests for displacement operations
+Convention: The displacement unitary is fixed to be
+U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
+where \hat{a}^\dagger is the photon creation operator.
+"""
+import pytest
+
+import numpy as np
+from scipy.special import factorial as fac
+
+
+MAG_ALPHAS = np.linspace(0, .8, 4)
+PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
+
+
+def test_no_displacement(begin_circuit, tol):
+    """Tests displacement operation where the result should be a vacuum state."""
+    backend = begin_circuit(1)
+    backend.displacement(0, 0)
+    assert backend.is_vacuum(tol)
+
+
+@pytest.mark.parametrize("r", MAG_ALPHAS)
+@pytest.mark.parametrize("p", PHASE_ALPHAS)
+def test_fidelity_coherent(begin_circuit, r, p, tol):
+    """Tests if a range of alpha-displaced states have the correct fidelity
+    with the corresponding coherent state.
+    """
+    alpha = r*np.exp(1j*p)
+
+    backend = begin_circuit(1)
+    backend.displacement(alpha, 0)
+    state = backend.state()
+
+    fid = state.fidelity_coherent([alpha])
+    assert np.abs(fid - 1) < tol
+
+
+@pytest.mark.parametrize("r", MAG_ALPHAS)
+@pytest.mark.parametrize("p", PHASE_ALPHAS)
+def test_normalized_displaced_state(begin_circuit, r, p, cutoff, pure, tol):
+    """Tests if a range of displaced states are normalized."""
+    alpha = r*np.exp(1j*p)
+
+    backend = begin_circuit(1)
+    backend.displacement(alpha, 0)
+    state = backend.state()
+
+    assert np.allclose(state.trace(), 1, atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("r", MAG_ALPHAS)
+@pytest.mark.parametrize("p", PHASE_ALPHAS)
+def test_coherent_state_fock_elements(begin_circuit, r, p, cutoff, pure, tol):
+    r"""Tests if a range of alpha-displaced states have the correct Fock basis elements:
+       |\alpha> = exp(-0.5 |\alpha|^2) \sum_n \alpha^n / \sqrt{n!} |n>
+    """
+    alpha = r*np.exp(1j*p)
+
+    backend = begin_circuit(1)
+    backend.displacement(alpha, 0)
+    state = backend.state()
+
+    if state.is_pure:
+        numer_state = state.ket()
+    else:
+        numer_state = state.dm()
+
+    n = np.arange(cutoff)
+    ref_state = np.exp(-0.5*np.abs(alpha)**2)*alpha**n / np.sqrt(fac(n))
+
+    if not pure:
+        ref_state = np.outer(ref_state, np.conj(ref_state))
+
+    assert np.allclose(numer_state, ref_state, atol=tol, rtol=0)

--- a/strawberryfields/backends/fockbackend/tests/test_squeeze.py
+++ b/strawberryfields/backends/fockbackend/tests/test_squeeze.py
@@ -17,10 +17,11 @@ Convention: The squeezing unitary is fixed to be
 U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
 where \hat{a} is the photon annihilation operator.
 """
+#pylint: disable=too-many-arguments
 import pytest
 
 import numpy as np
-from scipy.special import factorial as fac, erfinv, gammaln as lg
+from scipy.special import factorial as fac, gammaln as lg
 
 
 PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
@@ -35,13 +36,13 @@ def matrix_elem(n, r, m):
         return 0.0
 
     if r == 0.:
-        return np.complex(n==m) # delta function
+        return np.complex(n == m) # delta function
 
     k = np.arange(m % 2, min([m, n]) + 1, 2)
     res = np.sum(
         (-1)**((n-k)/2)
-          * np.exp((lg(m+1) + lg(n+1))/2 - lg(k+1) - lg((m-k)/2+1) - lg((n-k)/2+1))
-          * (np.sinh(r)/2+eps)**((n+m-2*k)/2) / (np.cosh(r)**((n+m+1)/2))
+        * np.exp((lg(m+1) + lg(n+1))/2 - lg(k+1) - lg((m-k)/2+1) - lg((n-k)/2+1))
+        * (np.sinh(r)/2+eps)**((n+m-2*k)/2) / (np.cosh(r)**((n+m+1)/2))
         )
     return res
 
@@ -70,7 +71,7 @@ def test_normalized_squeezed_state(begin_circuit, r, p, tol):
 
 @pytest.mark.parametrize("r", MAG)
 @pytest.mark.parametrize("p", PHASE)
-def test_no_odd_fock(begin_circuit, r, p, batched, tol):
+def test_no_odd_fock(begin_circuit, r, p, batched):
     """Tests if a range of squeezed vacuum states have
     only nonzero entries for even Fock states."""
     z = r * np.exp(1j * p)
@@ -126,7 +127,7 @@ def test_reference_squeezed_vacuum(begin_circuit, r, p, cutoff, batched, pure, t
 
 
 @pytest.mark.parametrize("r", MAG)
-def test_reference_squeezed_vacuum(begin_circuit, r, cutoff, pure, tol):
+def test_reference_squeezed_fock(begin_circuit, r, cutoff, pure, tol):
     """Tests if a range of squeezed fock states are equal to the form of Eq. (20)
     in 'On the Squeezed Number States and their Phase Space Representations'
     (https://arxiv.org/abs/quant-ph/0108024).

--- a/strawberryfields/backends/fockbackend/tests/test_squeeze.py
+++ b/strawberryfields/backends/fockbackend/tests/test_squeeze.py
@@ -1,0 +1,154 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Unit tests for squeezing operation
+Convention: The squeezing unitary is fixed to be
+U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
+where \hat{a} is the photon annihilation operator.
+"""
+import pytest
+
+import numpy as np
+from scipy.special import factorial as fac, erfinv, gammaln as lg
+
+
+PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+MAG = np.linspace(0.0, 0.2, 5, endpoint=False)
+
+
+def matrix_elem(n, r, m):
+    """Matrix element corresponding to squeezed density matrix[n, m]"""
+    eps = 1e-10
+
+    if n % 2 != m % 2:
+        return 0.0
+
+    if r == 0.:
+        return np.complex(n==m) # delta function
+
+    k = np.arange(m % 2, min([m, n]) + 1, 2)
+    res = np.sum(
+        (-1)**((n-k)/2)
+          * np.exp((lg(m+1) + lg(n+1))/2 - lg(k+1) - lg((m-k)/2+1) - lg((n-k)/2+1))
+          * (np.sinh(r)/2+eps)**((n+m-2*k)/2) / (np.cosh(r)**((n+m+1)/2))
+        )
+    return res
+
+
+def test_no_squeezing(begin_circuit, tol):
+    """Tests displacement operation where the result should be a vacuum state."""
+    backend = begin_circuit(1)
+    backend.squeeze(0, 0)
+    assert backend.is_vacuum(tol)
+
+
+@pytest.mark.parametrize("r", MAG)
+@pytest.mark.parametrize("p", PHASE)
+def test_normalized_squeezed_state(begin_circuit, r, p, tol):
+    """Tests if a range of alpha-displaced states have the correct fidelity
+    with the corresponding coherent state.
+    """
+    z = r*np.exp(1j*p)
+
+    backend = begin_circuit(1)
+    backend.squeeze(z, 0)
+    state = backend.state()
+
+    assert np.abs(state.trace() - 1) < tol
+
+
+@pytest.mark.parametrize("r", MAG)
+@pytest.mark.parametrize("p", PHASE)
+def test_no_odd_fock(begin_circuit, r, p, batched, tol):
+    """Tests if a range of squeezed vacuum states have
+    only nonzero entries for even Fock states."""
+    z = r * np.exp(1j * p)
+
+    backend = begin_circuit(1)
+    backend.squeeze(z, 0)
+    state = backend.state()
+
+    if state.is_pure:
+        num_state = state.ket()
+    else:
+        num_state = state.dm()
+
+    if batched:
+        odd_entries = num_state[:, 1::2]
+    else:
+        odd_entries = num_state[1::2]
+
+    assert np.all(odd_entries == 0)
+
+
+@pytest.mark.parametrize("r", MAG)
+@pytest.mark.parametrize("p", PHASE)
+def test_reference_squeezed_vacuum(begin_circuit, r, p, cutoff, batched, pure, tol):
+    """Tests if a range of squeezed vacuum states are equal to the form of Eq. (5.5.6) in Loudon."""
+    z = r * np.exp(1j * p)
+
+    backend = begin_circuit(1)
+    backend.squeeze(z, 0)
+    state = backend.state()
+
+    if state.is_pure:
+        num_state = state.ket()
+    else:
+        num_state = state.dm()
+
+    k = np.arange(0, cutoff, 2)
+    even_refs = np.sqrt(1/np.cosh(r))*np.sqrt(fac(k))/fac(k / 2)*(-0.5*np.exp(1j*p)*np.tanh(r))**(k/2)
+
+    if pure:
+        if batched:
+            even_entries = num_state[:, ::2]
+        else:
+            even_entries = num_state[::2]
+    else:
+        even_refs = np.outer(even_refs, even_refs.conj())
+        if batched:
+            even_entries = num_state[:, ::2, ::2]
+        else:
+            even_entries = num_state[::2, ::2]
+
+    assert np.allclose(even_entries, even_refs, atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("r", MAG)
+def test_reference_squeezed_vacuum(begin_circuit, r, cutoff, pure, tol):
+    """Tests if a range of squeezed fock states are equal to the form of Eq. (20)
+    in 'On the Squeezed Number States and their Phase Space Representations'
+    (https://arxiv.org/abs/quant-ph/0108024).
+    """
+    backend = begin_circuit(1)
+
+    for m in range(cutoff):
+        backend.reset(pure=pure)
+        backend.prepare_fock_state(m, 0)
+        backend.squeeze(r, 0)
+        state = backend.state()
+
+        if state.is_pure:
+            num_state = state.ket()
+        else:
+            num_state = state.dm()
+
+        ref_state = np.array([matrix_elem(n, r, m) for n in range(cutoff)])
+
+        if not pure:
+            ref_state = np.outer(ref_state, ref_state.conj())
+
+        print(num_state, ref_state)
+
+        assert np.allclose(num_state, ref_state, atol=tol, rtol=0)


### PR DESCRIPTION
Changes:

* Slightly modifies the imports of the Fock backend, so that they import anything from the main Strawberry Fields package is imported via an absolute path. This allows the Fock backend to be imported independently of Strawberry Fields.

* Added a `test` folder to the `fockbackend` submodule

* Added a pytest `conftest.py` configuration file, which defines the main test environment variables (cutoff, hbar, batched, pure, etc.) as pytest fixtures. Also creates a fixture for initializing the backend with a specific number of subsystems.

* Ported over `test_displacement_operator.py` and `test_squeezing.py`. *Note that I changed the names of the new tests to match the Fock backend methods they are testing.*

* Linted the two ported tests using pylint, and added the license boilerplate.

* Added an extra job matrix to the top level travis.yml file, to run the fockbackend pytest suite.

To run the new test suite, change to the `strawberryfields/backends` directory, and run

```bash
pytest fockbackend/tests --cov=fockbackend
```

Expected output:

```bash
============================= test session starts ==============================
platform linux -- Python 3.6.3, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
rootdir: /home/josh/Dropbox/Work/Xanadu/sf_cloud, inifile:
plugins: cov-2.5.1, celery-4.1.0
collected 121 items                                                            

fockbackend/tests/test_displacement.py ................................. [ 27%]
....................................................                     [ 70%]
fockbackend/tests/test_squeeze.py ....................................   [100%]

----------- coverage: platform linux, python 3.6.3-final-0 -----------
Name                                     Stmts   Miss  Cover
------------------------------------------------------------
fockbackend/__init__.py                      2      0   100%
fockbackend/backend.py                     135     59    56%
fockbackend/circuit.py                     242    158    35%
fockbackend/ops.py                         266    174    35%
fockbackend/tests/conftest.py               28      1    96%
fockbackend/tests/test_displacement.py      39      2    95%
fockbackend/tests/test_squeeze.py           74     22    70%
------------------------------------------------------------
TOTAL                                      786    416    47%


========================== 121 passed in 0.46 seconds ==========================
```