### PR TITLE
Removes the restriction of zero mean for PNR sampling

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,6 @@
     `rectangular_symmetric`, and `triangular`) now have standardized outputs
     `(tlist, diag, tilist)`, so they can easily be swapped.
 
-
 * Several changes to `ops.Interferometer`:
   [#127](https://github.com/XanaduAI/strawberryfields/pull/127)
 
@@ -53,6 +52,11 @@
   be passed the program registers, as compilation may sometimes require this.
   [#127](https://github.com/XanaduAI/strawberryfields/pull/127)
 
+### Improvements
+
+* Photon-counting measurements can now be done in the Gaussian backend for states with nonzero displacement.
+  [#154](https://github.com/XanaduAI/strawberryfields/pull/154)
+
 ### Bug fixes
 
 * When using the `'gbs'` compilation target, the measured registers are now sorted in
@@ -61,6 +65,9 @@
 
 * Fixed typo in the Gaussian Boson Sampling example notebook.
   [#133](https://github.com/XanaduAI/strawberryfields/pull/133)
+
+* Fixed a bug in the function `smeanxp` of the Gaussian Backend simulator. 
+  [#154](https://github.com/XanaduAI/strawberryfields/pull/154)
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = [
     "scipy>=1.0.0",
     "networkx>=2.0",
     "quantum-blackbird>=0.2.0",
-    "hafnian>=0.6",
+    "hafnian>=0.7",
     "toml",
     "appdirs"
 ]

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -249,7 +249,7 @@ class GaussianModes:
         nmodes = self.nlen
         r = np.empty(2*nmodes)
         r[0:nmodes] = 2*self.mean.real
-        r[nmodes:2*nmodes] = 2*self.mean.real
+        r[nmodes:2*nmodes] = 2*self.mean.imag
         return r
 
     def scovmat(self):

--- a/tests/backend/test_fock_measurement.py
+++ b/tests/backend/test_fock_measurement.py
@@ -162,15 +162,12 @@ class TestRepresentationIndependent:
         """Test that a coherent state with a mean photon number of 4 and sampled NUM_REPEATS times will produce photons"""
         backend = setup_backend(1)
         alpha = 2.0
-        nonzero = False
+        meas = np.array(backend.measure_fock([0]))
 
         for _ in range(NUM_REPEATS):
             backend.reset(pure=pure)
             backend.displacement(alpha, 0)
-            meas = backend.measure_fock([0])[0]
-            if meas > 0:
-                nonzero = True
-                break
-        assert nonzero
+            meas += backend.measure_fock([0])
+        assert np.all(meas > 0)
 
 

--- a/tests/backend/test_fock_measurement.py
+++ b/tests/backend/test_fock_measurement.py
@@ -156,3 +156,21 @@ class TestRepresentationIndependent:
 
             meas = backend.measure_fock([0, 1, 2])[0]
             assert np.all(np.array(meas) == 0)
+
+
+    def test_coherent_state_has_photons(self, setup_backend, pure):
+        """Test that a coherent state with a mean photon number of 4 and sampled NUM_REPEATS times will produce photons"""
+        backend = setup_backend(1)
+        alpha = 2.0
+        nonzero = False
+
+        for _ in range(NUM_REPEATS):
+            backend.reset(pure=pure)
+            backend.displacement(alpha, 0)
+            meas = backend.measure_fock([0])[0]
+            if meas > 0:
+                nonzero = True
+                break
+        assert nonzero
+
+

--- a/tests/integration/test_measurement_integration.py
+++ b/tests/integration/test_measurement_integration.py
@@ -130,3 +130,18 @@ class TestPostselection:
         n_mean_tot = np.trace(cov / (hbar / 2) - np.identity(4)) / 4
         expected = 2 * n_mean_per_mode
         assert np.allclose(n_mean_tot, expected)
+
+
+    @pytest.mark.backends("gaussian")
+    def test_coherent_state_has_photons(self, setup_eng, hbar):
+        """Test that a coherent state with a mean photon number of 4 and sampled 100 times will produce photons"""
+        shots = 100
+        eng, prog = setup_eng(1)
+        alpha = 2
+        with prog.context as q:
+            ops.Coherent(alpha) | q[0]
+            ops.MeasureFock() | q[0]
+        state = eng.run(prog).state
+        samples = np.array(eng.run(prog, run_options={"shots": shots})).flatten()
+
+        assert not np.all(samples == np.zeros_like(samples, dtype=int))


### PR DESCRIPTION
**Description of the Change:**
Removes the restriction of zero mean for PNR sampling. This is allowed by recently added capabilities in the hafnian library.
**Benefits:**
Can do more sophisticated sampling. Also useful in Franck-Condon factor sampling.
**Possible Drawbacks:**

**Related GitHub Issues:**
