### PR TITLE
Pytest backend

### DIFF
--- a/pytest/backend/test_beamsplitter_operation.py
+++ b/pytest/backend/test_beamsplitter_operation.py
@@ -27,10 +27,10 @@ import numpy as np
 from scipy.special import factorial
 
 
-T_VALUES = np.linspace(-0.2, 1., 3)
+T_VALUES = np.linspace(-0.2, 1.0, 3)
 PHASE_R = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 ALPHA = 0.1
-MAG_ALPHAS = np.linspace(0., ALPHA, 3)
+MAG_ALPHAS = np.linspace(0.0, ALPHA, 3)
 
 
 class TestRepresentationIndependent:
@@ -39,7 +39,7 @@ class TestRepresentationIndependent:
     def test_complex_t(self, setup_backend):
         """Test exception raised if t is complex"""
         t = 0.1 + 0.5j
-        r = np.exp(1j * 0.2) * np.sqrt(1. - np.abs(t) ** 2)
+        r = np.exp(1j * 0.2) * np.sqrt(1.0 - np.abs(t) ** 2)
         backend = setup_backend(2)
 
         with pytest.raises(ValueError, match="must be a float"):
@@ -50,7 +50,7 @@ class TestRepresentationIndependent:
     def test_vacuum_beamsplitter(self, setup_backend, t, r_phi, tol):
         """Tests beamsplitter operation in some limiting cases where the output
            should be the vacuum in both modes."""
-        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        r = np.exp(1j * r_phi) * np.sqrt(1.0 - np.abs(t) ** 2)
         backend = setup_backend(2)
 
         backend.beamsplitter(t, r, 0, 1)
@@ -67,7 +67,7 @@ class TestRepresentationIndependent:
             |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>"""
         phase_alpha = np.pi / 5
         alpha = mag_alpha * np.exp(1j * phase_alpha)
-        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        r = np.exp(1j * r_phi) * np.sqrt(1.0 - np.abs(t) ** 2)
         backend = setup_backend(2)
 
         backend.displacement(alpha, 0)
@@ -79,7 +79,7 @@ class TestRepresentationIndependent:
         assert np.allclose(fidel, 1, atol=tol, rtol=0)
 
 
-@pytest.mark.backends('tf', 'fock')
+@pytest.mark.backends("tf", "fock")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -89,7 +89,7 @@ class TestFockRepresentation:
         """Tests if a range of beamsplitter outputs states are normalized."""
 
         alpha = ALPHA * np.exp(1j * np.pi / 3)
-        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        r = np.exp(1j * r_phi) * np.sqrt(1.0 - np.abs(t) ** 2)
         backend = setup_backend(2)
 
         backend.displacement(alpha, 1)
@@ -101,7 +101,9 @@ class TestFockRepresentation:
     @pytest.mark.parametrize("t", T_VALUES)
     @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS[1:])
     @pytest.mark.parametrize("r_phi", PHASE_R)
-    def test_coherent_vacuum_interfered_fock_elements(self, setup_backend, mag_alpha, t, r_phi, cutoff, pure, tol):
+    def test_coherent_vacuum_interfered_fock_elements(
+        self, setup_backend, mag_alpha, t, r_phi, cutoff, pure, tol
+    ):
         r"""Tests if a range of beamsplitter output states (formed from a coherent state interfering with vacuum)
             have the correct Fock basis elements.
             |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out>
@@ -110,7 +112,7 @@ class TestFockRepresentation:
 
         phase_alpha = np.pi / 5
         alpha = mag_alpha * np.exp(1j * phase_alpha)
-        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        r = np.exp(1j * r_phi) * np.sqrt(1.0 - np.abs(t) ** 2)
         backend = setup_backend(2)
 
         backend.displacement(alpha, 0)
@@ -126,12 +128,26 @@ class TestFockRepresentation:
         alpha_outB = r * alpha
 
         n = np.arange(cutoff)
-        ref_stateA = np.exp(-0.5*np.abs(alpha_outA)**2)*alpha_outA**n/np.sqrt(factorial(n))
-        ref_stateB = np.exp(-0.5*np.abs(alpha_outB)**2)*alpha_outB**n/np.sqrt(factorial(n))
+        ref_stateA = (
+            np.exp(-0.5 * np.abs(alpha_outA) ** 2)
+            * alpha_outA ** n
+            / np.sqrt(factorial(n))
+        )
+        ref_stateB = (
+            np.exp(-0.5 * np.abs(alpha_outB) ** 2)
+            * alpha_outB ** n
+            / np.sqrt(factorial(n))
+        )
 
-        ref_state = np.einsum('i,j->ij', ref_stateA, ref_stateB)
+        ref_state = np.einsum("i,j->ij", ref_stateA, ref_stateB)
 
         if not pure:
-            ref_state = np.einsum('i,j,k,l->ijkl', ref_stateA, np.conj(ref_stateA), ref_stateB, np.conj(ref_stateB))
+            ref_state = np.einsum(
+                "i,j,k,l->ijkl",
+                ref_stateA,
+                np.conj(ref_stateA),
+                ref_stateB,
+                np.conj(ref_stateB),
+            )
 
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0)

--- a/pytest/backend/test_beamsplitter_operation.py
+++ b/pytest/backend/test_beamsplitter_operation.py
@@ -1,0 +1,137 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Unit tests for beamsplitter operations
+Convention: The beamsplitter operation transforms
+\hat{a} -> t \hat{a} + r \hat{b}
+\hat{b} -> - r^* \hat{a} + t^* \hat{b}
+where \hat{a}, \hat{b} are the photon creation operators of the two modes
+Equivalently, we have t:=\cos(\theta) (t assumed real) and r:=\exp{i\phi}\sin(\theta)
+"""
+
+import pytest
+
+import numpy as np
+from scipy.special import factorial
+
+
+T_VALUES = np.linspace(-0.2, 1., 3)
+PHASE_R = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+ALPHA = 0.1
+MAG_ALPHAS = np.linspace(0., ALPHA, 3)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_complex_t(self, setup_backend):
+        """Test exception raised if t is complex"""
+        t = 0.1 + 0.5j
+        r = np.exp(1j * 0.2) * np.sqrt(1. - np.abs(t) ** 2)
+        backend = setup_backend(2)
+
+        with pytest.raises(ValueError, match="must be a float"):
+            backend.beamsplitter(t, r, 0, 1)
+
+    @pytest.mark.parametrize("t", T_VALUES)
+    @pytest.mark.parametrize("r_phi", PHASE_R)
+    def test_vacuum_beamsplitter(self, setup_backend, t, r_phi, tol):
+        """Tests beamsplitter operation in some limiting cases where the output
+           should be the vacuum in both modes."""
+        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        backend = setup_backend(2)
+
+        backend.beamsplitter(t, r, 0, 1)
+        assert np.all(backend.is_vacuum(tol))
+
+    @pytest.mark.parametrize("t", T_VALUES)
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS[1:])
+    @pytest.mark.parametrize("r_phi", PHASE_R)
+    def test_coherent_vacuum_interfered(self, setup_backend, t, mag_alpha, r_phi, tol):
+        r"""Tests if a range of beamsplitter output states (formed from a coherent state interfering with vacuum)
+            have the correct fidelity with the expected coherent states outputs.
+            |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out>
+            and for each output mode,
+            |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>"""
+        phase_alpha = np.pi / 5
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        backend = setup_backend(2)
+
+        backend.displacement(alpha, 0)
+        backend.beamsplitter(t, r, 0, 1)
+        alpha_outA = t * alpha
+        alpha_outB = r * alpha
+        state = backend.state()
+        fidel = state.fidelity_coherent([alpha_outA, alpha_outB])
+        assert np.allclose(fidel, 1, atol=tol, rtol=0)
+
+
+@pytest.mark.backends('tf', 'fock')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("t", T_VALUES)
+    @pytest.mark.parametrize("r_phi", PHASE_R)
+    def test_normalized_beamsplitter_output(self, setup_backend, t, r_phi, tol):
+        """Tests if a range of beamsplitter outputs states are normalized."""
+
+        alpha = ALPHA * np.exp(1j * np.pi / 3)
+        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        backend = setup_backend(2)
+
+        backend.displacement(alpha, 1)
+        backend.beamsplitter(t, r, 0, 1)
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("t", T_VALUES)
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS[1:])
+    @pytest.mark.parametrize("r_phi", PHASE_R)
+    def test_coherent_vacuum_interfered_fock_elements(self, setup_backend, mag_alpha, t, r_phi, cutoff, pure, tol):
+        r"""Tests if a range of beamsplitter output states (formed from a coherent state interfering with vacuum)
+            have the correct Fock basis elements.
+            |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out>
+            and for each output mode,
+            |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>"""
+
+        phase_alpha = np.pi / 5
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        r = np.exp(1j * r_phi) * np.sqrt(1. - np.abs(t) ** 2)
+        backend = setup_backend(2)
+
+        backend.displacement(alpha, 0)
+        backend.beamsplitter(t, r, 0, 1)
+        state = backend.state()
+
+        if state.is_pure:
+            numer_state = state.ket()
+        else:
+            numer_state = state.dm()
+
+        alpha_outA = t * alpha
+        alpha_outB = r * alpha
+
+        n = np.arange(cutoff)
+        ref_stateA = np.exp(-0.5*np.abs(alpha_outA)**2)*alpha_outA**n/np.sqrt(factorial(n))
+        ref_stateB = np.exp(-0.5*np.abs(alpha_outB)**2)*alpha_outB**n/np.sqrt(factorial(n))
+
+        ref_state = np.einsum('i,j->ij', ref_stateA, ref_stateB)
+
+        if not pure:
+            ref_state = np.einsum('i,j,k,l->ijkl', ref_stateA, np.conj(ref_stateA), ref_stateB, np.conj(ref_stateB))
+
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0)

--- a/pytest/backend/test_displaced_squeezed_state_preparation.py
+++ b/pytest/backend/test_displaced_squeezed_state_preparation.py
@@ -19,8 +19,8 @@ import pytest
 import numpy as np
 from scipy.special import factorial
 
-MAG_ALPHAS = np.linspace(0.1, .5, 2)
-PHASE_ALPHAS = np.linspace(np.pi/6, 2 * np.pi, 2, endpoint=False)
+MAG_ALPHAS = np.linspace(0.1, 0.5, 2)
+PHASE_ALPHAS = np.linspace(np.pi / 6, 2 * np.pi, 2, endpoint=False)
 SQZ_R = np.linspace(0.01, 0.1, 2)
 SQZ_PHI = np.linspace(np.pi / 3, 2 * np.pi, 2, endpoint=False)
 
@@ -45,7 +45,9 @@ class TestRepresentationIndependent:
 
     @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
     @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
-    def test_displaced_squeezed_with_no_squeezing(self, setup_backend, mag_alpha, phase_alpha, tol):
+    def test_displaced_squeezed_with_no_squeezing(
+        self, setup_backend, mag_alpha, phase_alpha, tol
+    ):
         """Tests if a squeezed coherent state with no squeezing is equal to a coherent state."""
         r = phi = 0
         alpha = mag_alpha * np.exp(1j * phase_alpha)
@@ -57,7 +59,7 @@ class TestRepresentationIndependent:
         assert np.allclose(fidel, 1, atol=tol, rtol=0)
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -65,7 +67,9 @@ class TestFockRepresentation:
     @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
     @pytest.mark.parametrize("r", SQZ_R)
     @pytest.mark.parametrize("phi", SQZ_PHI)
-    def test_normalized_displaced_squeezed_state(self, setup_backend, mag_alpha, phase_alpha, r, phi, tol):
+    def test_normalized_displaced_squeezed_state(
+        self, setup_backend, mag_alpha, phase_alpha, r, phi, tol
+    ):
         """Tests if a range of squeezed vacuum states are normalized."""
         alpha = mag_alpha * np.exp(1j * phase_alpha)
         backend = setup_backend(1)
@@ -77,7 +81,9 @@ class TestFockRepresentation:
 
     @pytest.mark.parametrize("r", SQZ_R)
     @pytest.mark.parametrize("phi", SQZ_PHI)
-    def test_displaced_squeezed_with_no_displacement(self, setup_backend, r, phi, cutoff, batch_size, pure, tol):
+    def test_displaced_squeezed_with_no_displacement(
+        self, setup_backend, r, phi, cutoff, batch_size, pure, tol
+    ):
         """Tests if a squeezed coherent state with no displacement is equal to a squeezed state (Eq. (5.5.6) in Loudon)."""
         alpha = 0
         backend = setup_backend(1)
@@ -91,7 +97,12 @@ class TestFockRepresentation:
             num_state = state.dm()
 
         n = np.arange(0, cutoff, 2)
-        even_refs = np.sqrt(sech(r)) * np.sqrt(factorial(n)) / factorial(n / 2) * (-0.5 * np.exp(1j * phi) * np.tanh(r)) ** (n / 2)
+        even_refs = (
+            np.sqrt(sech(r))
+            * np.sqrt(factorial(n))
+            / factorial(n / 2)
+            * (-0.5 * np.exp(1j * phi) * np.tanh(r)) ** (n / 2)
+        )
 
         if batch_size is not None:
             if pure:

--- a/pytest/backend/test_displaced_squeezed_state_preparation.py
+++ b/pytest/backend/test_displaced_squeezed_state_preparation.py
@@ -1,0 +1,109 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for operations that prepare squeezed coherent states"""
+
+import pytest
+
+import numpy as np
+from scipy.special import factorial
+
+MAG_ALPHAS = np.linspace(0.1, .5, 2)
+PHASE_ALPHAS = np.linspace(np.pi/6, 2 * np.pi, 2, endpoint=False)
+SQZ_R = np.linspace(0.01, 0.1, 2)
+SQZ_PHI = np.linspace(np.pi / 3, 2 * np.pi, 2, endpoint=False)
+
+
+def sech(x):
+    """Hyperbolic secant"""
+    return 1 / np.cosh(x)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    @pytest.mark.parametrize("phi", SQZ_PHI)
+    def test_no_squeezing_no_displacement(self, setup_backend, phi, tol):
+        """Tests squeezing operation in the limiting case where the result should be a vacuum state."""
+        alpha = 0
+        r = 0
+
+        backend = setup_backend(1)
+        backend.prepare_displaced_squeezed_state(alpha, r, phi, 0)
+        assert np.all(backend.is_vacuum(tol))
+
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
+    @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
+    def test_displaced_squeezed_with_no_squeezing(self, setup_backend, mag_alpha, phase_alpha, tol):
+        """Tests if a squeezed coherent state with no squeezing is equal to a coherent state."""
+        r = phi = 0
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        backend = setup_backend(1)
+
+        backend.prepare_displaced_squeezed_state(alpha, r, phi, 0)
+        state = backend.state()
+        fidel = state.fidelity_coherent([alpha])
+        assert np.allclose(fidel, 1, atol=tol, rtol=0)
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
+    @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
+    @pytest.mark.parametrize("r", SQZ_R)
+    @pytest.mark.parametrize("phi", SQZ_PHI)
+    def test_normalized_displaced_squeezed_state(self, setup_backend, mag_alpha, phase_alpha, r, phi, tol):
+        """Tests if a range of squeezed vacuum states are normalized."""
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        backend = setup_backend(1)
+
+        backend.prepare_displaced_squeezed_state(alpha, r, phi, 0)
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("r", SQZ_R)
+    @pytest.mark.parametrize("phi", SQZ_PHI)
+    def test_displaced_squeezed_with_no_displacement(self, setup_backend, r, phi, cutoff, batch_size, pure, tol):
+        """Tests if a squeezed coherent state with no displacement is equal to a squeezed state (Eq. (5.5.6) in Loudon)."""
+        alpha = 0
+        backend = setup_backend(1)
+
+        backend.prepare_displaced_squeezed_state(alpha, r, phi, 0)
+        state = backend.state()
+
+        if state.is_pure:
+            num_state = state.ket()
+        else:
+            num_state = state.dm()
+
+        n = np.arange(0, cutoff, 2)
+        even_refs = np.sqrt(sech(r)) * np.sqrt(factorial(n)) / factorial(n / 2) * (-0.5 * np.exp(1j * phi) * np.tanh(r)) ** (n / 2)
+
+        if batch_size is not None:
+            if pure:
+                even_entries = num_state[:, ::2]
+            else:
+                even_entries = num_state[:, ::2, ::2]
+                even_refs = np.outer(even_refs, np.conj(even_refs))
+        else:
+            if pure:
+                even_entries = num_state[::2]
+            else:
+                even_entries = num_state[::2, ::2]
+                even_refs = np.outer(even_refs, np.conj(even_refs))
+
+        assert np.allclose(even_entries, even_refs, atol=tol, rtol=0)

