### PR TITLE
Add about() and cite() functions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,7 @@ Finally, detailed documentation on the :ref:`Strawberry fields API <code>` is pr
 How to cite
 ===========
 
-If you are doing research using Strawberry Fields, please cite `our paper <https://quantum-journal.org/papers/q-2019-03-11-129/>`_:
+If you are doing research using Strawberry Fields, please cite `our paper <https://quantum-journal.org/papers/q-2019-03-11-129/>`_ :cite:`strawberryfields`:
 
   Nathan Killoran, Josh Izaac, Nicolás Quesada, Ville Bergholm, Matthew Amy, and Christian Weedbrook. "Strawberry Fields: A Software Platform for Photonic Quantum Computing", Quantum, 3, 129 (2019).
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,6 +1,17 @@
 % Literature references for Strawberry Fields.
 % bibtex file for sphinxcontrib-bibtex
 
+@article{strawberryfields,
+  title = {{S}trawberry {F}ields: A Software Platform for Photonic Quantum Computing},
+  author = {Killoran, Nathan and Izaac, Josh and Quesada, Nicol{\'{a}}s and Bergholm, Ville and Amy, Matthew and Weedbrook, Christian},
+  journal = {Quantum},
+  volume = {3},
+  pages = {129},
+  year = {2019},
+  doi = {10.22331/q-2019-03-11-129},
+  archivePrefix = {arXiv},
+  eprint = {1804.03159},
+}
 
 @article{lloyd1998analog,
   doi = {10.1103/physrevlett.80.4088},

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -92,8 +92,8 @@ def about():
     import scipy
 
     # a QuTiP-style infobox
-    print('\nStrawberry Fields: a Python library for continuous variable quantum circuits.')
-    print('Copyright 2019 Xanadu Quantum Technologies Inc.\n')
+    print('\nStrawberry Fields: a Python library for continuous-variable quantum circuits.')
+    print('Copyright 2018-2019 Xanadu Quantum Technologies Inc.\n')
 
     print('Python version:            {}.{}.{}'.format(*sys.version_info[0:3]))
     print('Platform info:             {}'.format(platform.platform()))

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -103,9 +103,10 @@ def about():
     print('Scipy version:             {}'.format(scipy.__version__))
     try:
         import tensorflow
-        print('TensorFlow version:        {}'.format(tensorflow.__version__))
-    except:
-        pass
+        tf_version = tensorflow.__version__
+    except ModuleNotFoundError:
+        tf_version = None
+    print('TensorFlow version:        {}'.format(tf_version))
 
 
 def cite():

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -62,7 +62,11 @@ from .io import save, load
 from .program import Program, _convert as convert
 from ._version import __version__
 
-__all__ = ["Engine", "LocalEngine", "Program", "convert", "version", "save", "load"]
+__all__ = ["Engine", "LocalEngine", "Program", "convert", "version", "save", "load", "about", "cite"]
+
+
+#: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)
+hbar = 2
 
 
 def version():
@@ -75,5 +79,47 @@ def version():
     return __version__
 
 
-#: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)
-hbar = 2
+def about():
+    """About box for Strawberry Fields.
+
+    Prints the installed version numbers for SF and its dependencies,
+    and some system info. Please include this information in bug reports.
+    """
+    import sys
+    import platform
+    import os
+    import numpy
+    import scipy
+
+    # a QuTiP-style infobox
+    print('\nStrawberry Fields: a Python library for continuous variable quantum circuits.')
+    print('Copyright 2019 Xanadu Quantum Technologies Inc.\n')
+
+    print('Python version:            {}.{}.{}'.format(*sys.version_info[0:3]))
+    print('Platform info:             {}'.format(platform.platform()))
+    print('Installation path:         {}'.format(os.path.dirname(__file__)))
+    print('Strawberry Fields version: {}'.format(__version__))
+    print('Numpy version:             {}'.format(numpy.__version__))
+    print('Scipy version:             {}'.format(scipy.__version__))
+    try:
+        import tensorflow
+        print('TensorFlow version:        {}'.format(tensorflow.__version__))
+    except:
+        pass
+
+
+def cite():
+    """Prints a BibTeX citation for Strawberry Fields.
+    """
+    citation = """@article{strawberryfields,
+    title = {{S}trawberry {F}ields: A Software Platform for Photonic Quantum Computing},
+    author = {Killoran, Nathan and Izaac, Josh and Quesada, Nicol{\'{a}}s and Bergholm, Ville and Amy, Matthew and Weedbrook, Christian},
+    journal = {Quantum},
+    volume = {3},
+    pages = {129},
+    year = {2019},
+    doi = {10.22331/q-2019-03-11-129},
+    archivePrefix = {arXiv},
+    eprint = {1804.03159},
+}"""
+    print(citation)

--- a/tests/frontend/test_about.py
+++ b/tests/frontend/test_about.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for top-level Strawberry Fields functions.
+"""
+import strawberryfields as sf
+
+
+def test_about(capfd):
+    """sf.about works."""
+    sf.about()
+    out, err = capfd.readouterr()
+    # substantial output (actual length varies)
+    assert len(err) == 0
+    assert len(out) > 300
+
+
+def test_cite(capfd):
+    """sf.cite works."""
+    sf.cite()
+    out, err = capfd.readouterr()
+    # correct output
+    assert len(err) == 0
+    assert len(out) == 431


### PR DESCRIPTION
**Description of the Change:**

Implements issue #70.

Adds two top-level functions:

* `about()`, which prints human-readable system info including installed versions of various Python packages
* `cite()`, which prints a bibtex citation for SF

I also added the SF citation to the `references.bib` file.

**Benefits:**

Complete, informative bug reports are easier for the users to produce.  Possibly more citations :)