### PR TITLE
Engine.run: return_state removed.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,11 @@
+#  Release 0.12.dev
+
+### Improvements
+
+- Removed the `return_state` keyword argument from `LocalEngine.run()`. Now no state object is
+  returned if `modes==[]`. https://github.com/XanaduAI/strawberryfields/pull/126
+
+
 #  Release 0.11.dev
 
 ### New features

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -356,9 +356,7 @@ class LocalEngine(BaseEngine):
         Keyword Args:
             shots (int): number of times the program measurement evaluation is repeated
             modes (None, Sequence[int]): Modes to be returned in the ``Result.state`` :class:`.BaseState` object.
-                ``None`` returns all the modes (default).
-            return_state (bool): Whether to return a :class:`.BaseState` object object within ``Result.state``.
-                Default is True.
+                ``None`` returns all the modes (default). An empty sequence means no state object is returned.
             eval (bool): If False, the backend returns unevaluated tf.Tensors instead of
                 numbers/arrays for returned measurement results and state (default: True). TF backend only.
             session (tf.Session): TensorFlow session, used when evaluating returned measurement results and state.
@@ -377,7 +375,8 @@ class LocalEngine(BaseEngine):
 
         result = super()._run(program, compile_options=compile_options, **eng_run_options)
 
-        if run_options.get("return_state", True):
+        modes = run_options['modes']
+        if modes is None or modes:
             # state object requested
             # session and feed_dict are needed by TF backend both during simulation (if program
             # contains measurements) and state object construction.

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -99,7 +99,7 @@ class TestProperExecution:
     def test_no_return_state(self, setup_eng):
         """Engine returns no state object when none is requested."""
         eng, prog = setup_eng(2)
-        res = eng.run(prog, run_options={"return_state": False})
+        res = eng.run(prog, run_options={"modes": []})
         assert res.state is None
 
     def test_return_state(self, setup_eng):


### PR DESCRIPTION
**Description of the Change:**

* Removed the `LocalEngine.run()` argument `return_state`. Now a state object is returned iff modes is not an empty sequence.

**Benefits:**

One less argument. I don't see any uses for state objects with no modes.