### PR TITLE
Configuration file for Strawberry Fields

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -1,0 +1,12 @@
+## =================================================================
+##      STRAWBERRY FIELDS API CONFIGURATION OPTIONS
+## =================================================================
+
+[api]
+# Options for the Strawberry Fields Cloud API
+# Fill in your authentication
+authentatication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
+# Fill in the hostname of the Cloud API
+hostname = "localhost"
+# Whether Strawberry Fields should use SSL to connect to the API
+use_ssl = true

--- a/default_config.toml
+++ b/default_config.toml
@@ -5,7 +5,7 @@
 [api]
 # Options for the Strawberry Fields Cloud API
 # Fill in your authentication
-authentatication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
+authentatication_token = None # example token form: 071cdcce-9241-4965-93af-4a4dbc739135
 # Fill in the hostname of the Cloud API
 hostname = "localhost"
 # Whether Strawberry Fields should use SSL to connect to the API

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ scipy>=1.0.0
 tensorflow==1.3
 tensorflow-tensorboard>=0.1.8
 quantum-blackbird
+toml
+user_config_dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ tensorflow==1.3
 tensorflow-tensorboard>=0.1.8
 quantum-blackbird
 toml
-user_config_dir
+appdirs

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ requirements = [
     "numpy>=1.16.3",
     "scipy>=1.0.0",
     "networkx>=2.0",
-    "quantum-blackbird>=0.2.0"
+    "quantum-blackbird>=0.2.0",
+    "toml",
+    "appdirs"
 ]
 
 # extra_requirements = [

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -174,7 +174,7 @@ class Configuration:
         """Load a configuration file.
 
         Args:
-            filepath (str): path to the configuration file.
+            filepath (str): path to the configuration file
         """
         with open(filepath, "r") as f:
             self._config_file = toml.load(f)
@@ -183,7 +183,7 @@ class Configuration:
         """Save a configuration file.
 
         Args:
-            filepath (str): path to the configuration file.
+            filepath (str): path to the configuration file
         """
         with open(filepath, "w") as f:
             toml.dump(self._config, f)

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -23,7 +23,7 @@ This module contains the :class:`Configuration` class, which is used to
 load, store, save, and modify configuration options for Strawberry Fields.
 
 Behaviour
----------
+--------
 
 On first import, Strawberry Fields attempts to load the configuration file `config.toml`, by
 scanning the following three directories in order of preference:

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -52,7 +52,7 @@ and has the following format:
 
 .. code-block:: toml
 
-    [API]
+    [api]
     # Options for the Strawberry Fields Cloud API
     authentatication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
     hostname = "localhost"
@@ -113,7 +113,7 @@ class Configuration:
     def __repr__(self):
         return "Strawberry Fields Configuration <{}>".format(self._filepath)
 
-    def __init__(self, name):
+    def __init__(self, name="config.toml"):
         # Look for an existing configuration file
         self._config = DEFAULT_CONFIG
         self._config_file = {}
@@ -142,10 +142,10 @@ class Configuration:
 
         The environment variable takes precedence."""
         for section, section_config in self._config.items():
-            env_prefix = "SF_" + section.upper()
+            env_prefix = "SF_{}_".format(section.upper())
 
             for key, value in section_config.items():
-                # environment variables take precendence
+                # environment variables take precedence
                 env = env_prefix + key.upper()
                 if env in os.environ:
                     self._config[section][key] = os.environ[env]
@@ -160,7 +160,7 @@ class Configuration:
         if key in self._config:
             return self._config[key]
 
-        raise ConfigurationError("Unkown Strawberry Fields configuration section.")
+        raise ConfigurationError("Unknown Strawberry Fields configuration section.")
 
     @property
     def path(self):

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -126,16 +126,16 @@ class Configuration:
         # variable SF_CONF, and default user config directory, in that order.
         directories = [os.getcwd(), self._env_config_dir, self._user_config_dir]
         for idx, directory in enumerate(directories):
+            self._filepath = os.path.join(directory, self._name)
             try:
-                self._filepath = os.path.join(directory, self._name)
                 self.load(self._filepath)
-                break
             except FileNotFoundError:
                 # check if we have searched all directories
                 if idx == len(directories) - 1:
                     log.info("No Strawberry Fields configuration file found.")
-
-        self.update_config()
+            else:
+                self.update_config()
+                break
 
     def update_config(self):
         """Updates the configuration from either a loaded configuration

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -144,7 +144,7 @@ class Configuration:
         for section, section_config in self._config.items():
             env_prefix = "SF_{}_".format(section.upper())
 