--- a/pytest/backend/test_displacement_operation.py
+++ b/pytest/backend/test_displacement_operation.py
@@ -1,0 +1,96 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Unit tests for displacement operations
+Convention: The displacement unitary is fixed to be
+U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
+where \hat{a}^\dagger is the photon creation operator.
+"""
+#pylint: disable=too-many-arguments
+import pytest
+
+import numpy as np
+from scipy.special import factorial as fac
+
+
+MAG_ALPHAS = np.linspace(0, .8, 4)
+PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_no_displacement(self, setup_backend, tol):
+        """Tests displacement operation where the result should be a vacuum state."""
+        backend = setup_backend(1)
+        backend.displacement(0, 0)
+        assert np.all(backend.is_vacuum(tol))
+
+    @pytest.mark.parametrize("r", MAG_ALPHAS)
+    @pytest.mark.parametrize("p", PHASE_ALPHAS)
+    def test_fidelity_coherent(self, setup_backend, r, p, tol):
+        """Tests if a range of alpha-displaced states have the correct fidelity
+        with the corresponding coherent state.
+        """
+        alpha = r*np.exp(1j*p)
+
+        backend = setup_backend(1)
+        backend.displacement(alpha, 0)
+        state = backend.state()
+
+        fid = state.fidelity_coherent([alpha])
+        assert np.allclose(fid, 1, atol=tol, rtol=0)
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("r", MAG_ALPHAS)
+    @pytest.mark.parametrize("p", PHASE_ALPHAS)
+    def test_normalized_displaced_state(self, setup_backend, r, p, tol):
+        """Tests if a range of displaced states are normalized."""
+        alpha = r*np.exp(1j*p)
+
+        backend = setup_backend(1)
+        backend.displacement(alpha, 0)
+        state = backend.state()
+
+        assert np.allclose(state.trace(), 1, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("r", MAG_ALPHAS)
+    @pytest.mark.parametrize("p", PHASE_ALPHAS)
+    def test_coherent_state_fock_elements(self, setup_backend, r, p, cutoff, pure, tol):
+        r"""Tests if a range of alpha-displaced states have the correct Fock basis elements:
+           |\alpha> = exp(-0.5 |\alpha|^2) \sum_n \alpha^n / \sqrt{n!} |n>
+        """
+        alpha = r*np.exp(1j*p)
+
+        backend = setup_backend(1)
+        backend.displacement(alpha, 0)
+        state = backend.state()
+
+        if state.is_pure:
+            numer_state = state.ket()
+        else:
+            numer_state = state.dm()
+
+        n = np.arange(cutoff)
+        ref_state = np.exp(-0.5*np.abs(alpha)**2)*alpha**n / np.sqrt(fac(n))
+
+        if not pure:
+            ref_state = np.outer(ref_state, np.conj(ref_state))
+
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0)

--- a/pytest/backend/test_displacement_operation.py
+++ b/pytest/backend/test_displacement_operation.py
@@ -18,14 +18,14 @@ Convention: The displacement unitary is fixed to be
 U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
 where \hat{a}^\dagger is the photon creation operator.
 """
-#pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments
 import pytest
 
 import numpy as np
 from scipy.special import factorial as fac
 
 
-MAG_ALPHAS = np.linspace(0, .8, 4)
+MAG_ALPHAS = np.linspace(0, 0.8, 4)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
 
 
@@ -44,7 +44,7 @@ class TestRepresentationIndependent:
         """Tests if a range of alpha-displaced states have the correct fidelity
         with the corresponding coherent state.
         """
-        alpha = r*np.exp(1j*p)
+        alpha = r * np.exp(1j * p)
 
         backend = setup_backend(1)
         backend.displacement(alpha, 0)
@@ -54,7 +54,7 @@ class TestRepresentationIndependent:
         assert np.allclose(fid, 1, atol=tol, rtol=0)
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -62,7 +62,7 @@ class TestFockRepresentation:
     @pytest.mark.parametrize("p", PHASE_ALPHAS)
     def test_normalized_displaced_state(self, setup_backend, r, p, tol):
         """Tests if a range of displaced states are normalized."""
-        alpha = r*np.exp(1j*p)
+        alpha = r * np.exp(1j * p)
 
         backend = setup_backend(1)
         backend.displacement(alpha, 0)
@@ -76,7 +76,7 @@ class TestFockRepresentation:
         r"""Tests if a range of alpha-displaced states have the correct Fock basis elements:
            |\alpha> = exp(-0.5 |\alpha|^2) \sum_n \alpha^n / \sqrt{n!} |n>
         """
-        alpha = r*np.exp(1j*p)
+        alpha = r * np.exp(1j * p)
 
         backend = setup_backend(1)
         backend.displacement(alpha, 0)
@@ -88,7 +88,7 @@ class TestFockRepresentation:
             numer_state = state.dm()
 
         n = np.arange(cutoff)
-        ref_state = np.exp(-0.5*np.abs(alpha)**2)*alpha**n / np.sqrt(fac(n))
+        ref_state = np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(fac(n))
 
         if not pure:
             ref_state = np.outer(ref_state, np.conj(ref_state))

--- a/pytest/backend/test_fock_measurement.py
+++ b/pytest/backend/test_fock_measurement.py
@@ -16,7 +16,7 @@ r"""Unit tests for measurements in the Fock basis"""
 import pytest
 
 # fock measurements only supported by fock backends
-pytestmark = pytest.mark.backends('fock', 'tf')
+pytestmark = pytest.mark.backends("fock", "tf")
 
 import numpy as np
 
@@ -39,7 +39,9 @@ class TestFockRepresentation:
 
     def test_normalized_conditional_states(self, setup_backend, cutoff, pure, tol):
         """Tests if the conditional states resulting from Fock measurements in a subset of modes are normalized."""
-        state_preps = [n for n in range(cutoff)] + [cutoff - n for n in range(cutoff)] # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
+        state_preps = [n for n in range(cutoff)] + [
+            cutoff - n for n in range(cutoff)
+        ]  # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
         backend = setup_backend(3)
 
         for idx in range(NUM_REPEATS):
@@ -58,7 +60,9 @@ class TestFockRepresentation:
 
     def test_fock_measurements(self, setup_backend, cutoff, batch_size, pure, tol):
         """Tests if Fock measurements results on a variety of multi-mode Fock states are correct."""
-        state_preps = [n for n in range(cutoff)] + [cutoff - n for n in range(cutoff)] # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
+        state_preps = [n for n in range(cutoff)] + [
+            cutoff - n for n in range(cutoff)
+        ]  # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
 
         singletons = [(0,), (1,), (2,)]
         pairs = [(0, 1), (0, 2), (1, 2)]
@@ -70,11 +74,15 @@ class TestFockRepresentation:
         for idx in range(NUM_REPEATS):
             backend.reset(pure=pure)
 
-            n = [state_preps[idx % cutoff],
-                 state_preps[(idx + 1) % cutoff],
-                 state_preps[(idx + 2) % cutoff]]
+            n = [
+                state_preps[idx % cutoff],
+                state_preps[(idx + 1) % cutoff],
+                state_preps[(idx + 2) % cutoff],
+            ]
             n = np.array(n)
-            meas_modes = np.array(mode_choices[idx % len(mode_choices)]) # cycle through mode choices
+            meas_modes = np.array(
+                mode_choices[idx % len(mode_choices)]
+            )  # cycle through mode choices
 
             backend.prepare_fock_state(n[0], 0)
             backend.prepare_fock_state(n[1], 1)
@@ -84,6 +92,6 @@ class TestFockRepresentation:
             ref_result = n[meas_modes]
 
             if batch_size is not None:
-                ref_result = tuple(np.array([i]*batch_size) for i in ref_result)
+                ref_result = tuple(np.array([i] * batch_size) for i in ref_result)
 
             assert np.allclose(meas_result, ref_result, atol=tol, rtol=0)

--- a/pytest/backend/test_fock_measurement.py
+++ b/pytest/backend/test_fock_measurement.py
@@ -1,0 +1,89 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for measurements in the Fock basis"""
+import pytest
+
+# fock measurements only supported by fock backends
+pytestmark = pytest.mark.backends('fock', 'tf')
+
+import numpy as np
+
+
+NUM_REPEATS = 50
+
+
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    def test_vacuum_measurements(self, setup_backend, pure):
+        """Tests Fock measurement on the vacuum state."""
+        backend = setup_backend(3)
+
+        for _ in range(NUM_REPEATS):
+            backend.reset(pure=pure)
+
+            meas = backend.measure_fock([0, 1, 2])[0]
+            assert np.all(np.array(meas) == 0)
+
+    def test_normalized_conditional_states(self, setup_backend, cutoff, pure, tol):
+        """Tests if the conditional states resulting from Fock measurements in a subset of modes are normalized."""
+        state_preps = [n for n in range(cutoff)] + [cutoff - n for n in range(cutoff)] # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
+        backend = setup_backend(3)
+
+        for idx in range(NUM_REPEATS):
+            backend.reset(pure=pure)
+
+            # cycles through consecutive triples in `state_preps`
+            backend.prepare_fock_state(state_preps[idx % cutoff], 0)
+            backend.prepare_fock_state(state_preps[(idx + 1) % cutoff], 1)
+            backend.prepare_fock_state(state_preps[(idx + 2) % cutoff], 2)
+
+            for mode in range(3):
+                backend.measure_fock([mode])
+                state = backend.state()
+                tr = state.trace()
+                assert np.allclose(tr, 1, atol=tol, rtol=0)
+
+    def test_fock_measurements(self, setup_backend, cutoff, batch_size, pure, tol):
+        """Tests if Fock measurements results on a variety of multi-mode Fock states are correct."""
+        state_preps = [n for n in range(cutoff)] + [cutoff - n for n in range(cutoff)] # [0, 1, 2, ..., cutoff-1, cutoff, cutoff-1, ..., 2, 1]
+
+        singletons = [(0,), (1,), (2,)]
+        pairs = [(0, 1), (0, 2), (1, 2)]
+        triples = [(0, 1, 2)]
+        mode_choices = singletons + pairs + triples
+
+        backend = setup_backend(3)
+
+        for idx in range(NUM_REPEATS):
+            backend.reset(pure=pure)
+
+            n = [state_preps[idx % cutoff],
+                 state_preps[(idx + 1) % cutoff],
+                 state_preps[(idx + 2) % cutoff]]
+            n = np.array(n)
+            meas_modes = np.array(mode_choices[idx % len(mode_choices)]) # cycle through mode choices
+
+            backend.prepare_fock_state(n[0], 0)
+            backend.prepare_fock_state(n[1], 1)
+            backend.prepare_fock_state(n[2], 2)
+
+            meas_result = backend.measure_fock(meas_modes)
+            ref_result = n[meas_modes]
+
+            if batch_size is not None:
+                ref_result = tuple(np.array([i]*batch_size) for i in ref_result)
+
+            assert np.allclose(meas_result, ref_result, atol=tol, rtol=0)

--- a/pytest/backend/test_homodyne.py
+++ b/pytest/backend/test_homodyne.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for homodyne measurements."""
+import numpy as np
+
+
+N_MEAS = 300   # number of homodyne measurements to perform
+NUM_STDS = 10.
+std_10 = NUM_STDS / np.sqrt(N_MEAS)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_mode_reset_vacuum(self, setup_backend, tol):
+        """Tests that modes get reset to the vacuum after measurement."""
+        backend = setup_backend(1)
+
+        r = np.arcsinh(1.0)  #pylint: disable=assignment-from-no-return
+        alpha = 0.8
+
+        backend.squeeze(r, 0)
+        backend.displacement(alpha, 0)
+        backend.measure_homodyne(0, 0)
+
+        assert np.all(backend.is_vacuum(tol))
+
+    def test_mean_and_std_vacuum(self, setup_backend, pure, tol):
+        """Tests that the mean and standard deviation estimates of many homodyne
+        measurements are in agreement with the expected values for the
+        vacuum state"""
+        x = np.empty(0)
+
+        backend = setup_backend(1)
+
+        for _ in range(N_MEAS):
+            backend.reset(pure=pure)
+            meas_result = backend.measure_homodyne(0, 0)
+            x = np.append(x, meas_result)
+
+        assert np.allclose(x.mean(), 0., atol=std_10 + tol, rtol=0)
+        assert np.allclose(x.std(), 1., atol=std_10 + tol, rtol=0)
+
+
+    def test_mean_coherent(self, setup_backend, pure, tol):
+        """Tests that the mean and standard deviation estimates of many homodyne
+        measurements are in agreement with the expected values for a
+        coherent state"""
+        alpha = 1.+1.j
+        x = np.empty(0)
+
+        backend = setup_backend(1)
+
+        for _ in range(N_MEAS):
+            backend.reset(pure=pure)
+            backend.prepare_coherent_state(alpha, 0)
+
+            meas_result = backend.measure_homodyne(0, 0)
+            x = np.append(x, meas_result)
+
+        assert np.allclose(x.mean(), 2 * alpha.real, atol=std_10 + tol)

