### PR TITLE
Added test for cubic phase gate

### DIFF
--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import expm
 
 KAPPAS = np.linspace(0, 2 * np.pi, 7)
-GAMMAS = np.linspace(0, 2 * np.pi, 7)
+GAMMAS = np.linspace(0, 6, 7)
 
 @pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
@@ -48,13 +48,13 @@ class TestFockRepresentation:
         np.fill_diagonal(a[:, 1:], ladder_vals)
 
         #Construct (unnormalized) x matrix, ie a+a^dag, and it's third power
-        x = a + np.transpose(a)
-        x3 = np.matmul(x, np.matmul(x, x))
+        x = a + a.T
+        x3 = x @ x @ x
 
         gate = expm(1j * gamma * x3 / 6)
 
         #state to be transformed
-        ket = np.ones([cutoff]) / np.sqrt(cutoff)
+        ket = np.ones(cutoff) / np.sqrt(cutoff)
 
         ref_state = np.matmul(gate, ket)
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -46,18 +46,18 @@ class TestFockRepresentation:
         ladder_vals = np.arange(1, cutoff)
         ladder_vals = np.sqrt(ladder_vals)
         a = np.zeros([cutoff, cutoff])
-        np.fill_diagonal(a[:,1:], ladder_vals)
+        np.fill_diagonal(a[:, 1:], ladder_vals)
 
         #Construct (unnormalized) x matrix, ie a+a^dag, and it's third power
         x = a + np.transpose(a)
-        x3 = np.matmul(x, np.matmul(x,x))
+        x3 = np.matmul(x, np.matmul(x, x))
 
         gate = expm(1j * gamma * x3 / 6)
 
         #state to be transformed
         ket1 = np.array([1.0 for n in range(cutoff)])
         ket1 /= np.linalg.norm(ket1)
-        ket = ket1.reshape(-1,1)
+        ket = ket1.reshape(-1, 1)
 
         ref_state = np.matmul(gate, ket).flatten()
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import expm
 
 KAPPAS = np.linspace(0, 2 * np.pi, 7)
-GAMMAS = np.linspace(0, 2 * np.pi, 7)
+GAMMAS = np.linspace(0, 6, 7)
 
 @pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
@@ -54,11 +54,10 @@ class TestFockRepresentation:
         gate = expm(1j * gamma * x3 / 6)
 
         #state to be transformed
-        ket1 = np.array([1.0 for n in range(cutoff)])
-        ket1 /= np.linalg.norm(ket1)
-        ket = ket1.reshape(-1, 1)
+        ket = np.array([1.0 for n in range(cutoff)])
+        ket /= np.linalg.norm(ket)
 
-        ref_state = np.matmul(gate, ket).flatten()
+        ref_state = np.matmul(gate, ket)
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("kappa", KAPPAS)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -44,6 +44,10 @@ class TestFockRepresentation:
         else:
             numer_state = s.dm()
         ref_state = np.exp(1j * kappa * np.arange(cutoff) ** 2) / cutoff
+
+        print(ref_state)
+        print(numer_state)
+
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("kappa", KAPPAS)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -29,44 +29,6 @@ class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
 
-    @pytest.mark.parametrize("gamma", GAMMAS)
-    def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
-        #Tests if the Cubic phase gate has the right effect on states in the Fock basis
-
-        backend = setup_backend(1)
-
-        backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
-        backend.cubic_phase(gamma, 0)
-        s = backend.state()
-        if s.is_pure:
-            numer_state = s.ket()
-        else:
-            numer_state = s.dm()
-
-        #Create annihilation operator matrix
-        ladder_vals = np.arange(1, cutoff)
-        ladder_vals = np.sqrt(ladder_vals)
-        a = np.zeros([cutoff, cutoff])
-        np.fill_diagonal(a[:,1:], ladder_vals)
-
-        #Construct x matrix and it's third power
-        x = (a + np.transpose(a))/np.sqrt(2)
-        x3 = np.matmul(x, np.matmul(x,x))
-
-        gate = expm(1j * gamma * x3 / 3)
-
-        #state to be transformed
-        ket1 = np.array([1.0 for n in range(cutoff)])
-        ket1 /= np.linalg.norm(ket1)
-        ket = ket1.reshape(-1,1)
-
-        ref_state = np.matmul(gate, ket)
-
-        print(ref_state)
-        print(numer_state)
-
-        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
-
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -28,7 +28,44 @@ GAMMAS = np.linspace(0, 2 * np.pi, 7)
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
+    @pytest.mark.parametrize("gamma", GAMMAS)
+      def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
+          #Tests if the Cubic phase gate has the right effect on states in the Fock basis
 