-            for key, value in section_config.items():
+            for key, _ in section_config.items():
                 # environment variables take precedence
                 env = env_prefix + key.upper()
                 if env in os.environ:

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -142,11 +142,11 @@ class Configuration:
 
         The environment variable takes precedence."""
         for section, section_config in self._config.items():
-            env_prefix = "SF_" + section
+            env_prefix = "SF_" + section.upper()
 
             for key, value in section_config.items():
                 # environment variables take precendence
-                env = env_prefix + key
+                env = env_prefix + key.upper()
                 if env in os.environ:
                     self._config[section][key] = os.environ[env]
                     continue

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -127,15 +127,12 @@ class Configuration:
         directories = [os.getcwd(), self._env_config_dir, self._user_config_dir]
         for directory in directories:
             self._filepath = os.path.join(directory, self._name)
-            try:
-                config = self.load(self._filepath)
+            config = self.load(self._filepath)
+            if config:
+                self.update_config()
                 break
-            except FileNotFoundError:
-                pass
 
-        if config:
-            self.update_config()
-        else:
+        if config is None:
             log.info("No Strawberry Fields configuration file found.")
 
     def update_config(self):
@@ -177,9 +174,12 @@ class Configuration:
         Args:
             filepath (str): path to the configuration file
         """
-        with open(filepath, "r") as f:
-            self._config_file = toml.load(f)
-        return self._config_file
+        try:
+            with open(filepath, "r") as f:
+                self._config_file = toml.load(f)
+            return self._config_file
+        except FileNotFoundError:
+            return None
 
     def save(self, filepath):
         """Save a configuration file.

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -122,7 +122,7 @@ class Configuration:
         self._user_config_dir = user_config_dir("strawberryfields", "Xanadu")
         self._env_config_dir = os.environ.get("SF_CONF", "")
 
-        # search the current directory, the directory under environment
+        # Search the current directory, the directory under environment
         # variable SF_CONF, and default user config directory, in that order.
         directories = [os.curdir, self._env_config_dir, self._user_config_dir, ""]
         for idx, directory in enumerate(directories):
@@ -131,6 +131,7 @@ class Configuration:
                 self.load(self._filepath)
                 break
             except FileNotFoundError:
+                # check if we have searched all directories
                 if idx == len(directories) - 1:
                     log.info("No Strawberry Fields configuration file found.")
 
@@ -144,21 +145,20 @@ class Configuration:
         for section, section_config in self._config.items():
             env_prefix = "SF_{}_".format(section.upper())
 
-            for key, _ in section_config.items():
-                # environment variables take precedence
+            for key in section_config:
+                # Environment variables take precedence
                 env = env_prefix + key.upper()
-                if env in os.environ:
-                    self._config[section][key] = os.environ[env]
-                    continue
 
-                # check if a configuration file exists
-                if self._config_file:
-                    # update from configuration file
+                if env in os.environ:
+                    # Update from environment variable
+                    self._config[section][key] = os.environ[env]
+                elif self._config_file:
+                    # Update from configuration file
                     self._config[section][key] = self._config_file[section][key]
 
-    def __getattr__(self, key):
-        if key in self._config:
-            return self._config[key]
+    def __getattr__(self, section):
+        if section in self._config:
+            return self._config[section]
 
         raise ConfigurationError("Unknown Strawberry Fields configuration section.")
 

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -124,7 +124,7 @@ class Configuration:
 
         # Search the current directory, the directory under environment
         # variable SF_CONF, and default user config directory, in that order.
-        directories = [os.curdir, self._env_config_dir, self._user_config_dir, ""]
+        directories = [os.getcwd(), self._env_config_dir, self._user_config_dir]
         for idx, directory in enumerate(directories):
             try:
                 self._filepath = os.path.join(directory, self._name)

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -1,0 +1,189 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Configuration
+=============
+
+**Module name:** :mod:`strawberryfields.configuration`
+
+.. currentmodule:: strawberryfields.configuration
+
+This module contains the :class:`Configuration` class, which is used to
+load, store, save, and modify configuration options for Strawberry Fields.
+
+Behaviour
+---------
+
+On first import, Strawberry Fields attempts to load the configuration file `config.toml`, by
+scanning the following three directories in order of preference:
+
+1. The current directory
+2. The path stored in the environment variable ``SF_CONF``
+3. The default user configuration directory:
+
+   * On Linux: ``~/.config/strawberryfields``
+   * On Windows: ``~C:\Users\USERNAME\AppData\Local\Xanadu\strawberryfields``
+   * On MacOS: ``~/Library/Preferences/strawberryfields``
+
+If no configuration file is found, a warning message will be displayed in the logs,
+and all device parameters will need to be passed as keyword arguments when
+loading the device.
+
+The user can access the initialized configuration via `strawberryfields.config`, view the
+loaded configuration filepath, print the configurations options, access and modify
+them via keys, and save/load new configuration files.
+
+Configuration files
+-------------------
+
+The configuration file `config.toml` uses the `TOML standard <https://github.com/toml-lang/toml>`_,
+and has the following format:
+
+.. code-block:: toml
+
+    [API]
+    # Options for the Strawberry Fields Cloud API
+    authentatication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
+    hostname = "localhost"
+    use_ssl = true
+
+Summary of options
+------------------
+
+todo
+
+Summary of methods
+------------------
+
+.. currentmodule:: strawberryfields.configuration.Configuration
+
+.. autosummary::
+    path
+    load
+    save
+
+Code details
+~~~~~~~~~~~~
+
+.. currentmodule:: strawberryfields.configuration
+
+"""
+import os
+import logging as log
+
+import toml
+from appdirs import user_config_dir
+
+log.getLogger()
+
+
+DEFAULT_CONFIG = {"api": {"authentatication_token": "", "hostname": "localhost", "use_ssl": True}}
+
+
+class ConfigurationError(Exception):
+    """Exception used for configuration errors"""
+
+
+class Configuration:
+    """Configuration class.
+
+    This class is responsible for loading, saving, and storing StrawberryFields
+    and plugin/device configurations.
+
+    Args:
+        name (str): filename of the configuration file.
+        This should be a valid TOML file. You may also pass an absolute
+        or a relative file path to the configuration file.
+    """
+
+    def __str__(self):
+        return "{}".format(self._config)
+
+    def __repr__(self):
+        return "Strawberry Fields Configuration <{}>".format(self._filepath)
+
+    def __init__(self, name):
+        # Look for an existing configuration file
+        self._config = DEFAULT_CONFIG
+        self._config_file = {}
+        self._filepath = None
+        self._name = name
+        self._user_config_dir = user_config_dir("strawberryfields", "Xanadu")
+        self._env_config_dir = os.environ.get("SF_CONF", "")
+
+        # search the current directory, the directory under environment
+        # variable SF_CONF, and default user config directory, in that order.
+        directories = [os.curdir, self._env_config_dir, self._user_config_dir, ""]
+        for idx, directory in enumerate(directories):
+            try:
+                self._filepath = os.path.join(directory, self._name)
+                self.load(self._filepath)
+                break
+            except FileNotFoundError:
+                if idx == len(directories) - 1:
+                    log.info("No Strawberry Fields configuration file found.")
+
+        self.update_config()
+
+    def update_config(self):
+        """Updates the configuration from either a loaded configuration
+        file, or from an environment variable.
+
+        The environment variable takes precedence."""
+        for section, section_config in self._config.items():
+            env_prefix = "SF_" + section
+
+            for key, value in section_config.items():
+                # environment variables take precendence
+                env = env_prefix + key
+                if env in os.environ:
+                    self._config[section][key] = os.environ[env]
+                    continue
+
+                # check if a configuration file exists
+                if self._config_file:
+                    # update from configuration file
+                    self._config[section][key] = self._config_file[section][key]
+
+    def __getattr__(self, key):
+        if key in self._config:
+            return self._config[key]
+
+        raise ConfigurationError("Unkown Strawberry Fields configuration section.")
+
+    @property
+    def path(self):
+        """Return the path of the loaded configuration file.
+
+        Returns:
+            str: If no configuration is loaded, this returns ``None``."""
+        return self._filepath
+
+    def load(self, filepath):
+        """Load a configuration file.
+
+        Args:
+            filepath (str): path to the configuration file.
+        """
+        with open(filepath, "r") as f:
+            self._config_file = toml.load(f)
+
+    def save(self, filepath):
+        """Save a configuration file.
+
+        Args:
+            filepath (str): path to the configuration file.
+        """
+        with open(filepath, "w") as f:
+            toml.dump(self._config, f)

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -125,13 +125,13 @@ class Configuration:
         # Search the current directory, the directory under environment
         # variable SF_CONF, and default user config directory, in that order.
         directories = [os.getcwd(), self._env_config_dir, self._user_config_dir]