--- a/pytest/backend/test_homodyne.py
+++ b/pytest/backend/test_homodyne.py
@@ -16,8 +16,8 @@ r"""Unit tests for homodyne measurements."""
 import numpy as np
 
 
-N_MEAS = 300   # number of homodyne measurements to perform
-NUM_STDS = 10.
+N_MEAS = 300  # number of homodyne measurements to perform
+NUM_STDS = 10.0
 std_10 = NUM_STDS / np.sqrt(N_MEAS)
 
 
@@ -28,7 +28,7 @@ class TestRepresentationIndependent:
         """Tests that modes get reset to the vacuum after measurement."""
         backend = setup_backend(1)
 
-        r = np.arcsinh(1.0)  #pylint: disable=assignment-from-no-return
+        r = np.arcsinh(1.0)  # pylint: disable=assignment-from-no-return
         alpha = 0.8
 
         backend.squeeze(r, 0)
@@ -50,15 +50,14 @@ class TestRepresentationIndependent:
             meas_result = backend.measure_homodyne(0, 0)
             x = np.append(x, meas_result)
 
-        assert np.allclose(x.mean(), 0., atol=std_10 + tol, rtol=0)
-        assert np.allclose(x.std(), 1., atol=std_10 + tol, rtol=0)
-
+        assert np.allclose(x.mean(), 0.0, atol=std_10 + tol, rtol=0)
+        assert np.allclose(x.std(), 1.0, atol=std_10 + tol, rtol=0)
 
     def test_mean_coherent(self, setup_backend, pure, tol):
         """Tests that the mean and standard deviation estimates of many homodyne
         measurements are in agreement with the expected values for a
         coherent state"""
-        alpha = 1.+1.j
+        alpha = 1.0 + 1.0j
         x = np.empty(0)
 
         backend = setup_backend(1)

--- a/pytest/backend/test_modes.py
+++ b/pytest/backend/test_modes.py
@@ -50,7 +50,7 @@ class TestRepresentationIndependent:
         assert np.all(res == [1, 3])
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -62,7 +62,7 @@ class TestFockRepresentation:
             backend.add_mode(num_subsystems)
             state = backend.state()
             tr = state.trace()
-            assert np.allclose(tr, 1., atol=tol, rtol=0.)
+            assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     def test_normalized_del_mode(self, setup_backend, tol):
         """Tests if a state is normalized after deleting modes."""
@@ -72,7 +72,7 @@ class TestFockRepresentation:
             backend.del_mode(n)
             state = backend.state()
             tr = state.trace()
-            assert np.allclose(tr, 1., atol=tol, rtol=0.)
+            assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     def test_fock_measurements_after_add_mode(self, setup_backend, pure, cutoff):
         """Tests Fock measurements on a system after adding vacuum modes."""

