### PR TITLE
update readme and docs to explain python 3.7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Features
 Installation
 ============
 
-Strawberry Fields requires Python version 3.5 and above. Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
+Strawberry Fields requires Python version 3.5 and 3.6 (we are unable to support 3.7 until TensorFlow also supports 3.7). Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -13,7 +13,7 @@ Dependencies
 
 Strawberry Fields requires the following libraries be installed:
 
-* `Python <http://python.org/>`_ >=3.5
+* `Python <http://python.org/>`_ >=3.5,<3.7
 
 as well as the following Python packages:
 
@@ -24,6 +24,11 @@ as well as the following Python packages:
 
 
 If you currently do not have Python 3 installed, we recommend `Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed version of Python packaged for scientific computation.
+
+.. note::
+
+	As Tensorflow does not currently support Python 3.7 and above, we are unable to
+	also support Strawberry Fields on Python 3.7.
 
 
 Installation


### PR DESCRIPTION
**Description of the Change:** makes clear in the readme and documentation that Strawberry Fields cannot support Python 3.7 due to TensorFlow not supporting this Python version.

**Benefits:** clarity to users on Python 3.7

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #35 