-        for idx, directory in enumerate(directories):
+        for directory in directories:
             self._filepath = os.path.join(directory, self._name)
             try:
                 self.load(self._filepath)
             except FileNotFoundError:
-                # check if we have searched all directories
-                if idx == len(directories) - 1:
+                # Check if we have searched all directories
+                if directory == directories[-1]:
                     log.info("No Strawberry Fields configuration file found.")
             else:
                 self.update_config()

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -128,14 +128,15 @@ class Configuration:
         for directory in directories:
             self._filepath = os.path.join(directory, self._name)
             try:
-                self.load(self._filepath)
-            except FileNotFoundError:
-                # Check if we have searched all directories
-                if directory == directories[-1]:
-                    log.info("No Strawberry Fields configuration file found.")
-            else:
-                self.update_config()
+                config = self.load(self._filepath)
                 break
+            except FileNotFoundError:
+                pass
+
+        if config:
+            self.update_config()
+        else:
+            log.info("No Strawberry Fields configuration file found.")
 
     def update_config(self):
         """Updates the configuration from either a loaded configuration
@@ -178,6 +179,7 @@ class Configuration:
         """
         with open(filepath, "r") as f:
             self._config_file = toml.load(f)
+        return self._config_file
 
     def save(self, filepath):
         """Save a configuration file.

--- a/tests/frontend/test_about.py
+++ b/tests/frontend/test_about.py
@@ -14,7 +14,12 @@
 """
 Unit tests for top-level Strawberry Fields functions.
 """
+import pytest
+
 import strawberryfields as sf
+
+
+pytestmark = pytest.mark.frontend
 
 
 def test_about(capfd):

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -100,7 +100,7 @@ class TestConfiguration:
         config = conf.Configuration()
 
         # make a change
-        config._config['api']['hostname'] = "https://6.4.2.4"
+        config._config["api"]["hostname"] = "https://6.4.2.4"
         config.save(filename)
 
         result = toml.load(filename)
@@ -109,12 +109,14 @@ class TestConfiguration:
     def test_attribute_loading(self):
         """Test attributes automatically get the correct section key"""
         config = conf.Configuration()
-        assert config.api == config._config['api']
+        assert config.api == config._config["api"]
 
     def test_failed_attribute_loading(self):
         """Test an exception is raised if key does not exist"""
         config = conf.Configuration()
-        with pytest.raises(conf.ConfigurationError, match="Unknown"):
+        with pytest.raises(
+            conf.ConfigurationError, match="Unknown Strawberry Fields configuration section"
+        ):
             config.test
 
     def test_env_vars_take_precedence(self, tmpdir):

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -100,7 +100,7 @@ class TestConfiguration:
         config = conf.Configuration()
 
         # make a change
-        config._config['api']['hostname'] = "https:/6.4.2.4"
+        config._config['api']['hostname'] = "https://6.4.2.4"
         config.save(filename)
 
         result = toml.load(filename)

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -53,7 +53,7 @@ class TestConfiguration:
             f.write(TEST_FILE)
 
         with monkeypatch.context() as m:
-            m.setattr(os, "curdir", str(tmpdir))
+            m.setattr(os, "getcwd", lambda: str(tmpdir))
             os.environ["SF_CONF"] = ""
             config = conf.Configuration()
 

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -1,0 +1,134 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the configuration module"""
+import os
+import logging
+import pytest
+
+import toml
+
+from strawberryfields import configuration as conf
+
+pytestmark = pytest.mark.frontend
+logging.getLogger().setLevel(1)
+
+
+TEST_FILE = """\
+[api]
+# Options for the Strawberry Fields Cloud API
+authentatication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
+hostname = "localhost"
+use_ssl = true
+"""
+
+EXPECTED_CONFIG = {
+    "api": {
+        "authentatication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
+        "hostname": "localhost",
+        "use_ssl": True,
+    }
+}
+
+
+class TestConfiguration:
+    """Tests for the configuration class"""
+
+    def test_loading_current_directory(self, tmpdir, monkeypatch):
+        """Test that the default configuration file can be loaded
+        from the current directory."""
+        filename = tmpdir.join("config.toml")
+
+        with open(filename, "w") as f:
+            f.write(TEST_FILE)
+
+        with monkeypatch.context() as m:
+            m.setattr(os, "curdir", str(tmpdir))
+            os.environ["SF_CONF"] = ""
+            config = conf.Configuration()
+
+        assert config._config == EXPECTED_CONFIG
+        assert config.path == filename
+
+    def test_loading_env_variable(self, tmpdir):
+        """Test that the default configuration file can be loaded
+        via an environment variable."""
+        filename = tmpdir.join("config.toml")
+
+        with open(filename, "w") as f:
+            f.write(TEST_FILE)
+
+        os.environ["SF_CONF"] = str(tmpdir)
+        config = conf.Configuration()
+
+        assert config._config == EXPECTED_CONFIG
+        assert config.path == filename
+
+    def test_loading_absolute_path(self, tmpdir, monkeypatch):
+        """Test that the default configuration file can be loaded
+        via an absolute path."""
+        filename = os.path.abspath(tmpdir.join("config.toml"))
+
+        with open(filename, "w") as f:
+            f.write(TEST_FILE)
+
+        os.environ["SF_CONF"] = ""
+        config = conf.Configuration(name=str(filename))
+
+        assert config._config == EXPECTED_CONFIG
+        assert config.path == filename
+
+    def test_not_found_warning(self, caplog):
+        """Test that a warning is raised if no configuration file found."""
+
+        conf.Configuration(name="noconfig")
+        assert "No Strawberry Fields configuration file found." in caplog.text
+
+    def test_save(self, tmpdir):
+        """Test saving a configuration file."""
+        filename = str(tmpdir.join("test_config.toml"))
+        config = conf.Configuration()
+
+        # make a change
+        config._config['api']['hostname'] = "https:/6.4.2.4"
+        config.save(filename)
+
+        result = toml.load(filename)
+        assert config._config == result
+
+    def test_attribute_loading(self):
+        """Test attributes automatically get the correct section key"""
+        config = conf.Configuration()
+        assert config.api == config._config['api']
+
+    def test_failed_attribute_loading(self):
+        """Test an exception is raised if key does not exist"""
+        config = conf.Configuration()
+        with pytest.raises(conf.ConfigurationError, match="Unknown"):
+            config.test
+
+    def test_env_vars_take_precedence(self, tmpdir):
+        """Test that if a configuration file and an environment
+        variable is set, that the environment variable takes
+        precedence."""
+        filename = tmpdir.join("config.toml")
+
+        with open(filename, "w") as f:
+            f.write(TEST_FILE)
+
+        host = "https://6.4.2.4"
+
+        os.environ["SF_API_HOSTNAME"] = host
+        config = conf.Configuration(str(filename))
+
+        assert config.api["hostname"] == host


### PR DESCRIPTION
**Description of the Change:** Adds a basic configuration module to SF.

**Benefits:**

* Stores default configuration

* Platform-independent search of configuration file locations

* Environment variables have the same name, prefixed with `SF_{SECTION}_`. If they exist, they take precedence over a configuration file.

**Possible Drawbacks:** n/a

**Related GitHub Issues:**