--- a/pytest/backend/test_modes.py
+++ b/pytest/backend/test_modes.py
@@ -1,0 +1,109 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for add_mode and del_mode functions"""
+import pytest
+
+import numpy as np
+
+NUM_REPEATS = 10
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_add_mode_vacuum(self, setup_backend, tol):
+        """Tests if added modes are initialized to the vacuum state."""
+        backend = setup_backend(1)
+
+        for _n in range(4):
+            backend.add_mode(1)
+            assert np.all(backend.is_vacuum(tol))
+
+    def test_del_mode_vacuum(self, setup_backend, tol):
+        """Tests if reduced density matrix is in vacuum after deleting some modes."""
+        backend = setup_backend(4)
+
+        for n in range(4):
+            backend.del_mode([n])
+            assert np.all(backend.is_vacuum(tol))
+
+    def test_get_modes(self, setup_backend):
+        """Tests that get modes returns the correct result after deleting modes from the circuit"""
+        backend = setup_backend(4)
+
+        backend.squeeze(0.1, 0)
+        backend.del_mode([0, 2])
+
+        res = backend.get_modes()
+        assert np.all(res == [1, 3])
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    def test_normalized_add_mode(self, setup_backend, tol):
+        """Tests if a state is normalized after adding modes."""
+        backend = setup_backend(1)
+
+        for num_subsystems in range(3):
+            backend.add_mode(num_subsystems)
+            state = backend.state()
+            tr = state.trace()
+            assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    def test_normalized_del_mode(self, setup_backend, tol):
+        """Tests if a state is normalized after deleting modes."""
+        backend = setup_backend(4)
+
+        for n in range(4):
+            backend.del_mode(n)
+            state = backend.state()
+            tr = state.trace()
+            assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    def test_fock_measurements_after_add_mode(self, setup_backend, pure, cutoff):
+        """Tests Fock measurements on a system after adding vacuum modes."""
+        backend = setup_backend(1)
+
+        for m in range(3):
+            meas_results = []
+
+            for _ in range(NUM_REPEATS):
+                backend.reset(pure=pure)
+                backend.prepare_fock_state(cutoff - 1, 0)
+                backend.add_mode(m)
+
+                meas_result = backend.measure_fock([0])
+                meas_results.append(meas_result)
+
+            assert np.all(np.array(meas_results) == cutoff - 1)
+
+    def test_fock_measurements_after_del_mode(self, setup_backend, pure, cutoff):
+        """Tests Fock measurements on a system after tracing out an unentagled mode."""
+        backend = setup_backend(4)
+
+        for m in range(1, 4):
+            meas_results = []
+
+            for _ in range(NUM_REPEATS):
+                backend.reset(pure=pure)
+                backend.prepare_fock_state(cutoff - 1, 0)
+                backend.del_mode(m)
+
+                meas_result = backend.measure_fock([0])
+                meas_results.append(meas_result)
+
+            assert np.all(np.array(meas_results) == cutoff - 1)

--- a/pytest/backend/test_multimode_state_preparations.py
+++ b/pytest/backend/test_multimode_state_preparations.py
@@ -1,0 +1,436 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r""" Tests for various multi mode state preparation operations"""
+import itertools
+
+import pytest
+
+import numpy as np
+
+from strawberryfields import ops
+from strawberryfields.backends.gaussianbackend.states import GaussianState
+from strawberryfields.utils import random_covariance, displaced_squeezed_state
+
+# make test deterministic
+np.random.seed(42)
+
+
+MAG_ALPHAS = np.linspace(0, 0.8, 3)
+PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+NBARS = np.linspace(0, 5)
+
+
+@pytest.mark.backends("tf", "fock")
+class TestFockBasisMultimode:
+    """Testing preparing multimode states on the Fock backends"""
+
+    def test_multimode_ket_mode_permutations(self, setup_backend, pure, cutoff, tol):
+        """Test multimode ket preparation when modes are permuted"""
+        backend = setup_backend(4)
+
+        random_ket0 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
+        random_ket0 = random_ket0 / np.linalg.norm(random_ket0)
+
+        random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
+        random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
+
+        random_ket = np.outer(random_ket0, random_ket1)
+        rho = np.einsum("ij,kl->ikjl", random_ket, random_ket.conj())
+
+        backend.prepare_ket_state(random_ket, modes=[3, 1])
+        state = backend.state([3, 1])
+        multi_mode_preparation_dm = state.dm()
+
+        assert np.allclose(multi_mode_preparation_dm, rho, atol=tol, rtol=0)
+
+    def test_compare_single_mode_and_multimode_ket_preparation(
+        self, setup_backend, batch_size, pure, cutoff, tol
+    ):
+        """Test single and multimode ket preparation"""
+        backend = setup_backend(4)
+
+        random_ket0 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
+        random_ket0 = random_ket0 / np.linalg.norm(random_ket0)
+
+        random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
+        random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
+
+        random_ket = np.outer(random_ket0, random_ket1)
+
+        backend.prepare_ket_state(random_ket0, 0)
+        backend.prepare_ket_state(random_ket1, 1)
+        state = backend.state([0, 1])
+        single_mode_preparation_dm = state.dm()
+        single_mode_preparation_probs = np.array(state.all_fock_probs())
+
+        backend.reset(pure=pure)
+        backend.prepare_ket_state(random_ket, [0, 1])
+        state = backend.state([0, 1])
+        multi_mode_preparation_dm = state.dm()
+        multi_mode_preparation_probs = np.array(state.all_fock_probs())
+
+        assert np.allclose(
+            single_mode_preparation_dm, multi_mode_preparation_dm, atol=tol, rtol=0
+        )
+        assert np.allclose(
+            single_mode_preparation_probs,
+            multi_mode_preparation_probs,
+            atol=tol,
+            rtol=0,
+        )
+
+        if batch_size is not None:
+            single_mode_preparation_dm = single_mode_preparation_dm[0]
+            multi_mode_preparation_dm = multi_mode_preparation_dm[0]
+
+        assert np.all(
+            single_mode_preparation_dm.shape == multi_mode_preparation_dm.shape
+        )
+
+    def test_compare_single_mode_and_multimode_dm_preparation(
+        self, setup_backend, batch_size, pure, cutoff, tol
+    ):
+        """Compare the results of a successive single mode preparations
+        and a multi mode preparation of a product state."""
+        backend = setup_backend(4)
+        random_rho0 = np.random.normal(size=[cutoff] * 2) + 1j * np.random.normal(
+            size=[cutoff] * 2
+        )
+        random_rho0 = np.dot(random_rho0.conj().T, random_rho0)
+        random_rho0 = random_rho0 / random_rho0.trace()
+
+        random_rho1 = np.random.normal(size=[cutoff] * 2) + 1j * np.random.normal(
+            size=[cutoff] * 2
+        )
+        random_rho1 = np.dot(random_rho1.conj().T, random_rho1)
+        random_rho1 = random_rho1 / random_rho1.trace()
+        random_dm = np.outer(random_rho0, random_rho1)
+        random_dm = random_dm.reshape([cutoff] * 4)
+
+        backend.prepare_dm_state(random_rho0, 0)
+        backend.prepare_dm_state(random_rho1, 1)
+        state = backend.state([0, 1])
+        single_mode_preparation_dm = state.dm()
+        single_mode_preparation_probs = np.array(state.all_fock_probs())
+
+        # first we do a preparation from random_dm, with shape [cutoff]*4
+        backend.reset(pure=pure)
+        backend.prepare_dm_state(random_dm, [0, 1])
+        state = backend.state(modes=[0, 1])
+        multi_mode_preparation_dm = state.dm()
+        multi_mode_preparation_probs = np.array(state.all_fock_probs())
+
+        # second we do a preparation from the corresponding matrix with shape [cutoff**2]*2
+        backend.reset(pure=pure)
+        backend.prepare_dm_state(random_dm.reshape([cutoff ** 2] * 2), [0, 1])
+        state = backend.state(modes=[0, 1])
+        multi_mode_preparation_from_matrix_dm = state.dm()
+        multi_mode_preparation_from_matrix_probs = np.array(state.all_fock_probs())
+
+        # third we do a preparation from random_dm on modes 3 and 1 (in that order!) and test if the states end up in the correct modes
+        backend.reset(pure=pure)
+        backend.prepare_dm_state(random_dm, [3, 1])
+
+        multi_mode_preparation_31_mode_0 = backend.state(modes=0).dm()
+        multi_mode_preparation_31_mode_1 = backend.state(modes=1).dm()
+        multi_mode_preparation_31_mode_2 = backend.state(modes=2).dm()
+        multi_mode_preparation_31_mode_3 = backend.state(modes=3).dm()
+        multi_mode_preparation_31_probs = np.array(
+            backend.state(modes=[3, 1]).all_fock_probs()
+        )
+
+        single_mode_vac = np.zeros((cutoff, cutoff), dtype=np.complex128)
+        single_mode_vac.itemset(0, 1.0 + 0.0j)
+
+        assert np.allclose(random_dm, single_mode_preparation_dm, atol=tol, rtol=0)
+        assert np.allclose(
+            multi_mode_preparation_dm, single_mode_preparation_dm, atol=tol, rtol=0
+        )
+        assert np.allclose(
+            multi_mode_preparation_from_matrix_dm,
+            single_mode_preparation_dm,
+            atol=tol,
+            rtol=0,
+        )
+
+        assert np.allclose(
+            multi_mode_preparation_31_mode_0, single_mode_vac, atol=tol, rtol=0
+        )
+        assert np.allclose(
+            multi_mode_preparation_31_mode_1, random_rho1, atol=tol, rtol=0
+        )
+        assert np.allclose(
+            multi_mode_preparation_31_mode_2, single_mode_vac, atol=tol, rtol=0
+        )
+        assert np.allclose(
+            multi_mode_preparation_31_mode_3, random_rho0, atol=tol, rtol=0
+        )
+
+        # also check the fock probabilities to catch errors in both the preparation and state() the would cancel each other out
+        assert np.allclose(
+            single_mode_preparation_probs,
+            multi_mode_preparation_probs,
+            atol=tol,
+            rtol=0,
+        )
+        assert np.allclose(
+            single_mode_preparation_probs,
+            multi_mode_preparation_from_matrix_probs,
+            atol=tol,
+            rtol=0,
+        )
+        assert np.allclose(
+            single_mode_preparation_probs,
+            multi_mode_preparation_31_probs,
+            atol=tol,
+            rtol=0,
+        )
+
+        if batch_size is not None:
+            single_mode_preparation_dm = single_mode_preparation_dm[0]
+            multi_mode_preparation_dm = multi_mode_preparation_dm[0]
+            multi_mode_preparation_from_matrix_dm = multi_mode_preparation_from_matrix_dm[
+                0
+            ]
+
+        assert np.all(random_dm.shape == single_mode_preparation_dm.shape)
+        assert np.all(random_dm.shape == multi_mode_preparation_dm.shape)
+        assert np.all(random_dm.shape == multi_mode_preparation_from_matrix_dm.shape)
+
+    def test_prepare_multimode_random_product_dm_state_on_different_modes(
+        self, setup_backend, batch_size, pure, cutoff, tol
+    ):
+        """Tests if a random multi mode dm state is correctly prepared on different modes."""
+        backend = setup_backend(4)
+        N = 4
+
+        random_rho = np.random.normal(size=[cutoff ** 2] * 2) + 1j * np.random.normal(
+            size=[cutoff ** 2] * 2
+        )  # two mode random state
+        random_rho = np.dot(random_rho.conj().T, random_rho)
+        random_rho = random_rho / random_rho.trace()
+        random_rho = random_rho.reshape(
+            [cutoff] * 4
+        )  # reshape for easier comparison later
+
+        # test the state preparation on the first two modes
+        backend.prepare_dm_state(random_rho, [0, 1])
+        multi_mode_preparation_with_modes_ordered = backend.state([0, 1]).dm()
+        assert np.allclose(
+            multi_mode_preparation_with_modes_ordered, random_rho, atol=tol, rtol=0
+        )
+
+        # test the state preparation on two other modes that are not in order
+        backend.reset(pure=pure)
+        backend.prepare_dm_state(random_rho, [1, 2])
+        multi_mode_preparation_with_modes_inverted = backend.state([1, 2]).dm()
+        assert np.allclose(
+            multi_mode_preparation_with_modes_inverted, random_rho, atol=tol, rtol=0
+        )
+
+        # test various subsets of subsystems in various orders
+        for subsystems in list(itertools.permutations(range(N), 2)):
+            subsystems = list(subsystems)
+            backend.reset(pure=pure)
+            backend.prepare_dm_state(random_rho, subsystems)
+            dm = backend.state(modes=subsystems).dm()
+
+            assert np.allclose(random_rho, dm, atol=tol, rtol=0)
+            if batch_size is not None:
+                dm = dm[0]
+
+            assert np.all(random_rho.shape == dm.shape)
+
+    def test_fast_state_prep_on_all_modes(
+        self, setup_backend, batch_size, pure, cutoff, tol
+    ):
+        """Tests if a random multi mode ket state is correctly prepared with
+        the shortcut method on all modes."""
+        backend = setup_backend(4)
+        N = 4
+        random_ket = np.random.normal(size=[cutoff] * N) + 1j * np.random.normal(
+            size=[cutoff] * N
+        )
+        random_ket = random_ket / np.linalg.norm(random_ket)
+
+        backend.prepare_dm_state(random_ket, modes=range(N))
+        all_mode_preparation_ket = (
+            backend.state().ket()
+        )  # Returns None if the state if mixed
+
+        assert np.allclose(all_mode_preparation_ket, random_ket, atol=tol, rtol=0)
+
+        if batch_size is not None:
+            all_mode_preparation_ket = all_mode_preparation_ket[0]
+
+        assert np.all(all_mode_preparation_ket.shape == random_ket.shape)
+
+
+@pytest.mark.backends("gaussian")
+class TestGaussianMultimode:
+    """Tests for simulators that use the Gaussian representation."""
+
+    def test_singlemode_gaussian_state(self, setup_backend, batch_size, pure, tol):
+        """Test single mode Gaussian state preparation"""
+        N = 4
+        backend = setup_backend(N)
+
+        means = 2 * np.random.random(size=[2]) - 1
+        cov = random_covariance(1, pure=pure)
+
+        a = 0.2 + 0.4j
+        r = 1
+        phi = 0
+
+        # circuit is initially in displaced squeezed state
+        for i in range(N):
+            backend.prepare_displaced_squeezed_state(a, r, phi, mode=i)
+
+        # prepare Gaussian state in mode 1
+        backend.prepare_gaussian_state(means, cov, modes=1)
+
+        # test Gaussian state is correct
+        state = backend.state([1])
+        assert np.allclose(state.means(), means, atol=tol, rtol=0)
+        assert np.allclose(state.cov(), cov, atol=tol, rtol=0)
+
+        # test that displaced squeezed states are unchanged
+        ex_means, ex_V = displaced_squeezed_state(a, r, phi, basis="gaussian")
+        for i in [0, 2, 3]:
+            state = backend.state([i])
+            assert np.allclose(state.means(), ex_means, atol=tol, rtol=0)
+            assert np.allclose(state.cov(), ex_V, atol=tol, rtol=0)
+
+    def test_multimode_gaussian_state(self, setup_backend, batch_size, pure, tol):
+        """Test multimode Gaussian state preparation"""
+        N = 4
+        backend = setup_backend(N)
+
+        cov = np.diag(np.exp(2 * np.array([-1, -1, 1, 1])))
+        means = np.zeros([4])
+
+        # prepare displaced squeezed states in all modes
+        a = 0.2 + 0.4j
+        r = 0.5
+        phi = 0.12
+        for i in range(N):
+            backend.prepare_displaced_squeezed_state(a, r, phi, i)
+
+        # prepare new squeezed displaced state in mode 1 and 3
+        backend.prepare_gaussian_state(means, cov, modes=[1, 3])
+        state = backend.state([1, 3])
+
+        # test Gaussian state is correct
+        state = backend.state([1, 3])
+        assert np.allclose(state.means(), means, atol=tol, rtol=0)
+        assert np.allclose(state.cov(), cov, atol=tol, rtol=0)
+
+        # test that displaced squeezed states are unchanged
+        ex_means, ex_V = displaced_squeezed_state(a, r, phi, basis="gaussian")
+        for i in [0, 2]:
+            state = backend.state([i])
+            assert np.allclose(state.means(), ex_means, atol=tol, rtol=0)
+            assert np.allclose(state.cov(), ex_V, atol=tol, rtol=0)
+
+    def test_full_mode_squeezed_state(self, setup_backend, batch_size, pure, tol):
+        """Test full register Gaussian state preparation"""
+        N = 4
+        backend = setup_backend(N)
+
+        cov = np.diag(np.exp(2 * np.array([-1, -1, -1, -1, 1, 1, 1, 1])))
+        means = np.zeros([8])
+
+        backend.reset(pure=pure)
+        backend.prepare_gaussian_state(means, cov, modes=range(N))
+        state = backend.state()
+
+        # test Gaussian state is correct
+        state = backend.state()
+        assert np.allclose(state.means(), means, atol=tol, rtol=0)
+        assert np.allclose(state.cov(), cov, atol=tol, rtol=0)
+
+    def test_multimode_gaussian_random_state(
+        self, setup_backend, batch_size, pure, tol
+    ):
+        """Test multimode Gaussian state preparation on a random state"""
+        N = 4
+        backend = setup_backend(N)
+
+        means = 2 * np.random.random(size=[2 * N]) - 1
+        cov = random_covariance(N, pure=pure)
+
+        backend.reset(pure=pure)
+
+        # circuit is initially in a random state
+        backend.prepare_gaussian_state(means, cov, modes=range(N))
+
+        # test Gaussian state is correct
+        state = backend.state()
+        assert np.allclose(state.means(), means, atol=tol, rtol=0)
+        assert np.allclose(state.cov(), cov, atol=tol, rtol=0)
+
+        # prepare Gaussian state in mode 2 and 1
+        means2 = 2 * np.random.random(size=[4]) - 1
+        cov2 = random_covariance(2, pure=pure)
+        backend.prepare_gaussian_state(means2, cov2, modes=[2, 1])
+
+        # test resulting Gaussian state is correct
+        state = backend.state()
+
+        # in the new means vector, the modes 0 and 3 remain unchanged
+        # Modes 1 and 2, however, now have values given from elements
+        # means2[1] and means2[0].
+        ex_means = np.array(
+            [
+                means[0],
+                means2[1],
+                means2[0],
+                means[3],  # position
+                means[4],
+                means2[3],
+                means2[2],
+                means[7],
+            ]
+        )  # momentum
+
+        ex_cov = np.zeros([8, 8])
+
+        # in the new covariance matrix, modes 0 and 3 remain unchanged
+        idx = np.array([0, 3, 4, 7])
+        rows = idx.reshape(-1, 1)
+        cols = idx.reshape(1, -1)
+        ex_cov[rows, cols] = cov[rows, cols]
+
+        # in the new covariance matrix, modes 1 and 2 have values given by
+        # rows 1 and 0 respectively from cov2
+        idx = np.array([1, 2, 5, 6])
+        rows = idx.reshape(-1, 1)
+        cols = idx.reshape(1, -1)
+
+        idx = np.array([1, 0, 3, 2])
+        rows2 = idx.reshape(-1, 1)
+        cols2 = idx.reshape(1, -1)
+
+        ex_cov[rows, cols] = cov2[rows2, cols2]
+
+        assert np.allclose(state.means(), ex_means, atol=tol, rtol=0)
+        assert np.allclose(state.cov(), ex_cov, atol=tol, rtol=0)

--- a/pytest/backend/test_nongaussian_gates.py
+++ b/pytest/backend/test_nongaussian_gates.py
@@ -21,7 +21,7 @@ import numpy as np
 KAPPAS = np.linspace(0, 2 * np.pi, 7)
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -39,7 +39,7 @@ class TestFockRepresentation:
         else:
             numer_state = s.dm()
         ref_state = np.exp(1j * kappa * np.arange(cutoff) ** 2) / cutoff
-        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_cross_kerr_interaction(self, setup_backend, kappa, cutoff, tol):
@@ -62,6 +62,6 @@ class TestFockRepresentation:
 
         n1 = np.arange(cutoff).reshape(-1, 1)
         n2 = np.arange(cutoff).reshape(1, -1)
-        ref_state = np.exp(1j*kappa*n1*n2).flatten()/cutoff
-        ref_state = np.reshape(ref_state, [cutoff]*2)
-        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)
+        ref_state = np.exp(1j * kappa * n1 * n2).flatten() / cutoff
+        ref_state = np.reshape(ref_state, [cutoff] * 2)
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/pytest/backend/test_nongaussian_gates.py
+++ b/pytest/backend/test_nongaussian_gates.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for non-Gaussian gates"""
+
+import pytest
+
+import numpy as np
+
+KAPPAS = np.linspace(0, 2 * np.pi, 7)
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("kappa", KAPPAS)
+    def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):
+        """Tests if the Kerr interaction has the right effect on states in the Fock basis"""
+
+        backend = setup_backend(1)
+
+        backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
+        backend.kerr_interaction(kappa, 0)
+        s = backend.state()
+        if s.is_pure:
+            numer_state = s.ket()
+        else:
+            numer_state = s.dm()
+        ref_state = np.exp(1j * kappa * np.arange(cutoff) ** 2) / cutoff
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("kappa", KAPPAS)
+    def test_cross_kerr_interaction(self, setup_backend, kappa, cutoff, tol):
+        """Tests if the cross-Kerr interaction has the right effect on states in the Fock basis"""
+
+        backend = setup_backend(2)
+
+        ket1 = np.array([1.0 for n in range(cutoff)])
+        ket1 /= np.linalg.norm(ket1)
+        ket = np.outer(ket1, ket1)
+
+        backend.prepare_ket_state(ket, modes=[0, 1])
+        backend.cross_kerr_interaction(kappa, 0, 1)
+        s = backend.state()
+
+        if s.is_pure:
+            numer_state = s.ket()
+        else:
+            numer_state = s.dm()
+
+        n1 = np.arange(cutoff).reshape(-1, 1)
+        n2 = np.arange(cutoff).reshape(1, -1)
+        ref_state = np.exp(1j*kappa*n1*n2).flatten()/cutoff
+        ref_state = np.reshape(ref_state, [cutoff]*2)
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)

