### PR TITLE
New_modes bugfix.

### DIFF
--- a/strawberryfields/devicespecs/base.py
+++ b/strawberryfields/devicespecs/base.py
@@ -28,8 +28,8 @@ class BaseSpecs(DeviceSpecs):
     primitives = {
         # meta operations
         "All",
-        "New_modes",
-        "Delete",
+        "_New_modes",
+        "_Delete",
         # state preparations
         "Vacuum",
         "Coherent",

--- a/strawberryfields/devicespecs/fock.py
+++ b/strawberryfields/devicespecs/fock.py
@@ -26,8 +26,8 @@ class FockSpecs(DeviceSpecs):
     primitives = {
         # meta operations
         "All",
-        "New_modes",
-        "Delete",
+        "_New_modes",
+        "_Delete",
         # state preparations
         "Vacuum",
         "Coherent",

--- a/strawberryfields/devicespecs/gaussian.py
+++ b/strawberryfields/devicespecs/gaussian.py
@@ -26,8 +26,8 @@ class GaussianSpecs(DeviceSpecs):
     primitives = {
         # meta operations
         "All",
-        "New_modes",
-        "Delete",
+        "_New_modes",
+        "_Delete",
         # state preparations
         "Vacuum",
         "Coherent",

--- a/strawberryfields/devicespecs/tensorflow.py
+++ b/strawberryfields/devicespecs/tensorflow.py
@@ -26,8 +26,8 @@ class TFSpecs(DeviceSpecs):
     primitives = {
         # meta operations
         "All",
-        "New_modes",
-        "Delete",
+        "_New_modes",
+        "_Delete",
         # state preparations
         "Vacuum",
         "Coherent",

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -110,10 +110,9 @@ There are six kinds of :class:`Operation` objects:
         Dgate(RR(q[0])) | q[1]
         Dgate(RR(q[0], lambda q: q ** 2)) | q[2]
 
-* Meta-operations such as :class:`Delete` and :class:`New_modes` delete
-  and create modes during program execution.
-  In practice the user only deals with the pre-constructed
-  instance :py:data:`Del` and the function :func:`New`::
+* Modes can be created and deleted during program execution using the
+  function :func:`New` and the pre-constructed object :py:data:`Del`.
+  Behind the scenes they utilize the meta-operations :class:`_New_modes` and :class:`_Delete`::
 
     with prog.context as (alice,):
         Sgate(1)    | alice
@@ -241,8 +240,8 @@ Meta-operations
 
 .. autosummary::
    All
-   New_modes
-   Delete
+   _New_modes
+   _Delete
 
 
 Operations shortcuts
@@ -263,8 +262,8 @@ this is to provide shorthands for operations that accept no arguments, as well a
 
 ======================   =================================================================================
 **Shorthand variable**   **Operation**
-``New``                  :class:`~.New_modes`
-``Del``                  :class:`~.Delete`
+``New``                  :class:`~._New_modes`
+``Del``                  :class:`~._Delete`
 ``Vac``                  :class:`~.Vacuum`
 ``Fourier``              :class:`~.Fouriergate`
 ``Measure``              :class:`~.MeasureFock`
@@ -1504,7 +1503,7 @@ class MetaOperation(Operation):
         super().__init__(par=[])
 
 
-class Delete(MetaOperation):
+class _Delete(MetaOperation):
     """Deletes one or more existing modes.
     Also accessible via the shortcut variable ``Del``.
 
@@ -1540,11 +1539,11 @@ def New(n=1):
     # create RegRefs for the new modes
     refs = Program._current_context._add_subsystems(n)
     # append the actual Operation to the Program
-    Program._current_context.append(New_modes(n), refs)
+    Program._current_context.append(_New_modes(n), refs)
     return refs
 
 
-class New_modes(MetaOperation):
+class _New_modes(MetaOperation):
     """Used internally for adding new modes to the system in a deferred way.
 
     This class cannot be used with the :meth:`__or__` syntax since it would be misleading.
@@ -1898,7 +1897,7 @@ class Gaussian(Preparation, Decomposition):
 #=======================================================================
 # Shorthands, e.g. pre-constructed singleton-like objects
 
-Del = Delete()
+Del = _Delete()
 Vac = Vacuum()
 Measure = MeasureFock()
 MeasureX = MeasureHomodyne(0)

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -110,10 +110,10 @@ There are six kinds of :class:`Operation` objects:
         Dgate(RR(q[0])) | q[1]
         Dgate(RR(q[0], lambda q: q ** 2)) | q[2]
 
-* Meta-operations such as :class:`Delete` and :class:`New_modes` Operations delete
+* Meta-operations such as :class:`Delete` and :class:`New_modes` delete
   and create modes during program execution.
   In practice the user only deals with the pre-constructed
-  instances :py:data:`Del` and :py:data:`New`::
+  instance :py:data:`Del` and the function :func:`New`::
 
     with prog.context as (alice,):
         Sgate(1)    | alice
@@ -1525,33 +1525,40 @@ class Delete(MetaOperation):
         return 'Del'
 
 
+def New(n=1):
+    """Adds new subsystems to the quantum register.
+
+    The new modes are prepared in the vacuum state.
+
+    Must only be called in a :class:`Program` context.
+
+    Args:
+        n (int): number of subsystems to add
+    Returns:
+        tuple[RegRef]: tuple of the newly added subsystem references
+    """
+    # create RegRefs for the new modes
+    refs = Program._current_context._add_subsystems(n)
+    # append the actual Operation to the Program
+    Program._current_context.append(New_modes(n), refs)
+    return refs
+
+
 class New_modes(MetaOperation):
-    """Used for adding new modes to the system.
-    Also accessible via the shortcut variable ``New``.
+    """Used internally for adding new modes to the system in a deferred way.
 
-    The new modes are prepapred in the vacuum state.
-
-    This class cannot be used with the :meth:`__or__` syntax since it would be misleading,
-    instead we use :meth:`__call__` on a single instance to dispatch the command to the :class:`.Program`.
+    This class cannot be used with the :meth:`__or__` syntax since it would be misleading.
+    Indeed, users should *not* use this class directly, but rather the function :func:`New`.
     """
     ns = 0
 
-    def __call__(self, n=1):
-        """Adds one or more new modes to the system in a deferred way.
-
-        Appends the operation to a :class:`.Program` instance.
-
-        Args:
-            n (int): number of modes added
+    def __init__(self, n=1):
         """
-        # FIXME there is just a single instance, hence instance attributes may be overwritten!
-        # pylint: disable=attribute-defined-outside-init
+        Args:
+            n (int): number of modes to add
+        """
+        super().__init__()
         self.n = n  # int: store the number of new modes for the __str__ method
-        # create RegRef placeholders for the new modes
-        refs = Program._current_context._add_subsystems(n)
-        # append the actual creation command to the program
-        Program._current_context.append(self, refs)
-        return refs
 
     def _apply(self, reg, backend, **kwargs):
         # pylint: disable=unused-variable
@@ -1891,7 +1898,6 @@ class Gaussian(Preparation, Decomposition):
 #=======================================================================
 # Shorthands, e.g. pre-constructed singleton-like objects
 
-New = New_modes()
 Del = Delete()
 Vac = Vacuum()
 Measure = MeasureFock()

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -539,8 +539,8 @@ class Program:
         """Create new subsystem references, add them to the reg_ref dictionary.
 
         To avoid discrepancies with the backend this method must not be called directly,
-        but rather indirectly by using :class:`~strawberryfields.ops.New_modes`
-        instances in the Program context.
+        but rather indirectly by using :func:`~strawberryfields.ops.New`
+        in a Program context.
 
         .. note:: This is the only place where :class:`RegRef` instances are constructed.
 

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -566,7 +566,7 @@ class Program:
         """Delete existing subsystem references.
 
         To avoid discrepancies with the backend this method must not be called directly,
-        but rather indirectly by using :class:`~strawberryfields.ops.Delete` instances
+        but rather indirectly by using :class:`~strawberryfields.ops._Delete` instances
         in the Program context.
 
         Args:

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -81,17 +81,17 @@ class TestProgramGateInteraction:
         assert prog.circuit[1].reg[1].ind == 2
 
     def test_create_or_exception(self):
-        """New must not be called via its __or__ method"""
+        """New_modes must not be called via its __or__ method"""
         with pytest.raises(ValueError):
-            ops.New.__or__(0)
+            ops.New_modes(1).__or__(0)
 
     def test_create_non_positive_integer(self, prog):
         """number of new modes must be a positive integer"""
         with pytest.raises(ValueError):
-            ops.New.__call__(-2)
+            ops.New(-2)
 
         with pytest.raises(ValueError):
-            ops.New.__call__(1.5)
+            ops.New(1.5)
 
     def test_delete_not_existing(self, prog):
         """deleting nonexistent modes not allowed"""

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -81,9 +81,9 @@ class TestProgramGateInteraction:
         assert prog.circuit[1].reg[1].ind == 2
 
     def test_create_or_exception(self):
-        """New_modes must not be called via its __or__ method"""
+        """_New_modes must not be called via its __or__ method"""
         with pytest.raises(ValueError):
-            ops.New_modes(1).__or__(0)
+            ops._New_modes(1).__or__(0)
 
     def test_create_non_positive_integer(self, prog):
         """number of new modes must be a positive integer"""


### PR DESCRIPTION
**Description of the Change:**

Replaces the `ops.New` singleton object with a similarly named function that creates a `New_modes` instance and appends it to the `Program`.

**Benefits:**

Previously, since there was just a single object, the `New_modes.n` instance variable would be overwritten each time `New.__call__` was called. `New_modes.n` is currently only used by `New_modes.__str__`, which is why this bug escaped notice.

This should be a drop-in replacement.