### PR TITLE
Eliminate hbar from backend API.

### DIFF
--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -73,3 +73,7 @@ def version():
       str: package version number
     """
     return __version__
+
+
+#: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)
+hbar = 2

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -30,7 +30,7 @@ This module implements the backend API. It contains the classes
 
 as well as a few methods which apply only to the Gaussian backend.
 
-.. note:: The backend API is hbar-independent.
+.. note:: The backend API is :math:`\hbar` independent.
           Internally the Strawberry Fields backends use :math:`\hbar=2`.
 
 
@@ -463,7 +463,7 @@ class BaseBackend:
            \hat{q}_\phi = \sqrt{2/\hbar}(\cos(\phi)\hat{x} +\sin(\phi)\hat{p}) = e^{-i\phi} \hat{a} +e^{i\phi} \hat{a}^\dagger.
 
         .. note::
-           This method is hbar-independent.
+           This method is :math:`\hbar` independent.
            The returned values can be converted to conventional position/momentum
            eigenvalues by multiplying them with :math:`\sqrt{\hbar/2}`.
 
@@ -592,16 +592,16 @@ class BaseFock(BaseBackend):
         to the specified mode.
 
         .. note::
-           This method is hbar-independent.
-           The usual definition of the cubic phase gate is hbar-dependent:
+           This method is :math:`\hbar` independent.
+           The usual definition of the cubic phase gate is :math:`\hbar` dependent:
 
            .. math::
               V(\gamma) = \exp\left(i \frac{\gamma}{3\hbar} \hat{x}^3\right) = \exp\left(i \frac{\gamma \sqrt{\hbar/2}}{6} (\hat{a} +\hat{a}^\dagger)^3\right).
 
            Hence the cubic phase gate `V(gamma)` is executed on a backend by scaling the
            `gamma` parameter by :math:`\sqrt{\hbar/2}` and then passing it to this method,
-           much in the way the hbar-dependent `X` and `Z` gates are implemented through the
-           hbar-independent :meth:`~BaseBackend.displacement` method.
+           much in the way the :math:`\hbar` dependent `X` and `Z` gates are implemented through the
+           :math:`\hbar` independent :meth:`~BaseBackend.displacement` method.
 
         .. warning::
             The cubic phase gate can suffer heavily from numerical inaccuracies
@@ -694,7 +694,7 @@ class BaseGaussian(BaseBackend):
         The requested modes are traced out and replaced with the given Gaussian state.
 
         .. note::
-           This method is hbar-independent.
+           This method is :math:`\hbar` independent.
            The input arrays are the means and covariance of the
            :math:`a+a^\dagger` and :math:`-i(a-a^\dagger)` operators.
            They are obtained by dividing the xp means by :math:`\sqrt{\hbar/2}`

--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -30,8 +30,9 @@ This module implements the backend API. It contains the classes
 
 as well as a few methods which apply only to the Gaussian backend.
 
-.. note:: The Strawberry Fields backends by default assume :math:`\hbar=2`, however
-    different conventions may be chosen when calling :meth:`~.BaseBackend.begin_circuit`
+.. note:: The backend API is hbar-independent.
+          Internally the Strawberry Fields backends use :math:`\hbar=2`.
+
 
 .. note::
     Keyword arguments are denoted ``**kwargs``, and allow additional
@@ -111,6 +112,8 @@ for quantum optical circuits.
 
 .. autosummary::
     measure_heterodyne
+
+.. currentmodule:: strawberryfields.backends.base
 
 Code details
 ~~~~~~~~~~~~
@@ -254,7 +257,7 @@ class BaseBackend:
         """
         return self._supported.get(name, False)
 
-    def begin_circuit(self, num_subsystems, cutoff_dim=None, hbar=2, pure=True, **kwargs):
+    def begin_circuit(self, num_subsystems, *, cutoff_dim=None, pure=True, **kwargs):
         r"""Instantiate a quantum circuit.
 
         Instantiates a circuit with num_subsystems modes to track and update a quantum optical state.
@@ -452,8 +455,17 @@ class BaseBackend:
         r"""Measure a :ref:`phase space quadrature <homodyne>` of the given mode.
 
         For the measured mode, samples the probability distribution
