### PR TITLE
Change `Program.target` to a property, and ensure run options are saved to Blackbird scripts

### DIFF
--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -56,6 +56,10 @@ def to_blackbird(prog, version="1.0"):
         # set the target
         bb._target["name"] = prog.target
 
+        # set the run options
+        if prog.run_options:
+            bb._target["options"] = prog.run_options
+
     # fill in the quantum circuit
     for cmd in prog.circuit:
         op = {"kwargs": {}, "args": []}

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -188,7 +188,7 @@ class Program:
         #: bool: if True, no more Commands can be appended to the Program
         self.locked = False
         #: str, None: for compiled Programs, the short name of the target CircuitSpecs template, otherwise None
-        self.target = None
+        self._target = None
         #: Program, None: for compiled Programs, this is the original, otherwise None
         self.source = None
 
@@ -523,7 +523,7 @@ class Program:
         # create the compiled Program
         compiled = self._linked_copy()
         compiled.circuit = seq
-        compiled.target = target
+        compiled._target = target
 
         # get run options of compiled program
         # for the moment, shots is the only supported run option.
@@ -573,3 +573,15 @@ class Program:
             document = drawer.compile_document(tex_dir=tex_dir)
 
         return [document, tex]
+
+    @property
+    def target(self):
+        """The target specification the program has been compiled against.
+
+        If the program has not been compiled, this will return ``None``.
+
+        Returns:
+            str or None: the short name of the target CircuitSpecs template if
+            compiled, otherwise None
+        """
+        return self._target

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -109,6 +109,16 @@ class TestSFToBlackbirdConversion:
         assert bb.version == "1.0"
         assert bb.target["name"] == "gaussian"
 
+    def test_metadata_run_options(self):
+        """Test run options correctly converts"""
+        prog = Program(4, name="test_program")
+        bb = io.to_blackbird(prog.compile("gaussian", shots=1024))
+
+        assert bb.name == "test_program"
+        assert bb.version == "1.0"
+        assert bb.target["name"] == "gaussian"
+        assert bb.target["options"] == {"shots": 1024}
+
     def test_gate_noarg(self):
         """Test gate with no argument converts"""
         # create a test program


### PR DESCRIPTION
**Description of the Change:**

* Makes `Program.target` a property, to make it less likely that a user manually changes the value

* Fixes a bug where compilation and engine run options (such as shots) were not being saved to Blackbird scripts. Adds a test to check this works as intended.

**Benefits:**

* Now slightly harder to 'fake' compilation

* Shots will be correctly saved to a blackbird program

**Possible Drawbacks:**

* Still possible to fool compilation, by instead changing the hidden attribute. The question is, is this sufficient? Or should we also change the engine logic to force re-compilation every time? My preference is to keep the existing engine logic, just to avoid the overhead of the non-efficient compilation process.

**Related GitHub Issues:** n/a
