### PR TITLE
Travis CI: The sudo tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 cache: pip
 python:
@@ -13,13 +12,9 @@ matrix:
   include:
     - env: OPTIONS="frontend or fock or gaussian"
     - env: OPTIONS="tf and pure"
-      sudo: required
     - env: OPTIONS="tf and mixed"
-      sudo: required
     - env: BATCHED=1 OPTIONS="tf and pure"
-      sudo: required
     - env: BATCHED=1 OPTIONS="tf and mixed"
-      sudo: required
 install:
   - pip install -r requirements.txt
   - pip install wheel codecov pytest pytest-cov --upgrade


### PR DESCRIPTION
**Description of the Change:**
Remove __sudo:__ tag in .travis.yml because it is deprecated.

**Benefits:**
Simplify, remove dead code.

**Possible Drawbacks:**
I can not think of any drawbacks.

**Related GitHub Issues:**