-        :math:`f(q) = \bra{q}_x R^\dagger(\phi) \rho R(\phi) \ket{q}_x`
+        :math:`f(q) = \bra{q_\phi} R^\dagger(\phi) \rho R(\phi) \ket{q_\phi}`
         and returns the sampled value.
+        Here :math:`\ket{q_\phi}` is the eigenstate of the operator
+
+        .. math::
+           \hat{q}_\phi = \sqrt{2/\hbar}(\cos(\phi)\hat{x} +\sin(\phi)\hat{p}) = e^{-i\phi} \hat{a} +e^{i\phi} \hat{a}^\dagger.
+
+        .. note::
+           This method is hbar-independent.
+           The returned values can be converted to conventional position/momentum
+           eigenvalues by multiplying them with :math:`\sqrt{\hbar/2}`.
 
         Updates the current state of the circuit such that the measured mode is reset
         to the vacuum state. This is because we cannot represent exact position or
@@ -494,7 +506,7 @@ class BaseBackend:
                 requesting the modes=[3,1] results in a two mode state being returned with the first mode being
                 subsystem 3 and the second mode being subsystem 1 of simulator.
         Returns:
-            An instance of the Strawberry Fields State class, suited to the particular backend.
+            BaseState: state description, suited to the particular backend
         """
         raise NotImplementedError
 
@@ -569,8 +581,27 @@ class BaseFock(BaseBackend):
         raise NotImplementedError
 
 
-    def cubic_phase(self, gamma, mode):
+    def cubic_phase(self, gamma_prime, mode):
         r"""Apply the cubic phase operation to the specified mode.
