### PR TITLE
Remove TF dependency from Strawberry Fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,18 +49,33 @@ Features
 Installation
 ============
 
-Strawberry Fields requires Python version 3.5 and 3.6 (we are unable to support 3.7 until TensorFlow also supports 3.7). Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
+Strawberry Fields requires Python version 3.5+. Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 
-    $ python -m pip install strawberryfields
+    pip install strawberryfields
 
 
-If you are using the ``tensorflow-gpu`` module for TensorFlow GPU support, you can install the following package for GPU support in Strawberry Fields:
+TensorFlow support
+------------------
 
-.. code-block:: bash
+To use Strawberry Fields with TensorFlow, version 1.3 of
+TensorFlow is required. This can be installed alongside Strawberry Fields
+as follows:
 
-    $ python -m pip install strawberryfields-gpu
+.. code-block:: console
+
+    pip install strawberryfields tensorflow==1.3
+
+Or, to install Strawberry Fields and TensorFlow with GPU and CUDA support:
+
+.. code-block:: console
+
+    pip install strawberryfields tensorflow-gpu==1.3
+
+
+Note that TensorFlow version 1.3 is only supported on Python versions
+less than 3.7.
 
 
 Getting started

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,6 +77,7 @@ mock_fns.update({"pi": MagicMock(),
                  "Number": int,
                  "Tensor": list,
                  "Variable": list,
+                 "__version__": "1.3",
                  "ndarray": MagicMock})
 
 mock = Mock(**mock_fns)

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -63,7 +63,7 @@ Python version:
     python --version
 
 If the above prints out 3.7, and you still want to use TensorFlow, you will need to install Python 3.6.
-The recommended method is to install `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_.
+The recommended method is to install `Anaconda for Python 3 <https://www.anaconda.com/download/>`_.
 
 Once installed, you can then create a Python 3.6 Conda environment:
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -20,38 +20,58 @@ as well as the following Python packages:
 * `NumPy <http://numpy.org/>`_  >=1.13.3
 * `SciPy <http://scipy.org/>`_  >=1.0.0
 * `NetworkX <http://networkx.github.io/>`_ >=2.0
-* `Tensorflow <https://www.tensorflow.org/>`_ >=1.3,<1.7
+* `Blackbird <https://quantum-blackbird.readthedocs.io>`_ >=0.2.0
 
 
 If you currently do not have Python 3 installed, we recommend `Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed version of Python packaged for scientific computation.
-
-.. note::
-
-    As Tensorflow does not currently support Python 3.7 and above, we are unable to
-    also support Strawberry Fields on Python 3.7.
 
 
 Installation
 ============
 
 Installation of Strawberry Fields, as well as all required Python packages mentioned above, can be installed via ``pip``:
-::
 
-    $ python -m pip install strawberryfields
+.. code-block:: console
 
-
-If you are using the ``tensorflow-gpu`` module for TensorFlow GPU support, you can install the following package for GPU support in Strawberry Fields:
-::
-
-    $ python -m pip install strawberryfields-gpu
+    pip install strawberryfields
 
 
-Make sure you are using the Python 3 version of pip.
+TensorFlow support
+==================
 
-Alternatively, you can install Strawberry Fields from the source code by navigating to the top directory and running
-::
+To use Strawberry Fields with TensorFlow, version 1.3 of
+TensorFlow is required. This can be installed alongside Strawberry Fields
+as follows:
 
-    $ python setup.py install
+.. code-block:: console
+
+    pip install strawberryfields tensorflow==1.3
+
+Or, to install Strawberry Fields and TensorFlow with GPU and CUDA support:
+
+.. code-block:: console
+
+    pip install strawberryfields tensorflow-gpu==1.3
+
+
+Note that TensorFlow version 1.3 is only support on Python version
+less than 3.7. You can use the following command to check your
+Python version:
+
+.. code-block:: console
+
+    python --version
+
+If the above prints out 3.7, you will need to install Python 3.6.
+The recommended method is to install `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_.
+
+Once installed, you can then create a Python 3.6 Conda environment:
+
+.. code-block:: console
+
+    conda create --name new_env python=3.6
+    conda activate new_env
+    pip install strawberryfields tensorflow==1.3
 
 
 Notebook downloads

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -54,7 +54,7 @@ Or, to install Strawberry Fields and TensorFlow with GPU and CUDA support:
     pip install strawberryfields tensorflow-gpu==1.3
 
 
