### PR TITLE
Update ops.py

### DIFF
--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1698,7 +1698,7 @@ class GraphEmbed(Decomposition):
                 if np.abs(s) >= _decomposition_tol:
                     cmds.append(Command(Sgate(s), reg[n]))
 
-            if not np.allclose(self.U, np.identity(len(self.U)), atol = _decomposition_tol):
+            if not np.allclose(self.U, np.identity(len(self.U)), atol=_decomposition_tol):
                 cmds.append(Command(Interferometer(self.U), reg))
         return cmds
 

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1698,7 +1698,7 @@ class GraphEmbed(Decomposition):
                 if np.abs(s) >= _decomposition_tol:
                     cmds.append(Command(Sgate(s), reg[n]))
 
-            if not np.allclose(self.U,  np.identity(len(self.U)), atol = _decomposition_tol):
+            if not np.allclose(self.U, np.identity(len(self.U)), atol = _decomposition_tol):
                 cmds.append(Command(Interferometer(self.U), reg))
         return cmds
 

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1698,7 +1698,7 @@ class GraphEmbed(Decomposition):
                 if np.abs(s) >= _decomposition_tol:
                     cmds.append(Command(Sgate(s), reg[n]))
 
-            if np.all(np.abs(self.U - np.identity(len(self.U))) >= _decomposition_tol):
+            if not np.allclose(self.U,  np.identity(len(self.U)), atol = _decomposition_tol):
                 cmds.append(Command(Interferometer(self.U), reg))
         return cmds
 

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1687,7 +1687,7 @@ class GraphEmbed(Decomposition):
         else:
             self.identity = False
             self.sq, self.U = graph_embed(
-                A, mean_photon_per_mode=mean_photon_per_mode, make_traceless=make_traceless, atol=tol
+                A, mean_photon_per_mode=mean_photon_per_mode, make_traceless=make_traceless, atol=tol, rtol=0
             )
 
     def _decompose(self, reg):
@@ -1698,7 +1698,7 @@ class GraphEmbed(Decomposition):
                 if np.abs(s) >= _decomposition_tol:
                     cmds.append(Command(Sgate(s), reg[n]))
 
-            if not np.allclose(self.U, np.identity(len(self.U)), atol=_decomposition_tol):
+            if not np.allclose(self.U, np.identity(len(self.U)), atol=_decomposition_tol, rtol=0):
                 cmds.append(Command(Interferometer(self.U), reg))
         return cmds
 

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -293,7 +293,7 @@ class TestGraphEmbed:
         ]
         )
         sq, U = dec.graph_embed(A)
-
+        assert not np.allclose(U, np.identity(n))
         G = ops.GraphEmbed(A)
         cmds = G.decompose(prog.register)
 

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -295,7 +295,6 @@ class TestGraphEmbed:
         G = ops.GraphEmbed(A)
         cmds = G.decompose(prog.register)
 
-        #print([str(cmd.op) for cmd in cmds])
         assert str(cmds[-1].op)[:4] == "Interferometer"[:4]
 
 class TestGaussianTransform:

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -274,12 +274,10 @@ class TestGraphEmbed:
 
         assert np.allclose(ratio, np.ones([n, n]), atol=tol, rtol=0)
 
-
-
-    def test_decomposition_interferometer_with_zero(self, hbar, tol):
+    def test_decomposition_interferometer_with_zero(self, tol):
         """Test that an graph is correctly decomposed when the interferometer
-        has one zero somewhere is the unitary matrix, which is the case for the
-        Adjacency matrix below"""
+        has one zero somewhere in the unitary matrix, which is the case for the
+        adjacency matrix below"""
         n = 6
         prog = sf.Program(n)
 
@@ -294,10 +292,15 @@ class TestGraphEmbed:
         )
         sq, U = dec.graph_embed(A)
         assert not np.allclose(U, np.identity(n))
+
         G = ops.GraphEmbed(A)
         cmds = G.decompose(prog.register)
+        last_op = cmds[-1].op
+        param_val = last_op.p[0].x
 
-        assert str(cmds[-1].op)[:4] == "Interferometer"[:4]
+        assert isinstance(last_op, ops.Interferometer)
+        assert last_op.ns == n
+        assert np.allclose(param_val, U, atol=tol, rtol=0)
 
 class TestGaussianTransform:
     """Tests for the GaussianTransform quantum operation"""

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -277,7 +277,9 @@ class TestGraphEmbed:
 
 
     def test_decomposition_interferometer_with_zero(self, hbar, tol):
-        """Test that an graph is correctly decomposed"""
+        """Test that an graph is correctly decomposed when the interferometer
+        has one zero somewhere is the unitary matrix, which is the case for the
+        Adjacency matrix below"""
         n = 6
         prog = sf.Program(n)
 

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -275,6 +275,29 @@ class TestGraphEmbed:
         assert np.allclose(ratio, np.ones([n, n]), atol=tol, rtol=0)
 
 
+
+    def test_decomposition_interferometer_with_zero(self, hbar, tol):
+        """Test that an graph is correctly decomposed"""
+        n = 6
+        prog = sf.Program(n)
+
+        A = np.array([
+        [0, 1, 0, 0, 1, 1],
+        [1, 0, 1, 0, 1, 1],
+        [0, 1, 0, 1, 1, 0],
+        [0, 0, 1, 0, 1, 0],
+        [1, 1, 1, 1, 0, 1],
+        [1, 1, 0, 0, 1, 0],
+        ]
+        )
+        sq, U = dec.graph_embed(A)
+
+        G = ops.GraphEmbed(A)
+        cmds = G.decompose(prog.register)
+
+        #print([str(cmd.op) for cmd in cmds])
+        assert str(cmds[-1].op)[:4] == "Interferometer"[:4]
+
 class TestGaussianTransform:
     """Tests for the GaussianTransform quantum operation"""
 


### PR DESCRIPTION
The previous version was checking that all the elements of the interferometer were different from the identity. What you want to change is that it is *not* the identity, which implies checking that there is at least one element that is different, this can be done more elegantly by using np.allclose .


**Description of the Change:**
Fixes bug in ops GraphEmbed
**Benefits:**
Kills a bug
**Possible Drawbacks:**

**Related GitHub Issues:**