+
+        Applies the operation
+
+        .. math::
+           \exp\left(i \frac{\gamma'}{6} (\hat{a} +\hat{a}^\dagger)^3\right)
+
+        to the specified mode.
+
+        .. note::
+           This method is hbar-independent.
+           The usual definition of the cubic phase gate is hbar-dependent:
+
+           .. math::
+              V(\gamma) = \exp\left(i \frac{\gamma}{3\hbar} \hat{x}^3\right) = \exp\left(i \frac{\gamma \sqrt{\hbar/2}}{6} (\hat{a} +\hat{a}^\dagger)^3\right).
+
+           Hence the cubic phase gate `V(gamma)` is executed on a backend by scaling the
+           `gamma` parameter by :math:`\sqrt{\hbar/2}` and then passing it to this method,
+           much in the way the hbar-dependent `X` and `Z` gates are implemented through the
+           hbar-independent :meth:`~BaseBackend.displacement` method.
 
         .. warning::
             The cubic phase gate can suffer heavily from numerical inaccuracies
@@ -580,7 +611,7 @@ class BaseFock(BaseBackend):
             provides an alternative non-Gaussian gate.
 
         Args:
-            gamma (float): cubic phase shift
+            gamma_prime (float): scaled cubic phase shift, :math:`\gamma' = \gamma \sqrt{\hbar/2}`
             mode (int): which mode to apply it to
         """
         raise NotImplementedError
@@ -626,7 +657,7 @@ class BaseFock(BaseBackend):
             modes (int or Sequence[int]): specifies the mode or modes to restrict the return state to.
                 This argument is optional; the default value ``modes=None`` returns the state containing all modes.
         Returns:
-            An instance of the Strawberry Fields FockState class.
+            FockState: state description
         """
         raise NotImplementedError
 
@@ -660,11 +691,18 @@ class BaseGaussian(BaseBackend):
         r"""Prepare the given Gaussian state (via the provided vector of
         means and the covariance matrix) in the specified modes.
 
-        The requested mode(s) is/are traced out and replaced with the given Gaussian state.
+        The requested modes are traced out and replaced with the given Gaussian state.
+
+        .. note::
+           This method is hbar-independent.
+           The input arrays are the means and covariance of the
+           :math:`a+a^\dagger` and :math:`-i(a-a^\dagger)` operators.
+           They are obtained by dividing the xp means by :math:`\sqrt{\hbar/2}`
+           and the xp covariance by :math:`\hbar/2`.
 
         Args:
-            r (array): the vector of means in xp ordering.
-            V (array): the covariance matrix in xp ordering.
+            r (array): vector of means in xp ordering
+            V (array): covariance matrix in xp ordering
             modes (int or Sequence[int]): which mode to prepare the state in
                 If the modes are not sorted, this is take into account when preparing the state.
                 i.e., when a two mode state is prepared in modes=[3,1], then the first

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -56,7 +56,7 @@ class FockBackend(BaseFock):
             remapped_modes = remapped_modes[0]
         return remapped_modes
 
-    def begin_circuit(self, num_subsystems, cutoff_dim=None, hbar=2, pure=True, **kwargs):
+    def begin_circuit(self, num_subsystems, *, cutoff_dim=None, pure=True, **kwargs):
         r"""
         Create a quantum circuit (initialized in vacuum state) with the number of modes
         equal to num_subsystems and a Fock-space cutoff dimension of cutoff_dim.
@@ -66,8 +66,6 @@ class FockBackend(BaseFock):
             cutoff_dim (int): numerical cutoff dimension in Fock space for each mode.
                 ``cutoff_dim=D`` represents the Fock states :math:`|0\rangle,\dots,|D-1\rangle`.
                 This argument is **required** for the Fock backend.
-            hbar (float): The value of :math:`\hbar` to initialise the circuit with, depending on the conventions followed.
-                By default, :math:`\hbar=2`. See :ref:`conventions` for more details.
             pure (bool): whether to begin the circuit in a pure state representation
         """
         # pylint: disable=attribute-defined-outside-init
@@ -81,7 +79,7 @@ class FockBackend(BaseFock):
             raise ValueError("Argument 'pure' must be either True or False")
 
         self._init_modes = num_subsystems
-        self.circuit = Circuit(num_subsystems, cutoff_dim, hbar, pure)
+        self.circuit = Circuit(num_subsystems, cutoff_dim, pure)
         self._modemap = ModeMap(num_subsystems)
 
     def add_mode(self, n=1):
@@ -364,10 +362,9 @@ class FockBackend(BaseFock):
             index_permutation = [2*x+i for x in mode_permutation for i in (0, 1)]
             red_state = np.transpose(red_state, np.argsort(index_permutation))
 
-        hbar = self.circuit._hbar
         cutoff = self.circuit._trunc # pylint: disable=protected-access
         mode_names = ["q[{}]".format(i) for i in np.array(self.get_modes())[modes]]
-        state = BaseFockState(red_state, len(modes), pure, cutoff, hbar, mode_names)
+        state = BaseFockState(red_state, len(modes), pure, cutoff, mode_names)
         return state
 
     # ==============================================

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -52,14 +52,12 @@ class Circuit():
     in the fock basis.
     """
 
-    def __init__(self, num, trunc, hbar=2, pure=True, do_checks=False, mode='blas'):
+    def __init__(self, num, trunc, pure=True, do_checks=False, mode='blas'):
         r"""Class initializer.
 
         Args:
             num (non-negative int): Number of modes in the register.
             trunc (positive int): Truncation parameter.  Fock states up to |trunc-1> are representable.
-            hbar (int): The value of :math:`\hbar` to initialise the circuit with, depending on the conventions followed.
-                By default, :math:`\hbar=2`. See :ref:`conventions` for more details.
             pure (bool, optional): Whether states are pure (True) or mixed (False)
             do_checks (bool, optional): Whether arguments are to be checked first
             mode (str, optional): Whether to use BLAS or einsum for matrix operations.
@@ -74,7 +72,7 @@ class Circuit():
             raise ValueError("Truncation must be positive -- got {}".format(trunc))
 
         self._num_modes = num
-        self._hbar = hbar
+        self._hbar = 2
         self._checks = do_checks
         self._mode = mode
         self.reset(pure=pure, cutoff_dim=trunc)

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -34,19 +34,17 @@ class GaussianBackend(BaseGaussian):
         self._supported["mixed_states"] = True
         self._short_name = "gaussian"
 
-    def begin_circuit(self, num_subsystems, cutoff_dim=None, hbar=2, pure=None, **kwargs):
+    def begin_circuit(self, num_subsystems, *, cutoff_dim=None, pure=None, **kwargs):
         r"""
         Create a quantum circuit (initialized in vacuum state) with number of modes
         equal to num_subsystems.
 
         Args:
             num_subsystems (int): number of modes the circuit should begin with
-            hbar (float): The value of :math:`\hbar` to initialise the circuit with, depending on the conventions followed.
-                By default, :math:`\hbar=2`. See :ref:`conventions` for more details.
         """
         # pylint: disable=attribute-defined-outside-init
         self._init_modes = num_subsystems
-        self.circuit = GaussianModes(num_subsystems, hbar)
+        self.circuit = GaussianModes(num_subsystems)
 
     def add_mode(self, n=1):
         """
@@ -360,4 +358,4 @@ class GaussianBackend(BaseGaussian):
             Amat = self.circuit.Amat()
 
         return GaussianState((means, covmat), len(modes), qmat, Amat,
-                             hbar=self.circuit.hbar, mode_names=mode_names)
+                             mode_names=mode_names)

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -27,7 +27,7 @@ class GaussianModes:
     The state of the modes is manipulated by calling the various methods."""
     # pylint: disable=too-many-public-methods
 
-    def __init__(self, num_subsystems, hbar):
+    def __init__(self, num_subsystems):
         r"""The class is initialized by providing an integer indicating the number of modes
         Unlike the "standard" covariance matrix for the Wigner function that uses symmetric ordering
         as defined in e.g.
@@ -50,7 +50,7 @@ class GaussianModes:
         if not isinstance(num_subsystems, int):
             raise ValueError("Number of modes must be an integer")
 
-        self.hbar = hbar
+        self.hbar = 2
         self.reset(num_subsystems)
 
     def add_mode(self, n=1):

--- a/strawberryfields/backends/gaussianbackend/states.py
+++ b/strawberryfields/backends/gaussianbackend/states.py
@@ -29,14 +29,12 @@ class GaussianState(BaseGaussianState):
         num_modes (int): the number of modes in the state
         qmat (array): The covariance matrix for the Q function
         Amat (array): The A matrix from Hamilton's paper
-        hbar (float): (default 2) The value of :math:`\hbar` in the commutation relation
-            :math:`[\x,\p]=i\hbar`
         mode_names (Sequence): (optional) this argument contains a list providing mode names
             for each mode in the state
     """
-    def __init__(self, state_data, num_modes, qmat, Amat, hbar=2., mode_names=None):
+    def __init__(self, state_data, num_modes, qmat, Amat, mode_names=None):
         # pylint: disable=too-many-arguments
-        super().__init__(state_data, num_modes, hbar, mode_names)
+        super().__init__(state_data, num_modes, mode_names)
 
         # some of the Gaussian backend operations expect as input a 'GaussianMode' class.
         # The following mini class matches the attributes expected for fock_probs and fidelity.

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -62,7 +62,7 @@ class TFBackend(BaseFock):
             remapped_modes = remapped_modes[0]
         return remapped_modes
 
-    def begin_circuit(self, num_subsystems, cutoff_dim=None, hbar=2, pure=True, **kwargs):
+    def begin_circuit(self, num_subsystems, *, cutoff_dim=None, pure=True, **kwargs):
         r"""Create a quantum circuit (initialized in vacuum state) with the number of modes
         equal to num_subsystems and a Fock-space cutoff dimension of cutoff_dim.
 
@@ -71,8 +71,6 @@ class TFBackend(BaseFock):
             cutoff_dim (int): numerical cutoff dimension in Fock space for each mode.
                 ``cutoff_dim=D`` represents the Fock states :math:`|0\rangle,\dots,|D-1\rangle`.
                 This argument is **required** for the Tensorflow backend.
-            hbar (float): The value of :math:`\hbar` to initialise the circuit with, depending on the conventions followed.
-                By default, :math:`\hbar=2`. See :ref:`conventions` for more details.
             pure (bool): whether to begin the circuit in a pure state representation
             **kwargs: optional keyword arguments which will be passed to the underlying circuit class
 
@@ -95,7 +93,7 @@ class TFBackend(BaseFock):
                 raise ValueError("batch_size of 1 not supported, please use different batch_size or set batch_size=None")
             else:
                 self._modemap = ModeMap(num_subsystems)
-                circuit = Circuit(self._graph, num_subsystems, cutoff_dim, hbar, pure, batch_size)
+                circuit = Circuit(self._graph, num_subsystems, cutoff_dim, pure, batch_size)
 
         self._init_modes = num_subsystems
         self.circuit = circuit
@@ -113,8 +111,6 @@ class TFBackend(BaseFock):
                   If False, then the circuit is reset to its initial state, but ops that
                   have already been declared are still accessible.
           cutoff_dim (int): new cutoff dimension for the simulated circuit.
-          hbar (float): New :math:`\hbar` value. See :ref:`conventions` for more details.
-
         """
         hard = kwargs.get('hard', True)
         if hard:
@@ -420,7 +416,7 @@ class TFBackend(BaseFock):
 
             modenames = ["q[{}]".format(i) for i in np.array(self.get_modes())[modes]]
             state_ = FockStateTF(s, len(modes), pure, self.circuit.cutoff_dim,
-                                 graph=self._graph, batched=batched, hbar=self.circuit.hbar,
+                                 graph=self._graph, batched=batched,
                                  mode_names=modenames, eval=evaluate_results)
         return state_
 

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -48,11 +48,12 @@ class Circuit:
          using the Fock representation with given cutoff_dim.
          The state of the modes is manipulated by calling the various methods."""
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
-    def __init__(self, graph, num_modes, cutoff_dim, hbar=2., pure=True, batch_size=None):
+    def __init__(self, graph, num_modes, cutoff_dim, pure=True, batch_size=None):
         self._graph = None # will be set when reset is called below, but reset needs something to compare to
         self._batch_size = batch_size
         self._batched = False if batch_size is None else True
-        self.reset(pure, graph, num_subsystems=num_modes, cutoff_dim=cutoff_dim, hbar=hbar)
+        self._hbar = 2
+        self.reset(pure, graph, num_subsystems=num_modes, cutoff_dim=cutoff_dim)
 
     def _make_vac_states(self, cutoff_dim):
         """Make vacuum state tensors for the underlying graph"""
@@ -191,7 +192,7 @@ class Circuit:
         self._update_state(new_state)
         self._num_modes += num_modes
 
-    def reset(self, pure=True, graph=None, num_subsystems=None, cutoff_dim=None, hbar=None):
+    def reset(self, pure=True, graph=None, num_subsystems=None, cutoff_dim=None):
         r"""
         Resets the state of the circuit to have all modes in vacuum.
         For all the parameters, None means unchanged.
@@ -202,7 +203,6 @@ class Circuit:
               graph (and all its defined operations) will be kept.
             num_subsystems (int): sets the number of modes in the reset circuit.
             cutoff_dim (int): new Fock space cutoff dimension to use.
-            hbar (float): new :math:`\hbar` value. See :ref:`conventions` for more details.
         """
         if pure is not None:
             if not isinstance(pure, bool):
@@ -218,11 +218,6 @@ class Circuit:
             if not isinstance(cutoff_dim, int) or cutoff_dim < 1:
                 raise ValueError("Argument 'cutoff_dim' must be a positive integer")
             self._cutoff_dim = cutoff_dim
-
-        if hbar is not None:
-            if not isinstance(hbar, numbers.Real) or hbar <= 0:
-                raise ValueError("Argument 'hbar' must be a positive number")
-            self._hbar = hbar
 
         if graph is not None:
             if not isinstance(graph, tf.Graph):

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -30,17 +30,15 @@ class FockStateTF(BaseFockState):
             num_modes (int): the number of modes in the state
             pure (bool): True if the state is a pure state, false if the state is mixed
             cutoff_dim (int): the Fock basis truncation size
-            hbar (float): (default 2) The value of :math:`\hbar` in the commutation relation
-                    :math:`[\x,\p]=i\hbar`
             mode_names (Sequence): (optional) this argument contains a list providing mode names
                     for each mode in the state.
             eval (bool): indicates the default return behaviour for the class instance (symbolic when eval=False, numerical when eval=True)
     """
 
-    def __init__(self, state_data, num_modes, pure, cutoff_dim, graph, batched=False, hbar=2., mode_names=None, eval=True):
+    def __init__(self, state_data, num_modes, pure, cutoff_dim, graph, batched=False, mode_names=None, eval=True):
         # pylint: disable=too-many-arguments
         state_data = tf.convert_to_tensor(state_data, name="state_data") # convert everything to a Tensor so we have the option to do symbolic evaluations
-        super().__init__(state_data, num_modes, pure, cutoff_dim, hbar, mode_names)
+        super().__init__(state_data, num_modes, pure, cutoff_dim, mode_names)
         self._batched = batched
         self._str = "<FockStateTF: num_modes={}, cutoff={}, pure={}, batched={}, hbar={}>". \
                                 format(self.num_modes, self.cutoff_dim, self._pure, self._batched, self._hbar)

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -72,7 +72,6 @@ Code details
 ~~~~~~~~~~~~
 
 """
-# pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
 
 from collections.abc import Sequence
 
@@ -90,9 +89,6 @@ class Engine:
         backend (str): name of the backend
         host    (str): URL of the remote backend host, or None if a local backend is used
     Keyword Args:
-        hbar (float): The value of :math:`\hbar` to initialise the engine with, depending on the
-            conventions followed. By default, :math:`\hbar=2`. See
-            :ref:`conventions` for more details.
     """
     def __init__(self, backend, host=None, **kwargs):
         #: list[Program]: list of Programs that have been run
@@ -101,8 +97,6 @@ class Engine:
         self.host = host
         #: dict[str]: keyword arguments for the backend
         self.kwargs = kwargs
-        #: float: numerical value of hbar in the (implicit) units of position * momentum
-        self.hbar = kwargs.get('hbar', 2)
 
         if isinstance(backend, str):
             #: str: short name of the backend
@@ -178,7 +172,7 @@ class Engine:
         for cmd in prog.circuit:
             try:
                 # try to apply it to the backend
-                cmd.op.apply(cmd.reg, self.backend, hbar=self.hbar, **kwargs)
+                cmd.op.apply(cmd.reg, self.backend, **kwargs)
                 applied.append(cmd)
             except NotApplicableError:
                 # command is not applicable to the current backend type
@@ -230,7 +224,7 @@ class Engine:
                 p.lock()
 
                 # TODO handle remote backends here, store measurement results in the RegRefs or maybe in the Engine object.
-                temp = self._run_program_locally(p, **kwargs)
+                self._run_program_locally(p, **kwargs)
                 self.run_progs.append(p)
         except Exception as e:
             # TODO reset the backend to the last checkpoint here?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ Default parameters, environment variables, fixtures, and common routines for the
 import os
 import pytest
 
+import strawberryfields as sf
 from strawberryfields.engine import Engine
 from strawberryfields.program import Program
 from strawberryfields.backends.base import BaseBackend
@@ -56,7 +57,8 @@ def alpha():
 @pytest.fixture(scope="session")
 def hbar():
     """The value of hbar"""
-    return float(os.environ.get("HBAR", HBAR))
+    sf.hbar = float(os.environ.get("HBAR", HBAR))
+    return sf.hbar
 
 
 @pytest.fixture(
@@ -124,7 +126,7 @@ def print_fixtures(cutoff, hbar, batch_size):
     ]
 )
 def setup_backend(
-    request, cutoff, hbar, pure, batch_size
+    request, cutoff, pure, batch_size
 ):  # pylint: disable=redefined-outer-name
     """Parameterized fixture, used to automatically create a backend of certain number of modes.
 
@@ -145,7 +147,6 @@ def setup_backend(
         backend.begin_circuit(
             num_subsystems=num_subsystems,
             cutoff_dim=cutoff,
-            hbar=hbar,
             pure=pure,
             batch_size=batch_size,
         )
@@ -162,7 +163,7 @@ def setup_backend(
     ]
 )
 def setup_backend_pars(
-    request, cutoff, hbar, pure, batch_size
+    request, cutoff, pure, batch_size
 ):  # pylint: disable=redefined-outer-name
     """Parameterized fixture, a container for the backend parameters.
 
@@ -173,11 +174,9 @@ def setup_backend_pars(
     use the ``@pytest.mark.backends()`` fixture. For example, for a test that
     only works on the TF and Fock backends, ``@pytest.mark.backends('tf', 'fock').
     """
-
     return {
         'backend_name': request.param,
         'cutoff_dim': cutoff,
-        'hbar': hbar,
         'pure': pure,
         'batch_size': batch_size,
     }

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -133,7 +133,7 @@ class TestGateBasics:
         assert not G.dagger
         assert G2.dagger
 
-        def dummy_apply(self, reg, backend, hbar, eval_params=False):
+        def dummy_apply(self, reg, backend, eval_params=False):
             """Dummy apply function, used to store the evaluated params"""
             self.res = [x.evaluate() for x in self.p]
 
@@ -143,7 +143,7 @@ class TestGateBasics:
             # in the attribute res. This allows us to extract
             # and verify the parameter was properly negated.
             m.setattr(ops.Operation, "apply", dummy_apply)
-            G2.apply(None, None, None)
+            G2.apply(None, None)
 
         orig_params = [x.evaluate() for x in G2.p]
         applied_params = G2.res

--- a/tests/integration/test_algorithms.py
+++ b/tests/integration/test_algorithms.py
@@ -24,23 +24,29 @@ from strawberryfields.utils import scale
 def test_teleportation_fidelity(setup_eng, pure):
     """Test that teleportation of a coherent state has high fidelity"""
     eng, prog = setup_eng(3)
+    s = np.sqrt(2)
+    z = 2
+    BS = BSgate(np.pi / 4, 0)
+    alpha = 0.5 + 0.2j
+
     with prog.context as q:
         # TODO: at some point, use the blackbird parser to
         # read in the following directly from the examples folder
-        Coherent(0.5 + 0.2j) | q[0]
-        BS = BSgate(np.pi / 4, 0)
+        Coherent(alpha) | q[0]
 
-        Squeezed(-2) | q[1]
-        Squeezed(2) | q[2]
+        Squeezed(-z) | q[1]
+        Squeezed(z) | q[2]
         BS | (q[1], q[2])
 
         BS | (q[0], q[1])
         MeasureHomodyne(0, select=0.07) | q[0]
         MeasureHomodyne(np.pi / 2, select=0.1) | q[1]
+        Xgate(scale(q[0], s)) | q[2]
+        Zgate(scale(q[1], s)) | q[2]
 
     state = eng.run(prog)
-    fidelity = state.fidelity_coherent([0, 0, 0.5 + 0.2j])
-    assert np.allclose(fidelity, 1, atol=0.1, rtol=0)
+    fidelity = state.fidelity_coherent([0, 0, alpha])
+    assert np.allclose(fidelity, 1, atol=0.02, rtol=0)
 
 
 @pytest.mark.backends("gaussian")

--- a/tests/integration/test_algorithms.py
+++ b/tests/integration/test_algorithms.py
@@ -35,8 +35,8 @@ def test_teleportation_fidelity(setup_eng, pure):
         BS | (q[1], q[2])
 
         BS | (q[0], q[1])
-        MeasureHomodyne(0, select=0) | q[0]
-        MeasureHomodyne(np.pi / 2, select=0) | q[1]
+        MeasureHomodyne(0, select=0.07) | q[0]
+        MeasureHomodyne(np.pi / 2, select=0.1) | q[1]
 
     state = eng.run(prog)
     fidelity = state.fidelity_coherent([0, 0, 0.5 + 0.2j])

--- a/tests/integration/test_ops_integration.py
+++ b/tests/integration/test_ops_integration.py
@@ -203,8 +203,8 @@ class TestKetDensityMatrixIntegration:
         """Test exceptions"""
         mu = np.array([0.0, 0.0])
         cov = np.identity(2)
-        state1 = GaussianState((mu, cov), 1, True, hbar)
-        state2 = BaseFockState(np.zeros(cutoff), 1, False, cutoff, hbar)
+        state1 = GaussianState((mu, cov), 1, None, None)
+        state2 = BaseFockState(np.zeros(cutoff), 1, False, cutoff)
 
         eng, prog = setup_eng(2)
 
@@ -227,7 +227,7 @@ class TestKetDensityMatrixIntegration:
         eng.reset()
 
         prog = sf.Program(2)
-        state1 = BaseFockState(ket0, 1, True, cutoff, hbar)
+        state1 = BaseFockState(ket0, 1, True, cutoff)
         with prog.context as q:
             ops.Ket(state1) | q[0]
         state2 = eng.run(prog, modes=[0])
@@ -252,7 +252,7 @@ class TestKetDensityMatrixIntegration:
         eng.reset()
 
         prog = sf.Program(2)
-        state1 = BaseFockState(ket, 2, True, cutoff, hbar)
+        state1 = BaseFockState(ket, 2, True, cutoff)
         with prog.context as q:
             ops.Ket(state1) | q
         state2 = eng.run(prog)
@@ -262,7 +262,7 @@ class TestKetDensityMatrixIntegration:
         """Test exceptions"""
         mu = np.array([0.0, 0.0])
         cov = np.identity(2)
-        state = GaussianState((mu, cov), 1, True, hbar)
+        state = GaussianState((mu, cov), 1, None, None)
 
         eng, prog = setup_eng(2)
 
@@ -285,7 +285,7 @@ class TestKetDensityMatrixIntegration:
         eng.reset()
 
         prog = sf.Program(2)
-        state1 = BaseFockState(rho, 1, False, cutoff, hbar)
+        state1 = BaseFockState(rho, 1, False, cutoff)
         with prog.context as q:
             ops.DensityMatrix(state1) | q[0]
         state2 = eng.run(prog, modes=[0])
@@ -310,7 +310,7 @@ class TestKetDensityMatrixIntegration:
         eng.reset()
 
         prog = sf.Program(2)
-        state1 = BaseFockState(rho, 2, False, cutoff, hbar)
+        state1 = BaseFockState(rho, 2, False, cutoff)
         with prog.context as q:
             ops.DensityMatrix(state1) | q
         state2 = eng.run(prog)


### PR DESCRIPTION
**Description of the Change:**

This PR simplifies the way hbar is handled. Previously many different objects kept track of the hbar value associated with the object data. This enabled practices that are not useful and that could be outright harmful, like combining gates with different hbar values in the same circuit, and made the call interfaces cluttered.

Changes:

* The backend API is now entirely hbar-independent, i.e. every backend API method is defined in terms of `a` and `a^\dagger` only, not x and p.
* The backends always explicitly use hbar=2 internally.
* hbar is now a global, frontend-only variable that the user can set at the beginning of the session. It is used at the `Operation.apply()` level to scale the inputs and outputs of the backend API calls as needed, and inside the `State` objects.
* The only backend API calls that need to do hbar scaling for the input parameters are the X, Z, and V gates, the Gaussian state decomposition, and homodyne measurements (both the returned value and postselection argument are scaled).


**Benefits:**

Makes the code more readable, debuggable and maintainable. Simplifies the UX.

**Possible Drawbacks:**

None as far as I can tell.