+          backend = setup_backend(1)
+
+          backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
+          backend.cubic_phase(gamma, 0)
+          s = backend.state()
+          if s.is_pure:
+              numer_state = s.ket()
+          else:
+              numer_state = s.dm()
+
+          #Create annihilation operator matrix
+          ladder_vals = np.arange(1, cutoff)
+          ladder_vals = np.sqrt(ladder_vals)
+          a = np.zeros([cutoff, cutoff])
+          np.fill_diagonal(a[:,1:], ladder_vals)
+
+          #Construct x matrix and it's third power
+          x = (a + np.transpose(a))/np.sqrt(2)
+          x3 = np.matmul(x, np.matmul(x,x))
+
+          gate = expm(1j * gamma * x3 / 3)
+
+          #state to be transformed
+          ket1 = np.array([1.0 for n in range(cutoff)])
+          ket1 /= np.linalg.norm(ket1)
+          ket = ket1.reshape(-1,1)
+
+          ref_state = np.matmul(gate, ket)
+
+          print(ref_state)
+          print(numer_state)
+
+          assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
+          
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):
@@ -44,10 +81,6 @@ class TestFockRepresentation:
         else:
             numer_state = s.dm()
         ref_state = np.exp(1j * kappa * np.arange(cutoff) ** 2) / cutoff
-
-        print(ref_state)
-        print(numer_state)
-
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
     @pytest.mark.parametrize("kappa", KAPPAS)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -29,43 +29,43 @@ class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
     @pytest.mark.parametrize("gamma", GAMMAS)
-      def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
-          #Tests if the Cubic phase gate has the right effect on states in the Fock basis
+    def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
+        #Tests if the Cubic phase gate has the right effect on states in the Fock basis
 
-          backend = setup_backend(1)
+        backend = setup_backend(1)
 
-          backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
-          backend.cubic_phase(gamma, 0)
-          s = backend.state()
-          if s.is_pure:
-              numer_state = s.ket()
-          else:
-              numer_state = s.dm()
+        backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
+        backend.cubic_phase(gamma, 0)
+        s = backend.state()
+        if s.is_pure:
+            numer_state = s.ket()
+        else:
+            numer_state = s.dm()
 
-          #Create annihilation operator matrix
-          ladder_vals = np.arange(1, cutoff)
-          ladder_vals = np.sqrt(ladder_vals)
-          a = np.zeros([cutoff, cutoff])
-          np.fill_diagonal(a[:,1:], ladder_vals)
+        #Create annihilation operator matrix
+        ladder_vals = np.arange(1, cutoff)
+        ladder_vals = np.sqrt(ladder_vals)
+        a = np.zeros([cutoff, cutoff])
+        np.fill_diagonal(a[:,1:], ladder_vals)
 
-          #Construct x matrix and it's third power
-          x = (a + np.transpose(a))/np.sqrt(2)
-          x3 = np.matmul(x, np.matmul(x,x))
+        #Construct x matrix and it's third power
+        x = (a + np.transpose(a))/np.sqrt(2)
+        x3 = np.matmul(x, np.matmul(x,x))
 
-          gate = expm(1j * gamma * x3 / 3)
+        gate = expm(1j * gamma * x3 / 3)
 
-          #state to be transformed
-          ket1 = np.array([1.0 for n in range(cutoff)])
-          ket1 /= np.linalg.norm(ket1)
-          ket = ket1.reshape(-1,1)
+        #state to be transformed
+        ket1 = np.array([1.0 for n in range(cutoff)])
+        ket1 /= np.linalg.norm(ket1)
+        ket = ket1.reshape(-1,1)
 
-          ref_state = np.matmul(gate, ket)
+        ref_state = np.matmul(gate, ket)
 
-          print(ref_state)
-          print(numer_state)
+        print(ref_state)
+        print(numer_state)
 
-          assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
-          
+        assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
+
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -28,6 +28,7 @@ GAMMAS = np.linspace(0, 2 * np.pi, 7)
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
+"""
     @pytest.mark.parametrize("gamma", GAMMAS)
     def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
         """Tests if the Cubic phase gate has the right effect on states in the Fock basis"""
@@ -66,7 +67,7 @@ class TestFockRepresentation:
 
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
-
+"""
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -23,7 +23,6 @@ from scipy.linalg import expm
 KAPPAS = np.linspace(0, 2 * np.pi, 7)
 GAMMAS = np.linspace(0, 2 * np.pi, 7)
 
