### PR TITLE
Show job failed error

### DIFF
--- a/strawberryfields/api_client.py
+++ b/strawberryfields/api_client.py
@@ -280,7 +280,8 @@ class ResourceManager:
     This class handles all interactions with APIClient by the resource.
     """
 
-    http_status_code = None
+    http_response_data = None
+    http_response_status_code = None
     errors = None
 
     def __init__(self, resource, client=None):
@@ -345,7 +346,8 @@ class ResourceManager:
             response (requests.Response): a response object to be parsed
         """
         if hasattr(response, "status_code"):
-            self.http_status_code = response.status_code
+            self.http_response_data = response.json()
+            self.http_response_status_code = response.status_code
 
             if response.status_code in (200, 201):
                 self.handle_success_response(response)

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -322,6 +322,7 @@ class LocalEngine(BaseEngine):
         backend (str, BaseBackend): short name of the backend, or a pre-constructed backend instance
         backend_options (None, Dict[str, Any]): keyword arguments to be passed to the backend
     """
+
     def __init__(self, backend, *, backend_options=None):
         backend_options = backend_options or {}
         super().__init__(backend, backend_options)
@@ -415,11 +416,13 @@ class LocalEngine(BaseEngine):
 
         temp_run_options.update(run_options or {})
         temp_run_options.setdefault("shots", 1)
-        temp_run_options.setdefault('modes', None)
+        temp_run_options.setdefault("modes", None)
 
         # avoid unexpected keys being sent to Operations
         eng_run_keys = ["eval", "session", "feed_dict", "shots"]
-        eng_run_options = {key: temp_run_options[key] for key in temp_run_options.keys() & eng_run_keys}
+        eng_run_options = {
+            key: temp_run_options[key] for key in temp_run_options.keys() & eng_run_keys
+        }
 
         result = super()._run(program, compile_options=compile_options, **eng_run_options)
 
@@ -455,6 +458,7 @@ class StarshipEngine(BaseEngine):
         # todo: move this into backend class
         class Chip0Backend(BaseBackend):
             circuit_spec = "chip0"
+
         self.backend = Chip0Backend()
 
         api_client_params = {k: v for k, v in kwargs.items() if k in DEFAULT_CONFIG["api"].keys()}
@@ -559,8 +563,8 @@ class StarshipEngine(BaseEngine):
         self.reset()
 
         if job.is_failed:
-            # TODO: Add failure details here. Should this exception be raised elsewhere?
-            raise JobExecutionError("Job execution failed. Please try again.")
+            message = str(job.manager.http_response_data["meta"])
+            raise JobExecutionError(message)
         elif job.is_complete:
             job.result.manager.get()
             return job.result.result.value

--- a/tests/frontend/test_api_client.py
+++ b/tests/frontend/test_api_client.py
@@ -325,7 +325,8 @@ class TestResourceManager:
         monkeypatch.setattr(manager, "handle_error_response", mock_handle_error_response)
 
         manager.handle_response(mock_response)
-        assert manager.http_status_code == mock_response.status_code
+        assert manager.http_response_data == mock_response.json()
+        assert manager.http_response_status_code == mock_response.status_code
         mock_handle_error_response.assert_called_once_with(mock_response)
 
         mock_response.status_code = 200

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -263,8 +263,9 @@ class TestStarshipEngine:
 
         some_params = {"param": MagicMock()}
 
-        with pytest.raises(JobExecutionError):
+        with pytest.raises(JobExecutionError) as e:
             starship_engine._run_program(program, **some_params)
+        assert e.value.args[0] == str(mock_job.manager.http_response_data['meta'])
 
     def test__run(self, starship_engine, monkeypatch):
         """


### PR DESCRIPTION
**Description of the Change:**
When a job fails to execute and the server returns a correct error message regarding the job execution failure, forward this information to the user.
**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
