### PR TITLE
Adds a Program context check to ops.New(). Updates related tests.

### DIFF
--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1536,6 +1536,8 @@ def New(n=1):
     Returns:
         tuple[RegRef]: tuple of the newly added subsystem references
     """
+    if Program._current_context is None:
+        raise RuntimeError('New() can only be called inside a Program context.')
     # create RegRefs for the new modes
     refs = Program._current_context._add_subsystems(n)
     # append the actual Operation to the Program

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -82,20 +82,24 @@ class TestProgramGateInteraction:
 
     def test_create_or_exception(self):
         """_New_modes must not be called via its __or__ method"""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Wrong number of subsystems'):
             ops._New_modes(1).__or__(0)
+
+    def test_create_outside_program_context(self):
+        """New() must be only called inside a Program context."""
+        with pytest.raises(RuntimeError, match='can only be called inside a Program context'):
+            ops.New()
 
     def test_create_non_positive_integer(self, prog):
         """number of new modes must be a positive integer"""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='is not a positive integer'):
             ops.New(-2)
-
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='is not a positive integer'):
             ops.New(1.5)
 
     def test_delete_not_existing(self, prog):
         """deleting nonexistent modes not allowed"""
-        with pytest.raises(RegRefError):
+        with pytest.raises(RegRefError, match='does not exist'):
             ops.Del.__or__(100)
 
     def test_delete(self, prog):
@@ -119,7 +123,7 @@ class TestProgramGateInteraction:
         """deleting a mode that was already deleted"""
         q = prog.register
         ops.Del | q[1]
-        with pytest.raises(RegRefError):
+        with pytest.raises(RegRefError, match='has already been deleted'):
             ops.Del.__or__(1)
 
     def test_create_delete_multiple_modes(self):


### PR DESCRIPTION
**Description of the Change:**

Now `ops.New()` raises an exception if it is called outside a Program context, instead of just failing with a cryptic error message.

Also improved some related tests.