-Note that TensorFlow version 1.3 is only support on Python version
+Note that TensorFlow version 1.3 is only supported on Python versions
 less than 3.7. You can use the following command to check your
 Python version:
 
@@ -62,15 +62,15 @@ Python version:
 
     python --version
 
-If the above prints out 3.7, you will need to install Python 3.6.
+If the above prints out 3.7, and you still want to use TensorFlow, you will need to install Python 3.6.
 The recommended method is to install `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_.
 
 Once installed, you can then create a Python 3.6 Conda environment:
 
 .. code-block:: console
 
-    conda create --name new_env python=3.6
-    conda activate new_env
+    conda create --name sf_tensorflow_env python=3.6
+    conda activate sf_tensorflow_env
     pip install strawberryfields tensorflow==1.3
 
 

--- a/examples/gaussian_boson_sampling.py
+++ b/examples/gaussian_boson_sampling.py
@@ -41,4 +41,4 @@ measure_states = [[0,0,0,0], [1,1,0,0], [0,1,0,1], [1,1,1,1], [2,0,0,0]]
 # different Fock states at the output, and print them to the terminal
 for i in measure_states:
     prob = state.fock_prob(i)
-print("|{}>: {}".format("".join(str(j) for j in i), prob))
+    print("|{}>: {}".format("".join(str(j) for j in i), prob))

--- a/examples/gaussian_boson_sampling.py
+++ b/examples/gaussian_boson_sampling.py
@@ -3,8 +3,6 @@ import numpy as np
 import strawberryfields as sf
 from strawberryfields.ops import *
 
-import tensorflow as tf
-
 # initialise the engine and register
 prog = sf.Program(4)
 

--- a/examples/gaussian_boson_sampling.py
+++ b/examples/gaussian_boson_sampling.py
@@ -4,7 +4,7 @@ import strawberryfields as sf
 from strawberryfields.ops import *
 
 # initialise the engine and register
-prog = sf.Program(4)
+eng, q = sf.Engine(4)
 
 # define the linear interferometer
 U = np.array([
@@ -18,7 +18,8 @@ U = np.array([
     -0.421179844245+0.183644837982j, 0.818769184612+0.068015658737j]
 ])
 
-with prog.context as q:
+
+with eng:
     # prepare the input squeezed states
     S = Sgate(1)
     S | q[0]
@@ -31,8 +32,7 @@ with prog.context as q:
     # end circuit
 
 # run the engine
-eng = sf.LocalEngine(backend='gaussian')
-state = eng.run(prog).state
+state = eng.run('gaussian')
 
 # Fock states to measure at output
 measure_states = [[0,0,0,0], [1,1,0,0], [0,1,0,1], [1,1,1,1], [2,0,0,0]]
@@ -41,4 +41,4 @@ measure_states = [[0,0,0,0], [1,1,0,0], [0,1,0,1], [1,1,1,1], [2,0,0,0]]
 # different Fock states at the output, and print them to the terminal
 for i in measure_states:
     prob = state.fock_prob(i)
-    print("|{}>: {}".format("".join(str(j) for j in i), prob))
+print("|{}>: {}".format("".join(str(j) for j in i), prob))

--- a/examples/gaussian_boson_sampling.py
+++ b/examples/gaussian_boson_sampling.py
@@ -3,8 +3,10 @@ import numpy as np
 import strawberryfields as sf
 from strawberryfields.ops import *
 
+import tensorflow as tf
+
 # initialise the engine and register
-eng, q = sf.Engine(4)
+prog = sf.Program(4)
 
 # define the linear interferometer
 U = np.array([
@@ -18,8 +20,7 @@ U = np.array([
     -0.421179844245+0.183644837982j, 0.818769184612+0.068015658737j]
 ])
 
-
-with eng:
+with prog.context as q:
     # prepare the input squeezed states
     S = Sgate(1)
     S | q[0]
@@ -32,7 +33,8 @@ with eng:
     # end circuit
 
 # run the engine
-state = eng.run('gaussian')
+eng = sf.LocalEngine(backend='gaussian')
+state = eng.run(prog).state
 
 # Fock states to measure at output
 measure_states = [[0,0,0,0], [1,1,0,0], [0,1,0,1], [1,1,1,1], [2,0,0,0]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 networkx>=2.0
 numpy>=1.16.3
 scipy>=1.0.0
-tensorflow>=1.3.0,<1.7
+tensorflow==1.3
 tensorflow-tensorboard>=0.1.8
 quantum-blackbird

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ requirements = [
     "numpy>=1.16.3",
     "scipy>=1.0.0",
     "networkx>=2.0",
-    "tensorflow>=1.3.0,<1.7",
     "quantum-blackbird"
 ]
 

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -14,16 +14,20 @@
 """This module loads the required backend classes"""
 
 from .base import BaseBackend, BaseFock, BaseGaussian, ModeMap
-from .tfbackend import TFBackend
 from .gaussianbackend import GaussianBackend
 from .fockbackend import FockBackend
 
-__all__ = ['BaseBackend', 'BaseFock', 'BaseGaussian', 'FockBackend', 'GaussianBackend', 'TFBackend']
+__all__ = [
+    "BaseBackend",
+    "BaseFock",
+    "BaseGaussian",
+    "FockBackend",
+    "GaussianBackend",
+    "TFBackend",
+]
 
-supported_backends = {"base": BaseBackend,
-                      "tf": TFBackend,
-                      "gaussian": GaussianBackend,
-                      "fock": FockBackend}
+supported_backends = {"base": BaseBackend, "gaussian": GaussianBackend, "fock": FockBackend}
+
 
 def load_backend(name):
     """Loads the specified backend by mapping a string
@@ -31,8 +35,15 @@ def load_backend(name):
     dictionary. Note that this function is used by the
     frontend only, and should not be user-facing.
     """
+    if name == "tf":
+        # treat the tensorflow backend differently, to
+        # isolate the import of tensorflow
+        from .tfbackend import TFBackend
+
+        return TFBackend
+
     if name in supported_backends:
         backend = supported_backends[name]()
         return backend
-    else:
-        raise ValueError("Backend '{}' is not supported.".format(name))
+
+    raise ValueError("Backend '{}' is not supported.".format(name))

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -40,7 +40,7 @@ def load_backend(name):
         # isolate the import of tensorflow
         from .tfbackend import TFBackend
 
-        return TFBackend
+        return TFBackend()
 
     if name in supported_backends:
         backend = supported_backends[name]()

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -161,17 +161,21 @@ To use Strawberry Fields with TensorFlow support, version 1.3 of
 TensorFlow is required. This can be installed as follows:
 
 pip install tensorflow==1.3
+"""
+
+
+tf_info_python = """\
+ImportError:
+To use Strawberry Fields with TensorFlow support, version 1.3 of
+TensorFlow is required.
 
 Note that TensorFlow version 1.3 is only supported on Python versions
-less than 3.7. You can use the following command to check your
-Python version:
+less than or equal to 3.6. To continue using TensorFlow with Strawberry Fields,
+you will need to install Python 3.6.
 
-python --version
+The recommended method is to install Anaconda3:
 
-If the above prints out 3.7, and you still want to use TensorFlow, you will need to install Python 3.6.
-The recommended method is to install Miniconda3:
-
-https://docs.conda.io/en/latest/miniconda.html
+https://www.anaconda.com/download
 
 Once installed, you can then create a Python 3.6 Conda environment:
 
@@ -189,4 +193,8 @@ def excepthook(type, value, traceback):
 
 if not (tf_available and tf_version[:3] == "1.3"):
     sys.excepthook = excepthook
+
+    if sys.version_info[1] > 6:
+        raise ImportError(tf_info_python)
+
     raise ImportError(tf_info)

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -141,6 +141,53 @@ Code details
    :members:
 
 """
+import sys
 
 from .backend import TFBackend
 from .ops import def_type as tf_complex_type
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf_available = False
+else:
+    tf_available = True
+    tf_version = tf.__version__
+
+
+tf_info = """\
+ImportError:
+To use Strawberry Fields with TensorFlow support, version 1.3 of
+TensorFlow is required. This can be installed as follows:
+
+pip install tensorflow==1.3
+
+Note that TensorFlow version 1.3 is only support on Python version
+less than 3.7. You can use the following command to check your
+Python version:
+
+python --version
+
+If the above prints out 3.7, you will need to install Python 3.6.
+The recommended method is to install Miniconda3:
+
+https://docs.conda.io/en/latest/miniconda.html
+
+Once installed, you can then create a Python 3.6 Conda environment:
+
+conda create --name new_env python=3.6
+conda activate new_env
+pip install strawberryfields tensorflow==1.3
+"""
+
+
+def excepthook(type, value, traceback):
+    """Exception hook to suppress superfluous exceptions"""
+    print(value)
+
+
+if tf_available and tf_version[:3] == "1.3":
+    import tensorflow as tf
+else:
+    sys.excepthook = excepthook
+    raise ImportError(tf_info)

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -175,8 +175,8 @@ https://www.anaconda.com/download
 
 Once installed, you can then create a Python 3.6 Conda environment:
 
-conda create --name new_env python=3.6
-conda activate new_env
+conda create --name sf_tensorflow_env python=3.6
+conda activate sf_tensorflow_env
 pip install strawberryfields tensorflow==1.3
 """
 

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -148,7 +148,7 @@ from .ops import def_type as tf_complex_type
 
 try:
     import tensorflow as tf
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     tf_available = False
 else:
     tf_available = True

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -143,9 +143,6 @@ Code details
 """
 import sys
 
-from .backend import TFBackend
-from .ops import def_type as tf_complex_type
-
 try:
     import tensorflow as tf
 except (ImportError, ModuleNotFoundError):
@@ -153,6 +150,9 @@ except (ImportError, ModuleNotFoundError):
 else:
     tf_available = True
     tf_version = tf.__version__
+
+from .backend import TFBackend
+from .ops import def_type as tf_complex_type
 
 
 tf_info = """\

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -144,19 +144,16 @@ Code details
 import sys
 
 try:
-    import tensorflow as tf
+    import tensorflow
 except (ImportError, ModuleNotFoundError):
     tf_available = False
+    tf_version = None
 else:
     tf_available = True
-    tf_version = tf.__version__
-
-from .backend import TFBackend
-from .ops import def_type as tf_complex_type
+    tf_version = tensorflow.__version__
 
 
 tf_info = """\
-ImportError:
 To use Strawberry Fields with TensorFlow support, version 1.3 of
 TensorFlow is required. This can be installed as follows:
 
@@ -165,7 +162,6 @@ pip install tensorflow==1.3
 
 
 tf_info_python = """\
-ImportError:
 To use Strawberry Fields with TensorFlow support, version 1.3 of
 TensorFlow is required.
 
@@ -198,3 +194,7 @@ if not (tf_available and tf_version[:3] == "1.3"):
         raise ImportError(tf_info_python)
 
     raise ImportError(tf_info)
+
+
+from .backend import TFBackend
+from .ops import def_type as tf_complex_type

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -162,13 +162,13 @@ TensorFlow is required. This can be installed as follows:
 
 pip install tensorflow==1.3
 
-Note that TensorFlow version 1.3 is only support on Python version
+Note that TensorFlow version 1.3 is only supported on Python versions
 less than 3.7. You can use the following command to check your
 Python version:
 
 python --version
 
-If the above prints out 3.7, you will need to install Python 3.6.
+If the above prints out 3.7, and you still want to use TensorFlow, you will need to install Python 3.6.
 The recommended method is to install Miniconda3:
 
 https://docs.conda.io/en/latest/miniconda.html

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -187,8 +187,6 @@ def excepthook(type, value, traceback):
     print(value)
 
 
-if tf_available and tf_version[:3] == "1.3":
-    import tensorflow as tf
-else:
+if not (tf_available and tf_version[:3] == "1.3"):
     sys.excepthook = excepthook
     raise ImportError(tf_info)

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -183,6 +183,7 @@ pip install strawberryfields tensorflow==1.3
 
 def excepthook(type, value, traceback):
     """Exception hook to suppress superfluous exceptions"""
+    #pylint: disable=unused-argument
     print(value)
 
 

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -90,13 +90,10 @@ Code details
 ~~~~~~~~~~~~
 
 """
-import sys
-import mock
 import numbers
 
+import mock
 import numpy as np
-
-import strawberryfields as sf
 
 from .program import (RegRef, RegRefTransform)
 

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -92,7 +92,7 @@ Code details
 """
 import numbers
 
-import mock
+from unittest import mock
 import numpy as np
 
 from .program import (RegRef, RegRefTransform)

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -90,13 +90,20 @@ Code details
 ~~~~~~~~~~~~
 
 """
-
 import numbers
 
 import numpy as np
 import tensorflow as tf
 
+import strawberryfields as sf
+
 from .program import (RegRef, RegRefTransform)
+
+
+try:
+    import tensorflow as tf
+except ImportError:
+    import numpy as tf # HACK
 
 
 # supported TF classes

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -90,10 +90,11 @@ Code details
 ~~~~~~~~~~~~
 
 """
+import sys
+import mock
 import numbers
 
 import numpy as np
-import tensorflow as tf
 
 import strawberryfields as sf
 
@@ -102,12 +103,10 @@ from .program import (RegRef, RegRefTransform)
 
 try:
     import tensorflow as tf
+    _tf_classes = (tf.Tensor, tf.Variable)
 except ImportError:
-    import numpy as tf # HACK
-
-
-# supported TF classes
-_tf_classes = (tf.Tensor, tf.Variable)
+    tf = mock.MagicMock()
+    _tf_classes = tuple()
 
 
 def _unwrap(params):

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -101,7 +101,7 @@ from .program import (RegRef, RegRefTransform)
 try:
     import tensorflow as tf
     _tf_classes = (tf.Tensor, tf.Variable)
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     tf = mock.MagicMock()
     _tf_classes = tuple()
 

--- a/strawberryfields/utils.py
+++ b/strawberryfields/utils.py
@@ -129,7 +129,11 @@ import collections
 import copy
 from inspect import signature
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except (ImportError, ModuleNotFoundError):
+    tf_available = False
+
 import numpy as np
 from numpy.random import randn
 from numpy.polynomial.hermite import hermval

--- a/tests/backend/test_tf_import.py
+++ b/tests/backend/test_tf_import.py
@@ -1,0 +1,48 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Unit tests for TensorFlow 1.3 version checking"""
+import pytest
+
+
+def test_incorrect_tf_version(monkeypatch):
+    """Test that an exception is raised if the version
+    of TensorFlow installed is not version 1.3"""
+    with monkeypatch.context() as m:
+        # force Python check to pass
+        m.setattr("sys.version_info", (3, 6, 3))
+        m.setattr("tensorflow.__version__", "1.12.2")
+
+        with pytest.raises(ImportError, message="version 1.3 of TensorFlow is required"):
+            from strawberryfields.backends.tfbackend import TFBackend
+
+
+def test_incorrect_python_version(monkeypatch):
+    """Test that an exception is raised if the version
+    of Python installed is > 3.6"""
+    with monkeypatch.context() as m:
+        m.setattr("sys.version_info", (3, 8, 1))
+
+        with pytest.raises(ImportError, message="you will need to install Python 3.6"):
+            from strawberryfields.backends.tfbackend import TFBackend
+
+
+def test_tensorflow_not_installed(monkeypatch):
+    """Test that an exception is raised if TensorFlow is not installed"""
+    with monkeypatch.context() as m:
+        # force Python check to pass
+        m.setattr("sys.version_info", (3, 6, 3))
+        m.delitem("sys.modules", "tensorflow", raising=False)
+
+        with pytest.raises(ImportError, message="version 1.3 of TensorFlow is required"):
+            from strawberryfields.backends.tfbackend import TFBackend

--- a/tests/frontend/test_parameters.py
+++ b/tests/frontend/test_parameters.py
@@ -17,7 +17,6 @@ import pytest
 pytestmark = pytest.mark.frontend
 
 import numpy as np
-import tensorflow as tf
 
 import strawberryfields as sf
 from strawberryfields import ops
@@ -26,15 +25,18 @@ from strawberryfields.parameters import Parameter
 # make test deterministic
 np.random.random(32)
 
-TEST_VALUES = [
-    3,
-    0.14,
-    4.2 + 0.5j,
-    np.random.random(3),
-    tf.Variable(2),
-    tf.Variable(0.4),
-    tf.Variable(0.8 + 1.1j),
-]
+
+TEST_VALUES = [3, 0.14, 4.2 + 0.5j, np.random.random(3)]
+
+
+try:
+    import tensorflow as tf
+except (ImportError, ModuleNotFoundError) as e:
+    tf_available = False
+else:
+    tf_available = True
+    TEST_VALUES.extend([tf.Variable(2), tf.Variable(0.4), tf.Variable(0.8 + 1.1j)])
+
 
 TEST_PARAMETERS = [Parameter(i) for i in TEST_VALUES]
 
@@ -71,6 +73,7 @@ def test_parameter_shape():
     assert res == (2, 3)
 
 
+@pytest.mark.skipif(not tf_available, reason="Test only works with TensorFlow installed")
 def test_parameter_shape_tf():
     """Tests that ensure wrapping occurs as expected"""
     var = np.array([[1, 2, 3], [4, 5, 6]])

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -20,7 +20,8 @@ import numpy as np
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends import BaseGaussian, BaseFock
-from strawberryfields.backends import TFBackend, GaussianBackend, FockBackend
+from strawberryfields.backends import GaussianBackend, FockBackend
+from strawberryfields.backends.tfbackend import TFBackend
 from strawberryfields.backends.states import BaseState
 
 

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -21,8 +21,19 @@ import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends import BaseGaussian, BaseFock
 from strawberryfields.backends import GaussianBackend, FockBackend
-from strawberryfields.backends.tfbackend import TFBackend
 from strawberryfields.backends.states import BaseState
+
+
+try:
+    from strawberryfields.backends.tfbackend import TFBackend
+except (ImportError, ModuleNotFoundError, ValueError) as e:
+    eng_backend_params = [("gaussian", GaussianBackend), ("fock", FockBackend)]
+else:
+    eng_backend_params = [
+        ("tf", TFBackend),
+        ("gaussian", GaussianBackend),
+        ("fock", FockBackend),
+    ]
 
 
 # make test deterministic
@@ -32,10 +43,7 @@ b = -0.543
 c = 0.312
 
 
-@pytest.mark.parametrize(
-    "name,expected",
-    [("tf", TFBackend), ("gaussian", GaussianBackend), ("fock", FockBackend)],
-)
+@pytest.mark.parametrize("name,expected", eng_backend_params)
 def test_load_backend(name, expected, cutoff):
     """Test backends can be correctly loaded via strings"""
     eng = sf.Engine(name)
@@ -76,7 +84,7 @@ class TestEngineReset:
 
         # change the cutoff dimension
         new_cutoff = cutoff + 1
-        eng.reset({'cutoff_dim': new_cutoff})
+        eng.reset({"cutoff_dim": new_cutoff})
 
         state = eng.run(prog).state
         backend_cutoff = eng.backend.get_cutoff_dim()
@@ -162,6 +170,7 @@ class TestProperExecution:
         D = ops.Dgate(0.5)
         BS = ops.BSgate(0.7 * np.pi, np.pi / 2)
         R = ops.Rgate(np.pi / 3)
+
         def subroutine(a, b):
             """Subroutine for the quantum program"""
             R | a
@@ -237,7 +246,6 @@ class TestProperExecution:
         eng.reset()
         # the regrefs are reset as well
         assert np.all([r.val is None for r in prog.register])
-
 
     def test_empty_program(self, setup_eng):
         """Empty programs do not change the state of the backend."""

--- a/tests/integration/test_parameters_integration.py
+++ b/tests/integration/test_parameters_integration.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.parameters import Parameter
+from strawberryfields.backends.tfbackend import TFBackend
 
 
 # TODO: skipping tf test here for now.
@@ -62,7 +63,7 @@ def test_parameters_with_operations(batch_size, setup_eng, backend, hbar):
 
     # other types of parameters
     other_inputs = [0.14]
-    if isinstance(eng.backend, sf.backends.TFBackend):
+    if isinstance(eng.backend, TFBackend):
         # HACK: add placeholders for tf.Variables
         other_inputs.append(np.inf)
         if batch_size is not None:
@@ -137,7 +138,7 @@ def test_parameters_with_operations(batch_size, setup_eng, backend, hbar):
             if isinstance(p[0].x, ops.RR):
                 continue
 
-            if isinstance(eng.backend, sf.backends.TFBackend):
+            if isinstance(eng.backend, TFBackend):
                 # declare tensorflow Variables here (otherwise they will be on a different graph when we do backend.reset below)
                 # replace placeholders with tf.Variable instances
                 def f(q):

--- a/tests/integration/test_parameters_integration.py
+++ b/tests/integration/test_parameters_integration.py
@@ -20,15 +20,17 @@ import logging
 import pytest
 
 import numpy as np
-import tensorflow as tf
+# import tensorflow as tf
 
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.parameters import Parameter
-from strawberryfields.backends.tfbackend import TFBackend
+# from strawberryfields.backends.tfbackend import TFBackend
+
+TFBackend = int # hack to avoid removing TFBackend from test
 
 
-# TODO: skipping tf test here for now.
+# TODO: broken for TensorFlow. Skipping tf test here for now.
 @pytest.mark.backends("fock")
 def test_parameters_with_operations(batch_size, setup_eng, backend, hbar):
     """Test using different types of Parameters with different classes

--- a/tests/integration/test_tf_symbolic.py
+++ b/tests/integration/test_tf_symbolic.py
@@ -23,9 +23,17 @@ pytestmark = pytest.mark.backends("tf")
 
 import numpy as np
 from scipy.special import factorial
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except (ImportError, ModuleNotFoundError):
+    pytestmark = pytest.mark.skip("TensorFlow not installed")
+else:
+    if tf.__version__[:3] != "1.3":
+        pytestmark = pytest.mark.skip("Test only runs with TensorFlow 1.3")
 
 from strawberryfields.ops import Dgate, MeasureX
+
 
 ALPHA = 0.5
 evalf = {'eval': False}

--- a/tests/integration/test_utils_integration.py
+++ b/tests/integration/test_utils_integration.py
@@ -15,7 +15,13 @@ r"""Integration tests for the utils.py module"""
 import pytest
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except (ImportError, ModuleNotFoundError) as e:
+    import mock
+    tf = mock.MagicMock()
+    tf.Tensor = int
 
 import strawberryfields as sf
 import strawberryfields.ops as ops


### PR DESCRIPTION
**Description of the Change:**

* Removes TF from `setup.py` (it is install in requirements.txt for our continuous integration).

* Adds a try-except for tensorflow import in `parameters.py`. If there is an `ImportError`, the module `tf` is simply mocked out.

* Added TensorFlow import logic and a useful exception message to the `TFBackend`, that checks whether TensorFlow is installed and is the correct version. If not, information is given to the user on how to install SF with TensorFlow support.

**Benefits:**

* Strawberry Fields will now install and run correctly without TensorFlow dependence. The exception message above will only be triggered if the user specifically requests the `'tf'` backend.

**Possible Drawbacks:**

* This is a stopgap solution; at some point, we should aim to spin the TF simulator to its own package.

**Related GitHub Issues:** n/a