--- a/pytest/backend/test_rotation_operation.py
+++ b/pytest/backend/test_rotation_operation.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for phase-shifter operations
+Convention: The phase-shift unitary is fixed to be
+U(\theta) = \exp(i * \theta \hat{n})
+where \hat{n} is the number operator. For positive \theta, this corresponds
+to a clockwise rotation of the state in phase space."""
+
+import pytest
+
+import numpy as np
+
+SHIFT_THETAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    @pytest.mark.parametrize("theta", SHIFT_THETAS)
+    def test_rotated_vacuum(self, setup_backend, theta, tol):
+        """Tests phase shift operation in some limiting cases where the result should be a vacuum state."""
+        backend = setup_backend(1)
+        backend.rotation(theta, 0)
+        assert np.all(backend.is_vacuum(tol))
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("theta", SHIFT_THETAS)
+    def test_normalized_rotated_coherent_states(self, setup_backend, theta, tol):
+        """Tests if a range of phase-shifted coherent states are normalized."""
+        alpha = 1.
+        backend = setup_backend(1)
+
+        backend.prepare_coherent_state(alpha, 0)
+        backend.rotation(theta, 0)
+
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("theta", SHIFT_THETAS)
+    def test_rotated_fock_states(self, setup_backend, theta, pure, cutoff, tol):
+        """Tests if a range of phase-shifted fock states |n> are equal to the form of
+        exp(i * theta * n)|n>"""
+        backend = setup_backend(1)
+
+        for n in range(cutoff):
+            backend.reset(pure=pure)
+
+            backend.prepare_fock_state(n, 0)
+            backend.rotation(theta, 0)
+            s = backend.state()
+
+            if s.is_pure:
+                numer_state = s.ket()
+            else:
+                numer_state = s.dm()
+
+            k = np.arange(cutoff)
+            ref_state = np.where(k == n, np.exp(1j*theta*k), 0)
+
+            if not pure:
+                ref_state = np.outer(ref_state, np.conj(ref_state))
+
+            assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)

--- a/pytest/backend/test_rotation_operation.py
+++ b/pytest/backend/test_rotation_operation.py
@@ -36,14 +36,14 @@ class TestRepresentationIndependent:
         assert np.all(backend.is_vacuum(tol))
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
     @pytest.mark.parametrize("theta", SHIFT_THETAS)
     def test_normalized_rotated_coherent_states(self, setup_backend, theta, tol):
         """Tests if a range of phase-shifted coherent states are normalized."""
-        alpha = 1.
+        alpha = 1.0
         backend = setup_backend(1)
 
         backend.prepare_coherent_state(alpha, 0)
@@ -51,7 +51,7 @@ class TestFockRepresentation:
 
         state = backend.state()
         tr = state.trace()
-        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+        assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("theta", SHIFT_THETAS)
     def test_rotated_fock_states(self, setup_backend, theta, pure, cutoff, tol):
@@ -72,9 +72,9 @@ class TestFockRepresentation:
                 numer_state = s.dm()
 
             k = np.arange(cutoff)
-            ref_state = np.where(k == n, np.exp(1j*theta*k), 0)
+            ref_state = np.where(k == n, np.exp(1j * theta * k), 0)
 
             if not pure:
                 ref_state = np.outer(ref_state, np.conj(ref_state))
 
-            assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)
+            assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/pytest/backend/test_squeeze_operation.py
+++ b/pytest/backend/test_squeeze_operation.py
@@ -1,0 +1,159 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Unit tests for squeezing operation
+Convention: The squeezing unitary is fixed to be
+U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
+where \hat{a} is the photon annihilation operator.
+"""
+#pylint: disable=too-many-arguments
+import pytest
+
+import numpy as np
+from scipy.special import factorial as fac, gammaln as lg
+
+
+PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+MAG = np.linspace(0.0, 0.2, 5, endpoint=False)
+
+
+def matrix_elem(n, r, m):
+    """Matrix element corresponding to squeezed density matrix[n, m]"""
+    eps = 1e-10
+
+    if n % 2 != m % 2:
+        return 0.0
+
+    if r == 0.:
+        return np.complex(n == m) # delta function
+
+    k = np.arange(m % 2, min([m, n]) + 1, 2)
+    res = np.sum(
+        (-1)**((n-k)/2)
+        * np.exp((lg(m+1) + lg(n+1))/2 - lg(k+1) - lg((m-k)/2+1) - lg((n-k)/2+1))
+        * (np.sinh(r)/2+eps)**((n+m-2*k)/2) / (np.cosh(r)**((n+m+1)/2))
+        )
+    return res
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_no_squeezing(self, setup_backend, tol):
+        """Tests displacement operation where the result should be a vacuum state."""
+        backend = setup_backend(1)
+        backend.squeeze(0, 0)
+        assert np.all(backend.is_vacuum(tol))
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("r", MAG)
+    @pytest.mark.parametrize("p", PHASE)
+    def test_normalized_squeezed_state(self, setup_backend, r, p, tol):
+        """Tests if a range of alpha-displaced states have the correct fidelity
+        with the corresponding coherent state.
+        """
+        z = r*np.exp(1j*p)
+
+        backend = setup_backend(1)
+        backend.squeeze(z, 0)
+        state = backend.state()
+        assert np.allclose(state.trace(), 1, atol=tol, rtol=0)
+
+
+    @pytest.mark.parametrize("r", MAG)
+    @pytest.mark.parametrize("p", PHASE)
+    def test_no_odd_fock(self, setup_backend, r, p, batch_size):
+        """Tests if a range of squeezed vacuum states have
+        only nonzero entries for even Fock states."""
+        z = r * np.exp(1j * p)
+
+        backend = setup_backend(1)
+        backend.squeeze(z, 0)
+        state = backend.state()
+
+        if state.is_pure:
+            num_state = state.ket()
+        else:
+            num_state = state.dm()
+
+        if batch_size is not None:
+            odd_entries = num_state[:, 1::2]
+        else:
+            odd_entries = num_state[1::2]
+
+        assert np.all(odd_entries == 0)
+
+
+    @pytest.mark.parametrize("r", MAG)
+    @pytest.mark.parametrize("p", PHASE)
+    def test_reference_squeezed_vacuum(self, setup_backend, r, p, cutoff, batch_size, pure, tol):
+        """Tests if a range of squeezed vacuum states are equal to the form of Eq. (5.5.6) in Loudon."""
+        z = r * np.exp(1j * p)
+
+        backend = setup_backend(1)
+        backend.squeeze(z, 0)
+        state = backend.state()
+
+        if state.is_pure:
+            num_state = state.ket()
+        else:
+            num_state = state.dm()
+
+        k = np.arange(0, cutoff, 2)
+        even_refs = np.sqrt(1/np.cosh(r))*np.sqrt(fac(k))/fac(k / 2)*(-0.5*np.exp(1j*p)*np.tanh(r))**(k/2)
+
+        if pure:
+            if batch_size is not None:
+                even_entries = num_state[:, ::2]
+            else:
+                even_entries = num_state[::2]
+        else:
+            even_refs = np.outer(even_refs, even_refs.conj())
+            if batch_size is not None:
+                even_entries = num_state[:, ::2, ::2]
+            else:
+                even_entries = num_state[::2, ::2]
+
+        assert np.allclose(even_entries, even_refs, atol=tol, rtol=0)
+
+
+    @pytest.mark.parametrize("r", MAG)
+    def test_reference_squeezed_fock(self, setup_backend, r, cutoff, pure, tol):
+        """Tests if a range of squeezed fock states are equal to the form of Eq. (20)
+        in 'On the Squeezed Number States and their Phase Space Representations'
+        (https://arxiv.org/abs/quant-ph/0108024).
+        """
+        backend = setup_backend(1)
+
+        for m in range(cutoff):
+            backend.reset(pure=pure)
+            backend.prepare_fock_state(m, 0)
+            backend.squeeze(r, 0)
+            state = backend.state()
+
+            if state.is_pure:
+                num_state = state.ket()
+            else:
+                num_state = state.dm()
+
+            ref_state = np.array([matrix_elem(n, r, m) for n in range(cutoff)])
+
+            if not pure:
+                ref_state = np.outer(ref_state, ref_state.conj())
+
+            assert np.allclose(num_state, ref_state, atol=tol, rtol=0)

--- a/pytest/backend/test_squeeze_operation.py
+++ b/pytest/backend/test_squeeze_operation.py
@@ -17,7 +17,7 @@ Convention: The squeezing unitary is fixed to be
 U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
 where \hat{a} is the photon annihilation operator.
 """
-#pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments
 import pytest
 
 import numpy as np
@@ -35,15 +35,21 @@ def matrix_elem(n, r, m):
     if n % 2 != m % 2:
         return 0.0
 
-    if r == 0.:
-        return np.complex(n == m) # delta function
+    if r == 0.0:
+        return np.complex(n == m)  # delta function
 
     k = np.arange(m % 2, min([m, n]) + 1, 2)
     res = np.sum(
-        (-1)**((n-k)/2)
-        * np.exp((lg(m+1) + lg(n+1))/2 - lg(k+1) - lg((m-k)/2+1) - lg((n-k)/2+1))
-        * (np.sinh(r)/2+eps)**((n+m-2*k)/2) / (np.cosh(r)**((n+m+1)/2))
+        (-1) ** ((n - k) / 2)
+        * np.exp(
+            (lg(m + 1) + lg(n + 1)) / 2
+            - lg(k + 1)
+            - lg((m - k) / 2 + 1)
+            - lg((n - k) / 2 + 1)
         )
+        * (np.sinh(r) / 2 + eps) ** ((n + m - 2 * k) / 2)
+        / (np.cosh(r) ** ((n + m + 1) / 2))
+    )
     return res
 
 
@@ -57,7 +63,7 @@ class TestRepresentationIndependent:
         assert np.all(backend.is_vacuum(tol))
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -67,13 +73,12 @@ class TestFockRepresentation:
         """Tests if a range of alpha-displaced states have the correct fidelity
         with the corresponding coherent state.
         """
-        z = r*np.exp(1j*p)
+        z = r * np.exp(1j * p)
 
         backend = setup_backend(1)
         backend.squeeze(z, 0)
         state = backend.state()
         assert np.allclose(state.trace(), 1, atol=tol, rtol=0)
-
 
     @pytest.mark.parametrize("r", MAG)
     @pytest.mark.parametrize("p", PHASE)
@@ -98,10 +103,11 @@ class TestFockRepresentation:
 
         assert np.all(odd_entries == 0)
 
-
     @pytest.mark.parametrize("r", MAG)
     @pytest.mark.parametrize("p", PHASE)
-    def test_reference_squeezed_vacuum(self, setup_backend, r, p, cutoff, batch_size, pure, tol):
+    def test_reference_squeezed_vacuum(
+        self, setup_backend, r, p, cutoff, batch_size, pure, tol
+    ):
         """Tests if a range of squeezed vacuum states are equal to the form of Eq. (5.5.6) in Loudon."""
         z = r * np.exp(1j * p)
 
@@ -115,7 +121,12 @@ class TestFockRepresentation:
             num_state = state.dm()
 
         k = np.arange(0, cutoff, 2)
-        even_refs = np.sqrt(1/np.cosh(r))*np.sqrt(fac(k))/fac(k / 2)*(-0.5*np.exp(1j*p)*np.tanh(r))**(k/2)
+        even_refs = (
+            np.sqrt(1 / np.cosh(r))
+            * np.sqrt(fac(k))
+            / fac(k / 2)
+            * (-0.5 * np.exp(1j * p) * np.tanh(r)) ** (k / 2)
+        )
 
         if pure:
             if batch_size is not None:
@@ -130,7 +141,6 @@ class TestFockRepresentation:
                 even_entries = num_state[::2, ::2]
 
         assert np.allclose(even_entries, even_refs, atol=tol, rtol=0)
-
 
     @pytest.mark.parametrize("r", MAG)
     def test_reference_squeezed_fock(self, setup_backend, r, cutoff, pure, tol):

--- a/pytest/backend/test_squeezed_state_preparation.py
+++ b/pytest/backend/test_squeezed_state_preparation.py
@@ -1,0 +1,113 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for operations that prepare squeezed states
+Convention: The squeezing unitary is fixed to be
+U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
+where \hat{a} is the photon annihilation operator."""
+
+import pytest
+
+import numpy as np
+from scipy.special import factorial
+
+
+SQZ_R = np.linspace(0.0, 0.1, 5)
+SQZ_THETA = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+
+
+def sech(x):
+    """Hyberbolic secant"""
+    return 1 / np.cosh(x)
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    @pytest.mark.parametrize("theta", SQZ_THETA)
+    def test_no_squeezing(self, setup_backend, theta, tol):
+        """Tests squeezing operation in some limiting cases where the result should be a vacuum state."""
+        backend = setup_backend(1)
+        backend.prepare_squeezed_state(0, theta, 0)
+        assert np.all(backend.is_vacuum(tol))
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    @pytest.mark.parametrize("r", SQZ_R)
+    @pytest.mark.parametrize("theta", SQZ_THETA)
+    def test_normalized_squeezed_state(self, setup_backend, r, theta, tol):
+        """Tests if a range of squeezed vacuum states are normalized."""
+        backend = setup_backend(1)
+
+        backend.prepare_squeezed_state(r, theta, 0)
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("r", SQZ_R)
+    @pytest.mark.parametrize("theta", SQZ_THETA)
+    def test_no_odd_fock(self, setup_backend, r, theta, batch_size):
+        """Tests if a range of squeezed vacuum states have
+        only nonzero entries for even Fock states."""
+        backend = setup_backend(1)
+
+        backend.prepare_squeezed_state(r, theta, 0)
+        s = backend.state()
+
+        if s.is_pure:
+            num_state = s.ket()
+        else:
+            num_state = s.dm()
+
+        if batch_size is not None:
+            odd_entries = num_state[:, 1::2]
+        else:
+            odd_entries = num_state[1::2]
+
+        assert np.all(odd_entries == 0)
+
+    @pytest.mark.parametrize("r", SQZ_R)
+    @pytest.mark.parametrize("theta", SQZ_THETA)
+    def test_reference_squeezed_states(self, setup_backend, r, theta, batch_size, pure, cutoff, tol):
+        """Tests if a range of squeezed vacuum states are equal to the form of Eq. (5.5.6) in Loudon."""
+        backend = setup_backend(1)
+
+        backend.prepare_squeezed_state(r, theta, 0)
+        s = backend.state()
+
+        if s.is_pure:
+            num_state = s.ket()
+        else:
+            num_state = s.dm()
+
+        n = np.arange(0, cutoff, 2)
+        even_refs = np.sqrt(sech(r)) * np.sqrt(factorial(n)) / factorial(n / 2) * (-0.5 * np.exp(1j * theta) * np.tanh(r)) ** (n / 2)
+
+        if batch_size is not None:
+            if pure:
+                even_entries = num_state[:, ::2]
+            else:
+                even_entries = num_state[:, ::2, ::2]
+                even_refs = np.outer(even_refs, np.conj(even_refs))
+        else:
+            if pure:
+                even_entries = num_state[::2]
+            else:
+                even_entries = num_state[::2, ::2]
+                even_refs = np.outer(even_refs, np.conj(even_refs))
+
+        assert np.allclose(even_entries, even_refs, atol=tol, rtol=0.)

