### PR TITLE
Add a `sorted()` call to `GBSSpec.compile()`

### DIFF
--- a/strawberryfields/circuitspecs/gbs.py
+++ b/strawberryfields/circuitspecs/gbs.py
@@ -96,5 +96,5 @@ class GBSSpecs(GaussianSpecs):
             measured |= temp
 
         # replace B with a single Fock measurement
-        B = [Command(ops.MeasureFock(), list(measured))]
+        B = [Command(ops.MeasureFock(), sorted(list(measured), key=lambda x: x.ind))]
         return super().compile(A + B, registers)

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -628,7 +628,7 @@ class TestGBS:
         prog = prog.compile('gbs')
         assert len(prog) == 4
         last_cmd = prog.circuit[-1]
-        assert last_cmd.op.__class__ == ops.MeasureFock
+        assert isinstance(last_cmd.op, ops.MeasureFock)
         assert [x.ind for x in last_cmd.reg] == list(range(3))
 
     def test_GBS_measure_fock_register_order(self):
@@ -644,5 +644,5 @@ class TestGBS:
 
         prog = prog.compile("gbs")
         last_cmd = prog.circuit[-1]
-        assert last_cmd.op.__class__ == ops.MeasureFock
+        assert isinstance(last_cmd.op, ops.MeasureFock)
         assert [x.ind for x in last_cmd.reg] == list(range(4))

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -630,3 +630,19 @@ class TestGBS:
         last_cmd = prog.circuit[-1]
         assert last_cmd.op.__class__ == ops.MeasureFock
         assert [x.ind for x in last_cmd.reg] == list(range(3))
+
+    def test_GBS_measure_fock_register_order(self):
+        """Test that compilation of MeasureFock on multiple modes
+        sorts the resulting register indices in ascending order."""
+        prog = sf.Program(4)
+
+        with prog.context as q:
+            ops.S2gate(0.45) | (q[0], q[2])
+            ops.S2gate(0.45) | (q[0], q[2])
+            ops.BSgate(0.54, -0.12) | (q[0], q[1])
+            ops.MeasureFock() | (q[0], q[3], q[2], q[1])
+
+        prog = prog.compile("gbs")
+        last_cmd = prog.circuit[-1]
+        assert last_cmd.op.__class__ == ops.MeasureFock
+        assert [x.ind for x in last_cmd.reg] == list(range(4))


### PR DESCRIPTION
**Context:** During GBS compilation, the call to `networkx.lexicographical_topological_sort()` permutes the returned order of the measured registers, since all permutations are equivalent.

**Description of the Change:** After the topological sort, the measured registers are sorted in ascending order in the compiled program. A test to confirm this behaviour is also added.

**Benefits:** This avoids unexpected results, as programs containing `MeasureFock() | q` previously could compile to `MeasureFock() | (q[0], q[2], q[1], q[3])`.

**Possible Drawbacks:** It would be nicer to preserve the order the user specifies the modes in. This is probably not possible, however, due to the topological sort. Further, the user should probably expect differences like this to occur when compiling.

**Related GitHub Issues:** #127 