-
 @pytest.mark.backends("fock", "tf")
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -62,6 +62,7 @@ class TestFockRepresentation:
         ref_state = np.matmul(gate, ket)
 
         print(ref_state)
+        print(numer_state)
 
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -30,11 +30,11 @@ class TestFockRepresentation:
 
     @pytest.mark.parametrize("gamma", GAMMAS)
     def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
-        #Tests if the Cubic phase gate has the right effect on states in the Fock basis
+        """Tests if the Cubic phase gate has the right effect on states in the Fock basis"""
 
         backend = setup_backend(1)
 
-        backend.prepare_ket_state(np.ones([cutoff]) / cutoff, 0)
+        backend.prepare_ket_state(np.ones([cutoff]) / np.sqrt(cutoff), 0)
         backend.cubic_phase(gamma, 0)
         s = backend.state()
         if s.is_pure:
@@ -48,24 +48,19 @@ class TestFockRepresentation:
         a = np.zeros([cutoff, cutoff])
         np.fill_diagonal(a[:,1:], ladder_vals)
 
-        #Construct x matrix and it's third power
-        x = (a + np.transpose(a))/np.sqrt(2)
+        #Construct (unnormalized) x matrix, ie a+a^dag, and it's third power
+        x = a + np.transpose(a)
         x3 = np.matmul(x, np.matmul(x,x))
 
-        gate = expm(1j * gamma * x3 / 3)
+        gate = expm(1j * gamma * x3 / 6)
 
         #state to be transformed
         ket1 = np.array([1.0 for n in range(cutoff)])
         ket1 /= np.linalg.norm(ket1)
         ket = ket1.reshape(-1,1)
 
-        ref_state = np.matmul(gate, ket)
-
-        print(ref_state)
-        print(numer_state)
-
+        ref_state = np.matmul(gate, ket).flatten()
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
-
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -61,6 +61,8 @@ class TestFockRepresentation:
 
         ref_state = np.matmul(gate, ket)
 
+        print(ref_state)
+
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
 

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -41,30 +41,30 @@ class TestFockRepresentation:
             numer_state = s.ket()
         else:
             numer_state = s.dm()
-            
+
         #Create annihilation operator matrix
         ladder_vals = np.arange(1, cutoff)
         ladder_vals = np.sqrt(ladder_vals)
         a = np.zeros([cutoff, cutoff])
         np.fill_diagonal(a[:,1:], ladder_vals)
-        
+
         #Construct x matrix and it's third power
         x = (a + np.transpose(a))/np.sqrt(2)
         x3 = np.matmul(x, np.matmul(x,x))
-        
+
         gate = expm(1j * gamma * x3 / 3)
-        
+
         #state to be transformed
         ket1 = np.array([1.0 for n in range(cutoff)])
         ket1 /= np.linalg.norm(ket1)
-        ket1 = ket1.reshape(-1,1)
-        
+        ket = ket1.reshape(-1,1)
+
         ref_state = np.matmul(gate, ket)
-        
+
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
-        
-        
-    
+
+
+
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):
         """Tests if the Kerr interaction has the right effect on states in the Fock basis"""

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -31,7 +31,7 @@ class TestFockRepresentation:
 """
     @pytest.mark.parametrize("gamma", GAMMAS)
     def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
-        """Tests if the Cubic phase gate has the right effect on states in the Fock basis"""
+        #Tests if the Cubic phase gate has the right effect on states in the Fock basis
 
         backend = setup_backend(1)
 

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -28,7 +28,7 @@ GAMMAS = np.linspace(0, 2 * np.pi, 7)
 class TestFockRepresentation:
     """Tests that make use of the Fock basis representation."""
 
-"""
+
     @pytest.mark.parametrize("gamma", GAMMAS)
     def test_cubic_phase(self, setup_backend, gamma, cutoff, tol):
         #Tests if the Cubic phase gate has the right effect on states in the Fock basis
@@ -67,7 +67,6 @@ class TestFockRepresentation:
 
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)
 
-"""
 
     @pytest.mark.parametrize("kappa", KAPPAS)
     def test_kerr_interaction(self, setup_backend, kappa, cutoff, tol):


### PR DESCRIPTION

**Description of the Change:**
Added test for cubic phase gate in 'tests/backend/test_nongaussian_gates.py'

**Benefits:**
Allows fock and tf backend testing of the cubic phase gate.

**Possible Drawbacks:**

**Related GitHub Issues:**