--- a/pytest/backend/test_squeezed_state_preparation.py
+++ b/pytest/backend/test_squeezed_state_preparation.py
@@ -43,7 +43,7 @@ class TestRepresentationIndependent:
         assert np.all(backend.is_vacuum(tol))
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -56,7 +56,7 @@ class TestFockRepresentation:
         backend.prepare_squeezed_state(r, theta, 0)
         state = backend.state()
         tr = state.trace()
-        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+        assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("r", SQZ_R)
     @pytest.mark.parametrize("theta", SQZ_THETA)
@@ -82,7 +82,9 @@ class TestFockRepresentation:
 
     @pytest.mark.parametrize("r", SQZ_R)
     @pytest.mark.parametrize("theta", SQZ_THETA)
-    def test_reference_squeezed_states(self, setup_backend, r, theta, batch_size, pure, cutoff, tol):
+    def test_reference_squeezed_states(
+        self, setup_backend, r, theta, batch_size, pure, cutoff, tol
+    ):
         """Tests if a range of squeezed vacuum states are equal to the form of Eq. (5.5.6) in Loudon."""
         backend = setup_backend(1)
 
@@ -95,7 +97,12 @@ class TestFockRepresentation:
             num_state = s.dm()
 
         n = np.arange(0, cutoff, 2)
-        even_refs = np.sqrt(sech(r)) * np.sqrt(factorial(n)) / factorial(n / 2) * (-0.5 * np.exp(1j * theta) * np.tanh(r)) ** (n / 2)
+        even_refs = (
+            np.sqrt(sech(r))
+            * np.sqrt(factorial(n))
+            / factorial(n / 2)
+            * (-0.5 * np.exp(1j * theta) * np.tanh(r)) ** (n / 2)
+        )
 
         if batch_size is not None:
             if pure:
@@ -110,4 +117,4 @@ class TestFockRepresentation:
                 even_entries = num_state[::2, ::2]
                 even_refs = np.outer(even_refs, np.conj(even_refs))
 
-        assert np.allclose(even_entries, even_refs, atol=tol, rtol=0.)
+        assert np.allclose(even_entries, even_refs, atol=tol, rtol=0.0)

--- a/pytest/backend/test_state_preparations.py
+++ b/pytest/backend/test_state_preparations.py
@@ -1,0 +1,208 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unit tests for various state preparation operations"""
+
+import pytest
+
+import numpy as np
+
+
+MAG_ALPHAS = np.linspace(0, .8, 4)
+PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
+NBARS = np.linspace(0, 5, 7)
+SEED = 143
+
+
+class TestRepresentationIndependent:
+    """Basic implementation-independent tests."""
+
+    def test_prepare_vac(self, setup_backend, tol):
+        """Tests the ability to prepare vacuum states."""
+        backend = setup_backend(1)
+        backend.prepare_vacuum_state(0)
+        assert np.all(backend.is_vacuum(tol))
+
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
+    @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
+    def test_fidelity_coherent(self, setup_backend, mag_alpha, phase_alpha, tol):
+        """Tests if a range of coherent states have the correct fidelity."""
+
+        backend = setup_backend(1)
+
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        backend.prepare_coherent_state(alpha, 0)
+        state = backend.state()
+        assert np.allclose(state.fidelity_coherent([alpha]), 1., atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("nbar", NBARS)
+    def test_prepare_thermal_state(self, setup_backend, nbar, cutoff, tol):
+        """Tests if thermal states with different nbar values
+        give the correct fock probabilities"""
+
+        backend = setup_backend(1)
+
+        backend.prepare_thermal_state(nbar, 0)
+        ref_probs = np.array([nbar ** n / (nbar + 1) ** (n + 1) for n in range(cutoff)])
+        state = backend.state()
+        state_probs = np.array([state.fock_prob([n]) for n in range(cutoff)]).T # transpose needed for array broadcasting to work in batch mode (data is unaffected in non-batched mode)
+        assert np.allclose(ref_probs, state_probs, atol=tol, rtol=0.)
+
+
+@pytest.mark.backends('fock', 'tf')
+class TestFockRepresentation:
+    """Tests that make use of the Fock basis representation."""
+
+    def test_normalized_prepare_vac(self, setup_backend, tol):
+        """Tests the ability to prepare vacuum states."""
+
+        backend = setup_backend(1)
+
+        backend.prepare_vacuum_state(0)
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
+    @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
+    def test_normalized_coherent_state(self, setup_backend, mag_alpha, phase_alpha, tol):
+        """Tests if a range of coherent states are normalized."""
+
+        alpha = mag_alpha * np.exp(1j * phase_alpha)
+        backend = setup_backend(1)
+
+        backend.prepare_coherent_state(alpha, 0)
+        state = backend.state()
+        tr = state.trace()
+        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+
+    def test_prepare_ket_state(self, setup_backend, cutoff, tol):
+        """Tests if a ket state with arbitrary parameters is correctly prepared."""
+        np.random.seed(SEED)
+        random_ket = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket = random_ket / np.linalg.norm(random_ket)
+        backend = setup_backend(1)
+
+        backend.prepare_ket_state(random_ket, 0)
+        state = backend.state()
+        assert np.allclose(state.fidelity(random_ket, 0), 1., atol=tol, rtol=0.)
+
+    def test_prepare_batched_ket_state(self, setup_backend, pure, batch_size, cutoff, tol):
+        """Tests if a batch of ket states with arbitrary parameters is correctly
+        prepared by comparing the fock probabilities of the batched case with
+        individual runs with non batched input states."""
+
+        if batch_size is None:
+            pytest.skip('Test skipped if no batching')
+
+        np.random.seed(SEED)
+        random_kets = np.array([(lambda ket: ket / np.linalg.norm(ket))(np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)) for _ in range(batch_size)])
+        backend = setup_backend(1)
+
+        backend.prepare_ket_state(random_kets, 0)
+        state = backend.state()
+        batched_probs = np.array(state.all_fock_probs())
+
+        individual_probs = []
+        for random_ket in random_kets:
+            backend.reset(pure=pure)
+            backend.prepare_ket_state(random_ket, 0)
+            state = backend.state()
+            probs_for_this_ket = np.array(state.all_fock_probs())
+            individual_probs.append(probs_for_this_ket[0])
+
+        individual_probs = np.array(individual_probs)
+        assert np.allclose(batched_probs, individual_probs, atol=tol, rtol=0.)
+
+    def test_prepare_rank_two_dm_state(self, setup_backend, cutoff, tol):
+        """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
+
+        np.random.seed(SEED)
+        random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
+        random_ket2 = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket2 = random_ket2 / np.linalg.norm(random_ket2)
+
+        backend = setup_backend(1)
+        backend.prepare_ket_state(random_ket1, 0)
+        state = backend.state()
+        ket_probs1 = np.array([state.fock_prob([n]) for n in range(cutoff)])
+
+        backend = setup_backend(1)
+        backend.prepare_ket_state(random_ket2, 0)
+        state = backend.state()
+        ket_probs2 = np.array([state.fock_prob([n]) for n in range(cutoff)])
+
+        ket_probs = 0.2*ket_probs1 + 0.8*ket_probs2
+
+        random_rho = 0.2*np.outer(np.conj(random_ket1), random_ket1) + 0.8*np.outer(np.conj(random_ket2), random_ket2)
+
+        backend = setup_backend(1)
+        backend.prepare_dm_state(random_rho, 0)
+        state = backend.state()
+        rho_probs = np.array([state.fock_prob([n]) for n in range(cutoff)])
+
+        assert np.allclose(state.trace(), 1., atol=tol, rtol=0.)
+        assert np.allclose(rho_probs, ket_probs, atol=tol, rtol=0.)
+
+    def test_prepare_random_dm_state(self, setup_backend, batch_size, pure, cutoff, tol):
+        """Tests if a random dm state is correctly prepared."""
+
+        np.random.seed(SEED)
+        random_rho = np.random.normal(size=[cutoff, cutoff]) + 1j*np.random.normal(size=[cutoff, cutoff])
+        random_rho = np.dot(random_rho.conj().T, random_rho)
+        random_rho = random_rho/random_rho.trace()
+
+        backend = setup_backend(1)
+        backend.prepare_dm_state(random_rho, 0)
+        state = backend.state()
+        rho_probs = np.array(state.all_fock_probs())
+
+        es, vs = np.linalg.eig(random_rho)
+
+        if batch_size is not None:
+            kets_mixed_probs = np.zeros([batch_size, len(es)], dtype=complex)
+        else:
+            kets_mixed_probs = np.zeros([len(es)], dtype=complex)
+
+        for e, v in zip(es, vs.T.conj()):
+            backend.reset(pure=pure)
+            backend.prepare_ket_state(v, 0)
+            state = backend.state()
+            probs_for_this_v = np.array(state.all_fock_probs())
+            kets_mixed_probs += e*probs_for_this_v
+
+        assert np.allclose(rho_probs, kets_mixed_probs, atol=tol, rtol=0.)
+
+    @pytest.mark.parametrize("theta", PHASE_ALPHAS)
+    def test_rotated_superposition_states(self, setup_backend, theta, pure, cutoff, tol):
+        r"""Tests if a range of phase-shifted superposition states are equal to the form of
+        \sum_n exp(i * theta * n)|n>"""
+
+        backend = setup_backend(1)
+
+        ref_state = np.array([np.exp(1j * theta * k) for k in range(cutoff)]) / np.sqrt(cutoff)
+
+        if not pure:
+            ref_state = np.outer(ref_state, np.conj(ref_state))
+
+        backend.prepare_ket_state(ref_state, 0)
+        s = backend.state()
+
+        if s.is_pure:
+            numer_state = s.ket()
+        else:
+            numer_state = s.dm()
+
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)

--- a/pytest/backend/test_state_preparations.py
+++ b/pytest/backend/test_state_preparations.py
@@ -19,7 +19,7 @@ import pytest
 import numpy as np
 
 
-MAG_ALPHAS = np.linspace(0, .8, 4)
+MAG_ALPHAS = np.linspace(0, 0.8, 4)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
 NBARS = np.linspace(0, 5, 7)
 SEED = 143
@@ -44,7 +44,7 @@ class TestRepresentationIndependent:
         alpha = mag_alpha * np.exp(1j * phase_alpha)
         backend.prepare_coherent_state(alpha, 0)
         state = backend.state()
-        assert np.allclose(state.fidelity_coherent([alpha]), 1., atol=tol, rtol=0.)
+        assert np.allclose(state.fidelity_coherent([alpha]), 1.0, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("nbar", NBARS)
     def test_prepare_thermal_state(self, setup_backend, nbar, cutoff, tol):
@@ -56,11 +56,13 @@ class TestRepresentationIndependent:
         backend.prepare_thermal_state(nbar, 0)
         ref_probs = np.array([nbar ** n / (nbar + 1) ** (n + 1) for n in range(cutoff)])
         state = backend.state()
-        state_probs = np.array([state.fock_prob([n]) for n in range(cutoff)]).T # transpose needed for array broadcasting to work in batch mode (data is unaffected in non-batched mode)
-        assert np.allclose(ref_probs, state_probs, atol=tol, rtol=0.)
+        state_probs = np.array(
+            [state.fock_prob([n]) for n in range(cutoff)]
+        ).T  # transpose needed for array broadcasting to work in batch mode (data is unaffected in non-batched mode)
+        assert np.allclose(ref_probs, state_probs, atol=tol, rtol=0.0)
 
 
-@pytest.mark.backends('fock', 'tf')
+@pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
@@ -72,11 +74,13 @@ class TestFockRepresentation:
         backend.prepare_vacuum_state(0)
         state = backend.state()
         tr = state.trace()
-        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+        assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS)
     @pytest.mark.parametrize("phase_alpha", PHASE_ALPHAS)
-    def test_normalized_coherent_state(self, setup_backend, mag_alpha, phase_alpha, tol):
+    def test_normalized_coherent_state(
+        self, setup_backend, mag_alpha, phase_alpha, tol
+    ):
         """Tests if a range of coherent states are normalized."""
 
         alpha = mag_alpha * np.exp(1j * phase_alpha)
@@ -85,29 +89,41 @@ class TestFockRepresentation:
         backend.prepare_coherent_state(alpha, 0)
         state = backend.state()
         tr = state.trace()
-        assert np.allclose(tr, 1., atol=tol, rtol=0.)
+        assert np.allclose(tr, 1.0, atol=tol, rtol=0.0)
 
     def test_prepare_ket_state(self, setup_backend, cutoff, tol):
         """Tests if a ket state with arbitrary parameters is correctly prepared."""
         np.random.seed(SEED)
-        random_ket = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
         random_ket = random_ket / np.linalg.norm(random_ket)
         backend = setup_backend(1)
 
         backend.prepare_ket_state(random_ket, 0)
         state = backend.state()
-        assert np.allclose(state.fidelity(random_ket, 0), 1., atol=tol, rtol=0.)
+        assert np.allclose(state.fidelity(random_ket, 0), 1.0, atol=tol, rtol=0.0)
 
-    def test_prepare_batched_ket_state(self, setup_backend, pure, batch_size, cutoff, tol):
+    def test_prepare_batched_ket_state(
+        self, setup_backend, pure, batch_size, cutoff, tol
+    ):
         """Tests if a batch of ket states with arbitrary parameters is correctly
         prepared by comparing the fock probabilities of the batched case with
         individual runs with non batched input states."""
 
         if batch_size is None:
-            pytest.skip('Test skipped if no batching')
+            pytest.skip("Test skipped if no batching")
 
         np.random.seed(SEED)
-        random_kets = np.array([(lambda ket: ket / np.linalg.norm(ket))(np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)) for _ in range(batch_size)])
+        random_kets = np.array(
+            [
+                (lambda ket: ket / np.linalg.norm(ket))(
+                    np.random.uniform(-1, 1, cutoff)
+                    + 1j * np.random.uniform(-1, 1, cutoff)
+                )
+                for _ in range(batch_size)
+            ]
+        )
         backend = setup_backend(1)
 
         backend.prepare_ket_state(random_kets, 0)
@@ -123,15 +139,19 @@ class TestFockRepresentation:
             individual_probs.append(probs_for_this_ket[0])
 
         individual_probs = np.array(individual_probs)
-        assert np.allclose(batched_probs, individual_probs, atol=tol, rtol=0.)
+        assert np.allclose(batched_probs, individual_probs, atol=tol, rtol=0.0)
 
     def test_prepare_rank_two_dm_state(self, setup_backend, cutoff, tol):
         """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
 
         np.random.seed(SEED)
-        random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
         random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
-        random_ket2 = np.random.uniform(-1, 1, cutoff) + 1j*np.random.uniform(-1, 1, cutoff)
+        random_ket2 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(
+            -1, 1, cutoff
+        )
         random_ket2 = random_ket2 / np.linalg.norm(random_ket2)
 
         backend = setup_backend(1)
@@ -144,25 +164,31 @@ class TestFockRepresentation:
         state = backend.state()
         ket_probs2 = np.array([state.fock_prob([n]) for n in range(cutoff)])
 
-        ket_probs = 0.2*ket_probs1 + 0.8*ket_probs2
+        ket_probs = 0.2 * ket_probs1 + 0.8 * ket_probs2
 
-        random_rho = 0.2*np.outer(np.conj(random_ket1), random_ket1) + 0.8*np.outer(np.conj(random_ket2), random_ket2)
+        random_rho = 0.2 * np.outer(np.conj(random_ket1), random_ket1) + 0.8 * np.outer(
+            np.conj(random_ket2), random_ket2
+        )
 
         backend = setup_backend(1)
         backend.prepare_dm_state(random_rho, 0)
         state = backend.state()
         rho_probs = np.array([state.fock_prob([n]) for n in range(cutoff)])
 
-        assert np.allclose(state.trace(), 1., atol=tol, rtol=0.)
-        assert np.allclose(rho_probs, ket_probs, atol=tol, rtol=0.)
+        assert np.allclose(state.trace(), 1.0, atol=tol, rtol=0.0)
+        assert np.allclose(rho_probs, ket_probs, atol=tol, rtol=0.0)
 
-    def test_prepare_random_dm_state(self, setup_backend, batch_size, pure, cutoff, tol):
+    def test_prepare_random_dm_state(
+        self, setup_backend, batch_size, pure, cutoff, tol
+    ):
         """Tests if a random dm state is correctly prepared."""
 
         np.random.seed(SEED)
-        random_rho = np.random.normal(size=[cutoff, cutoff]) + 1j*np.random.normal(size=[cutoff, cutoff])
+        random_rho = np.random.normal(size=[cutoff, cutoff]) + 1j * np.random.normal(
+            size=[cutoff, cutoff]
+        )
         random_rho = np.dot(random_rho.conj().T, random_rho)
-        random_rho = random_rho/random_rho.trace()
+        random_rho = random_rho / random_rho.trace()
 
         backend = setup_backend(1)
         backend.prepare_dm_state(random_rho, 0)
@@ -181,18 +207,22 @@ class TestFockRepresentation:
             backend.prepare_ket_state(v, 0)
             state = backend.state()
             probs_for_this_v = np.array(state.all_fock_probs())
-            kets_mixed_probs += e*probs_for_this_v
+            kets_mixed_probs += e * probs_for_this_v
 
-        assert np.allclose(rho_probs, kets_mixed_probs, atol=tol, rtol=0.)
+        assert np.allclose(rho_probs, kets_mixed_probs, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("theta", PHASE_ALPHAS)
-    def test_rotated_superposition_states(self, setup_backend, theta, pure, cutoff, tol):
+    def test_rotated_superposition_states(
+        self, setup_backend, theta, pure, cutoff, tol
+    ):
         r"""Tests if a range of phase-shifted superposition states are equal to the form of
         \sum_n exp(i * theta * n)|n>"""
 
         backend = setup_backend(1)
 
-        ref_state = np.array([np.exp(1j * theta * k) for k in range(cutoff)]) / np.sqrt(cutoff)
+        ref_state = np.array([np.exp(1j * theta * k) for k in range(cutoff)]) / np.sqrt(
+            cutoff
+        )
 
         if not pure:
             ref_state = np.outer(ref_state, np.conj(ref_state))
@@ -205,4 +235,4 @@ class TestFockRepresentation:
         else:
             numer_state = s.dm()
 
-        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.)
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/pytest/backend/test_symbolic.py
+++ b/pytest/backend/test_symbolic.py
@@ -1,0 +1,604 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Tests for the various Tensorflow-specific symbolic options of the frontend/backend.
+"""
+ #pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement
+
+import pytest
+
+# this test file is only supported by the TF backend
+pytestmark = pytest.mark.backends('tf')
+
+import numpy as np
+from scipy.special import factorial
+import tensorflow as tf
+
+from strawberryfields.ops import Dgate, MeasureX
+
+ALPHA = 0.5
+
+
+def coherent_state(alpha, cutoff):
+    """Returns the Fock representation of the coherent state |alpha> up to dimension given by cutoff"""
+    n = np.arange(cutoff)
+    return np.exp(- 0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(factorial(n))
+
+
+def _vac_ket(cutoff):
+    """Returns the ket of the vacuum state up to dimension given by cutoff"""
+    vac = np.zeros(cutoff)
+    vac[0] = 1
+    return vac
+
+
+def _vac_dm(cutoff):
+    """Returns the density matrix of the vacuum state up to dimension given by cutoff"""
+    vac = _vac_ket(cutoff)
+    return np.outer(vac, np.conj(vac))
+
+
+class TestOneModeSymbolic:
+    """Tests for symbolic workflows on one mode."""
+
+    #########################################
+    # tests basic eval behaviour of eng.run and states class.
+
+    def test_eng_run_eval_false_returns_tensor(self, setup_eng):
+        """Tests whether the eval=False option to the `eng.run` command
+        successfully returns an unevaluated Tensor."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        state_data = state.data
+
+        assert isinstance(state_data, tf.Tensor)
+
+    def test_eng_run_eval_false_measurements_are_tensors(self, setup_eng):
+        """Tests whether the eval=False option to the `eng.run` command
+        successfully returns a unevaluated Tensors for measurment results."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+            MeasureX   | q
+
+        eng.run(eval=False)
+        val = q[0].val
+        assert isinstance(val, tf.Tensor)
+
+    def test_eng_run_with_session_and_feed_dict(self, setup_eng, batch_size, cutoff, tol):
+        """Tests whether passing a tf Session and feed_dict
+        through `eng.run` leads to proper numerical simulation."""
+        a = tf.Variable(0.5)
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(a) | q
+
+        state = eng.run(session=sess, feed_dict={a: 0.0})
+
+        if state.is_pure:
+            k = state.ket()
+
+            if batch_size is not None:
+                dm = np.einsum('bi,bj->bij', k, np.conj(k))
+            else:
+                dm = np.outer(k, np.conj(k))
+        else:
+            dm = state.dm()
+
+        vac_dm = _vac_dm(cutoff)
+        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of ket method
+
+    def test_eng_run_eval_false_state_ket(self, setup_eng, pure):
+        """Tests whether the ket of the returned state is an unevaluated
+        Tensor object when eval=False is passed to `eng.run`."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, q = setup_eng(1)
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        ket = state.ket()
+        assert isinstance(ket, tf.Tensor)
+
+    def test_eval_false_state_ket(self, setup_eng, pure):
+        """Tests whether the ket of the returned state is an unevaluated
+        Tensor object when eval=False is passed to the ket method of a state."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, q = setup_eng(1)
+        with eng:
+            Dgate(0.5) | q
+        state = eng.run()
+        ket = state.ket(eval=False)
+        assert isinstance(ket, tf.Tensor)
+
+    def test_eval_true_state_ket(self, setup_eng, pure, cutoff, tol):
+        """Tests whether the ket of the returned state is equal to the
+        correct value when eval=True is passed to the ket method of a state."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, _ = setup_eng(1)
+        state = eng.run()
+        ket = state.ket(eval=True)
+        vac = _vac_ket(cutoff)
+        assert np.allclose(ket, vac, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of dm method
+
+    def test_eng_run_eval_false_state_dm(self, pure, setup_eng):
+        """Tests whether the density matrix of the returned state is an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        dm = state.dm()
+        assert isinstance(dm, tf.Tensor)
+
+    def test_eval_false_state_dm(self, pure, setup_eng):
+        """Tests whether the density matrix of the returned state is an
+        unevaluated Tensor object when eval=False is passed to the ket method of a state."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run()
+        dm = state.dm(eval=False)
+        assert isinstance(dm, tf.Tensor)
+
+    def test_eval_true_state_dm(self, setup_eng, pure, cutoff, tol):
+        """Tests whether the density matrix of the returned state is equal
+        to the correct value when eval=True is passed to the ket method of a state."""
+        if not pure:
+            pytest.skip("Tested only for pure states")
+
+        eng, _ = setup_eng(1)
+        state = eng.run()
+        dm = state.dm(eval=True)
+        vac_dm = _vac_dm(cutoff)
+        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of trace method
+
+    def test_eng_run_eval_false_state_trace(self, setup_eng):
+        """Tests whether the trace of the returned state is an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        tr = state.trace()
+        assert isinstance(tr, tf.Tensor)
+
+    def test_eval_false_state_trace(self, setup_eng):
+        """Tests whether the trace of the returned state is an
+        unevaluated Tensor object when eval=False is passed to the trace method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run()
+        tr = state.trace(eval=False)
+        assert isinstance(tr, tf.Tensor)
+
+    def test_eval_true_state_trace(self, setup_eng, tol):
+        """Tests whether the trace of the returned state is equal
+        to the correct value when eval=True is passed to the trace method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+        state = eng.run()
+
+        tr = state.trace(eval=True)
+        assert np.allclose(tr, 1, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of reduced_dm method
+
+    def test_eng_run_eval_false_state_reduced_dm(self, setup_eng):
+        """Tests whether the reduced_density matrix of the returned state
+        is an unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        rho = state.reduced_dm([0])
+        assert isinstance(rho, tf.Tensor)
+
+    def test_eval_false_state_reduced_dm(self, setup_eng):
+        """Tests whether the reduced density matrix of the returned state is an
+        unevaluated Tensor object when eval=False is passed to the reduced_dm method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run()
+        rho = state.reduced_dm([0], eval=False)
+        assert isinstance(rho, tf.Tensor)
+
+    def test_eval_true_state_reduced_dm(self, setup_eng, cutoff, tol):
+        """Tests whether the reduced density matrix of the returned state is
+        equal to the correct value when eval=True is passed to the reduced_dm method of a state."""
+        eng, _ = setup_eng(1)
+        state = eng.run()
+        rho = state.reduced_dm([0], eval=True)
+        vac_dm = _vac_dm(cutoff)
+        assert np.allclose(rho, vac_dm, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of fidelity_vacuum method
+
+    def test_eng_run_eval_false_state_fidelity_vacuum(self, setup_eng):
+        """Tests whether the fidelity_vacuum method of the state returns an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        fidel_vac = state.fidelity_vacuum()
+        assert isinstance(fidel_vac, tf.Tensor)
+
+    def test_eval_false_state_fidelity_vacuum(self, setup_eng):
+        """Tests whether the vacuum fidelity of the returned state is an
+        unevaluated Tensor object when eval=False is passed to the fidelity_vacuum method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run()
+        fidel_vac = state.fidelity_vacuum(eval=False)
+        assert isinstance(fidel_vac, tf.Tensor)
+
+    def test_eval_true_state_fidelity_vacuum(self, setup_eng, tol):
+        """Tests whether the vacuum fidelity of the returned state is equal
+        to the correct value when eval=True is passed to the fidelity_vacuum method of a state."""
+        eng, _ = setup_eng(1)
+        state = eng.run()
+        fidel_vac = state.fidelity_vacuum(eval=True)
+        assert np.allclose(fidel_vac, 1., atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of is_vacuum method
+
+    def test_eng_run_eval_false_state_is_vacuum(self, setup_eng):
+        """Tests whether the is_vacuum method of the state returns an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run(eval=False)
+        is_vac = state.is_vacuum()
+        assert isinstance(is_vac, tf.Tensor)
+
+    def test_eval_false_state_is_vacuum(self, setup_eng):
+        """Tests whether the is_vacuum method of the state returns an
+        unevaluated Tensor object when eval=False is passed to the is_vacuum method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(0.5) | q
+
+        state = eng.run()
+        is_vac = state.is_vacuum(eval=False)
+        assert isinstance(is_vac, tf.Tensor)
+
+    def test_eval_true_state_is_vacuum(self, setup_eng):
+        """Tests whether the is_vacuum method of the state returns
+        the correct value when eval=True is passed to the is_vacuum method of a state."""
+        eng, _ = setup_eng(1)
+        state = eng.run()
+        is_vac = state.is_vacuum(eval=True)
+        assert np.all(is_vac)
+
+    #########################################
+    # tests of eval behaviour of fidelity_coherent method
+
+    def test_eng_run_eval_false_state_fidelity_coherent(self, setup_eng):
+        """Tests whether the fidelity of the state with respect to coherent states is
+        an unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run(eval=False)
+        fidel_coh = state.fidelity_coherent([ALPHA])
+        assert isinstance(fidel_coh, tf.Tensor)
+
+    def test_eval_false_state_fidelity_coherent(self, setup_eng):
+        """Tests whether the fidelity of the state with respect to coherent states
+        is an unevaluated Tensor object when eval=False is passed to the fidelity_coherent method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        fidel_coh = state.fidelity_coherent([ALPHA], eval=False)
+        assert isinstance(fidel_coh, tf.Tensor)
+
+    def test_eval_true_state_fidelity_coherent(self, setup_eng, tol):
+        """Tests whether the fidelity of the state with respect to coherent states returns
+        the correct value when eval=True is passed to the fidelity_coherent method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        fidel_coh = state.fidelity_coherent([ALPHA], eval=True)
+        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of fidelity method
+
+    def test_eng_run_eval_false_state_fidelity(self, setup_eng, cutoff):
+        """Tests whether the fidelity of the state with respect to a local state is an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run(eval=False)
+        fidel = state.fidelity(coherent_state(ALPHA, cutoff), 0)
+        assert isinstance(fidel, tf.Tensor)
+
+    def test_eval_false_state_fidelity(self, setup_eng, cutoff):
+        """Tests whether the fidelity of the state with respect to a local state is
+        an unevaluated Tensor object when eval=False is passed to the fidelity method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        fidel = state.fidelity(coherent_state(ALPHA, cutoff), 0, eval=False)
+        assert isinstance(fidel, tf.Tensor)
+
+    def test_eval_true_state_fidelity(self, setup_eng, cutoff, tol):
+        """Tests whether the fidelity of the state with respect to a local state
+        returns the correct value when eval=True is passed to the fidelity method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        fidel_coh = state.fidelity(coherent_state(ALPHA, cutoff), 0, eval=True)
+        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of quad_expectation method
+
+    def test_eng_run_eval_false_state_quad_expectation(self, setup_eng):
+        """Tests whether the local quadrature expectation of the state is
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run(eval=False)
+        e, v = state.quad_expectation(0, 0)
+        assert isinstance(e, tf.Tensor)
+        assert isinstance(v, tf.Tensor)
+
+    def test_eval_false_state_quad_expectation(self, setup_eng):
+        """Tests whether the local quadrature expectation value of the state is
+        an unevaluated Tensor object when eval=False is passed to the quad_expectation method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+        state = eng.run()
+
+        e, v = state.quad_expectation(0, 0, eval=False)
+        assert isinstance(e, tf.Tensor)
+        assert isinstance(v, tf.Tensor)
+
+    def test_eval_true_state_quad_expectation(self, setup_eng, tol):
+        """Tests whether the local quadrature expectation value of the state returns
+        the correct value when eval=True is passed to the quad_expectation method of a state."""
+        hbar = 2.
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        e, v = state.quad_expectation(0, 0, eval=True)
+        true_exp = np.sqrt(hbar / 2.) * (ALPHA + np.conj(ALPHA))
+        true_var = hbar / 2.
+        assert np.allclose(e, true_exp, atol=tol, rtol=0.)
+        assert np.allclose(v, true_var, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of mean_photon method
+
+    def test_eng_run_eval_false_state_mean_photon(self, setup_eng):
+        """Tests whether the local mean photon number of the state is
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run(eval=False)
+        nbar, var = state.mean_photon(0)
+        assert isinstance(nbar, tf.Tensor)
+        assert isinstance(var, tf.Tensor)
+
+    def test_eval_false_state_mean_photon(self, setup_eng):
+        """Tests whether the local mean photon number of the state is
+        an unevaluated Tensor object when eval=False is passed to the mean_photon_number method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        nbar, var = state.mean_photon(0, eval=False)
+        assert isinstance(nbar, tf.Tensor)
+        assert isinstance(var, tf.Tensor)
+
+    def test_eval_true_state_mean_photon(self, setup_eng, tol):
+        """Tests whether the local mean photon number of the state returns
+        the correct value when eval=True is passed to the mean_photon method of a state."""
+        eng, q = setup_eng(1)
+
+        with eng:
+            Dgate(ALPHA) | q
+
+        state = eng.run()
+        nbar, var = state.mean_photon(0, eval=True)
+        ref_nbar = np.abs(ALPHA) ** 2
+        ref_var = np.abs(ALPHA) ** 2
+        assert np.allclose(nbar, ref_nbar, atol=tol, rtol=0.)
+        assert np.allclose(var, ref_var, atol=tol, rtol=0.)
+
+
+class TestTwoModeSymbolic:
+    """Tests for symbolic workflows on two modes."""
+
+    #########################################
+    # tests of eval behaviour of all_fock_probs method
+
+    def test_eng_run_eval_false_state_all_fock_probs(self, setup_eng):
+        """Tests whether the Fock-basis probabilities of the state are an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run(eval=False)
+        probs = state.all_fock_probs()
+        assert isinstance(probs, tf.Tensor)
+
+    def test_eval_false_state_all_fock_probs(self, setup_eng):
+        """Tests whether the Fock-basis probabilities of the state are an
+        unevaluated Tensor object when eval=False is passed to the all_fock_probs method of a state."""
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run()
+        probs = state.all_fock_probs(eval=False)
+        assert isinstance(probs, tf.Tensor)
+
+    def test_eval_true_state_all_fock_probs(self, setup_eng, cutoff, batch_size, tol):
+        """Tests whether the Fock-basis probabilities of the state return
+        the correct value when eval=True is passed to the all_fock_probs method of a state."""
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run()
+        probs = state.all_fock_probs(eval=True).flatten()
+        ref_probs = np.abs(np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff))).flatten() ** 2
+
+        if batch_size is not None:
+            ref_probs = np.tile(ref_probs, batch_size)
+
+        assert np.allclose(probs, ref_probs, atol=tol, rtol=0.)
+
+    #########################################
+    # tests of eval behaviour of fock_prob method
+
+    def test_eng_run_eval_false_state_fock_prob(self, setup_eng, cutoff):
+        """Tests whether the probability of a Fock measurement outcome on the state is an
+        unevaluated Tensor object when eval=False is passed to `eng.run`."""
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run(eval=False)
+        prob = state.fock_prob([cutoff // 2, cutoff // 2])
+        assert isinstance(prob, tf.Tensor)
+
+    def test_eval_false_state_fock_prob(self, setup_eng, cutoff):
+        """Tests whether the probability of a Fock measurement outcome on the state is an
+        unevaluated Tensor object when eval=False is passed to the fock_prob method of a state."""
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run()
+        prob = state.fock_prob([cutoff // 2, cutoff // 2], eval=False)
+        assert isinstance(prob, tf.Tensor)
+
+    def test_eval_true_state_fock_prob(self, setup_eng, cutoff, tol):
+        """Tests whether the probability of a Fock measurement outcome on the state returns
+         the correct value when eval=True is passed to the fock_prob method of a state."""
+        n1 = cutoff // 2
+        n2 = cutoff // 3
+
+        eng, q = setup_eng(2)
+
+        with eng:
+            Dgate(ALPHA) | q[0]
+            Dgate(-ALPHA) | q[1]
+
+        state = eng.run()
+        prob = state.fock_prob([n1, n2], eval=True)
+        ref_prob = np.abs(np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff)) ** 2)[n1, n2]
+        assert np.allclose(prob, ref_prob, atol=tol, rtol=0.)

--- a/pytest/backend/test_symbolic.py
+++ b/pytest/backend/test_symbolic.py
@@ -14,12 +14,12 @@
 r"""
 Tests for the various Tensorflow-specific symbolic options of the frontend/backend.
 """
- #pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement
+# pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement
 
 import pytest
 
 # this test file is only supported by the TF backend
-pytestmark = pytest.mark.backends('tf')
+pytestmark = pytest.mark.backends("tf")
 
 import numpy as np
 from scipy.special import factorial
@@ -33,7 +33,7 @@ ALPHA = 0.5
 def coherent_state(alpha, cutoff):
     """Returns the Fock representation of the coherent state |alpha> up to dimension given by cutoff"""
     n = np.arange(cutoff)
-    return np.exp(- 0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(factorial(n))
+    return np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(factorial(n))
 
 
 def _vac_ket(cutoff):
@@ -75,13 +75,15 @@ class TestOneModeSymbolic:
 
         with eng:
             Dgate(0.5) | q
-            MeasureX   | q
+            MeasureX | q
 
         eng.run(eval=False)
         val = q[0].val
         assert isinstance(val, tf.Tensor)
 
-    def test_eng_run_with_session_and_feed_dict(self, setup_eng, batch_size, cutoff, tol):
+    def test_eng_run_with_session_and_feed_dict(
+        self, setup_eng, batch_size, cutoff, tol
+    ):
         """Tests whether passing a tf Session and feed_dict
         through `eng.run` leads to proper numerical simulation."""
         a = tf.Variable(0.5)
@@ -98,14 +100,14 @@ class TestOneModeSymbolic:
             k = state.ket()
 
             if batch_size is not None:
-                dm = np.einsum('bi,bj->bij', k, np.conj(k))
+                dm = np.einsum("bi,bj->bij", k, np.conj(k))
             else:
                 dm = np.outer(k, np.conj(k))
         else:
             dm = state.dm()
 
         vac_dm = _vac_dm(cutoff)
-        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.)
+        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of ket method
@@ -147,7 +149,7 @@ class TestOneModeSymbolic:
         state = eng.run()
         ket = state.ket(eval=True)
         vac = _vac_ket(cutoff)
-        assert np.allclose(ket, vac, atol=tol, rtol=0.)
+        assert np.allclose(ket, vac, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of dm method
@@ -192,7 +194,7 @@ class TestOneModeSymbolic:
         state = eng.run()
         dm = state.dm(eval=True)
         vac_dm = _vac_dm(cutoff)
-        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.)
+        assert np.allclose(dm, vac_dm, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of trace method
@@ -231,7 +233,7 @@ class TestOneModeSymbolic:
         state = eng.run()
 
         tr = state.trace(eval=True)
-        assert np.allclose(tr, 1, atol=tol, rtol=0.)
+        assert np.allclose(tr, 1, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of reduced_dm method
@@ -267,7 +269,7 @@ class TestOneModeSymbolic:
         state = eng.run()
         rho = state.reduced_dm([0], eval=True)
         vac_dm = _vac_dm(cutoff)
-        assert np.allclose(rho, vac_dm, atol=tol, rtol=0.)
+        assert np.allclose(rho, vac_dm, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of fidelity_vacuum method
@@ -302,7 +304,7 @@ class TestOneModeSymbolic:
         eng, _ = setup_eng(1)
         state = eng.run()
         fidel_vac = state.fidelity_vacuum(eval=True)
-        assert np.allclose(fidel_vac, 1., atol=tol, rtol=0.)
+        assert np.allclose(fidel_vac, 1.0, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of is_vacuum method
@@ -376,7 +378,7 @@ class TestOneModeSymbolic:
 
         state = eng.run()
         fidel_coh = state.fidelity_coherent([ALPHA], eval=True)
-        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.)
+        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of fidelity method
@@ -415,7 +417,7 @@ class TestOneModeSymbolic:
 
         state = eng.run()
         fidel_coh = state.fidelity(coherent_state(ALPHA, cutoff), 0, eval=True)
-        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.)
+        assert np.allclose(fidel_coh, 1, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of quad_expectation method
@@ -449,7 +451,7 @@ class TestOneModeSymbolic:
     def test_eval_true_state_quad_expectation(self, setup_eng, tol):
         """Tests whether the local quadrature expectation value of the state returns
         the correct value when eval=True is passed to the quad_expectation method of a state."""
-        hbar = 2.
+        hbar = 2.0
         eng, q = setup_eng(1)
 
         with eng:
@@ -457,10 +459,10 @@ class TestOneModeSymbolic:
 
         state = eng.run()
         e, v = state.quad_expectation(0, 0, eval=True)
-        true_exp = np.sqrt(hbar / 2.) * (ALPHA + np.conj(ALPHA))
-        true_var = hbar / 2.
-        assert np.allclose(e, true_exp, atol=tol, rtol=0.)
-        assert np.allclose(v, true_var, atol=tol, rtol=0.)
+        true_exp = np.sqrt(hbar / 2.0) * (ALPHA + np.conj(ALPHA))
+        true_var = hbar / 2.0
+        assert np.allclose(e, true_exp, atol=tol, rtol=0.0)
+        assert np.allclose(v, true_var, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of mean_photon method
@@ -503,8 +505,8 @@ class TestOneModeSymbolic:
         nbar, var = state.mean_photon(0, eval=True)
         ref_nbar = np.abs(ALPHA) ** 2
         ref_var = np.abs(ALPHA) ** 2
-        assert np.allclose(nbar, ref_nbar, atol=tol, rtol=0.)
-        assert np.allclose(var, ref_var, atol=tol, rtol=0.)
+        assert np.allclose(nbar, ref_nbar, atol=tol, rtol=0.0)
+        assert np.allclose(var, ref_var, atol=tol, rtol=0.0)
 
 
 class TestTwoModeSymbolic:
@@ -550,12 +552,17 @@ class TestTwoModeSymbolic:
 
         state = eng.run()
         probs = state.all_fock_probs(eval=True).flatten()
-        ref_probs = np.abs(np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff))).flatten() ** 2
+        ref_probs = (
+            np.abs(
+                np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff))
+            ).flatten()
+            ** 2
+        )
 
         if batch_size is not None:
             ref_probs = np.tile(ref_probs, batch_size)
 
-        assert np.allclose(probs, ref_probs, atol=tol, rtol=0.)
+        assert np.allclose(probs, ref_probs, atol=tol, rtol=0.0)
 
     #########################################
     # tests of eval behaviour of fock_prob method
@@ -600,5 +607,7 @@ class TestTwoModeSymbolic:
 
         state = eng.run()
         prob = state.fock_prob([n1, n2], eval=True)
-        ref_prob = np.abs(np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff)) ** 2)[n1, n2]
-        assert np.allclose(prob, ref_prob, atol=tol, rtol=0.)
+        ref_prob = np.abs(
+            np.outer(coherent_state(ALPHA, cutoff), coherent_state(-ALPHA, cutoff)) ** 2
+        )[n1, n2]
+        assert np.allclose(prob, ref_prob, atol=tol, rtol=0.0)


### PR DESCRIPTION
* Added the already ported Fock backend tests from #55 to the top level pytest folder

* Ported over the `test_multimode_state_preparation` test, splitting it into a backend test, and an integration test (added to `test_ops_integration.py`).

Once this is merged, the following will have to take place in a new PR:

1. Remove the old unittest `tests` folder, and rename the `pytest` folder to `tests`

2. Update the top level makefile and the TravisCI config

3. Update the section in the documentation on running the tests.
