### PR TITLE
Add example code to docstrings for utils

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,6 +110,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.bibtex',
     'edit_on_github',
+    'sphinx_autodoc_typehints',
     'nbsphinx'
 ]
 

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -310,21 +310,19 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import resize
-        >>> import networkx as nx
-        >>> graph = nx.wheel_graph(5)
-        >>> graph.remove_edge(0, 4)
-        >>> clique = [0, 1, 2]
-        >>> resize.clique_swap(clique, graph)
-        [0, 2, 3]
-        >>> graph = nx.lollipop_graph(5, 1)
-        >>> graph.remove_edge(0, 4)
-        >>> graph.remove_edge(0, 3)
-        >>> clique = [0, 1, 2]
-        >>> resize.clique_swap(clique, graph, node_select="degree")
-        [1, 2, 4]
+    >>> from strawberryfields.apps.graph import resize
+    >>> import networkx as nx
+    >>> graph = nx.wheel_graph(5)
+    >>> graph.remove_edge(0, 4)
+    >>> clique = [0, 1, 2]
+    >>> resize.clique_swap(clique, graph)
+    [0, 2, 3]
+    >>> graph = nx.lollipop_graph(5, 1)
+    >>> graph.remove_edge(0, 4)
+    >>> graph.remove_edge(0, 3)
+    >>> clique = [0, 1, 2]
+    >>> resize.clique_swap(clique, graph, node_select="degree")
+    [1, 2, 4]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -318,7 +318,13 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
         >>> graph.remove_edge(0, 4)
         >>> subgraph = [0, 1, 2]  # these nodes form a clique
         >>> resize.clique_swap(subgraph, graph)
-        [0, 1, 4]
+        [0, 2, 3]
+        >>> graph = nx.lollipop_graph(5, 1)
+        >>> graph.remove_edge(0, 4)
+        >>> graph.remove_edge(0, 3)
+        >>> subgraph = [0, 1, 2]
+        >>> resize.clique_swap(subgraph, graph, node_select="degree")
+        [1, 2, 4]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -308,6 +308,18 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
     supported. Degree-based node selection involves picking the node with the greatest degree,
     with ties settled by uniform random choice.
 
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import resize
+        >>> import networkx as nx
+        >>> graph = nx.wheel_graph(5)
+        >>> graph.remove_edge(0, 4)
+        >>> subgraph = [0, 1, 2]  # these nodes form a clique
+        >>> resize.clique_swap(subgraph, graph)
+        [0, 1, 4]
+
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -310,19 +310,11 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import resize
-    >>> import networkx as nx
     >>> graph = nx.wheel_graph(5)
     >>> graph.remove_edge(0, 4)
     >>> clique = [0, 1, 2]
-    >>> resize.clique_swap(clique, graph)
+    >>> clique_swap(clique, graph)
     [0, 2, 3]
-    >>> graph = nx.lollipop_graph(5, 1)
-    >>> graph.remove_edge(0, 4)
-    >>> graph.remove_edge(0, 3)
-    >>> clique = [0, 1, 2]
-    >>> resize.clique_swap(clique, graph, node_select="degree")
-    [1, 2, 4]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -316,14 +316,14 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
         >>> import networkx as nx
         >>> graph = nx.wheel_graph(5)
         >>> graph.remove_edge(0, 4)
-        >>> subgraph = [0, 1, 2]  # these nodes form a clique
-        >>> resize.clique_swap(subgraph, graph)
+        >>> clique = [0, 1, 2]
+        >>> resize.clique_swap(clique, graph)
         [0, 2, 3]
         >>> graph = nx.lollipop_graph(5, 1)
         >>> graph.remove_edge(0, 4)
         >>> graph.remove_edge(0, 3)
-        >>> subgraph = [0, 1, 2]
-        >>> resize.clique_swap(subgraph, graph, node_select="degree")
+        >>> clique = [0, 1, 2]
+        >>> resize.clique_swap(clique, graph, node_select="degree")
         [1, 2, 4]
 
     Args:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -151,7 +151,7 @@ def is_subgraph(subgraph: Iterable, graph: nx.Graph):
 
 
 def is_clique(graph: nx.Graph) -> bool:
-    """Determines if the input graph is a clique. A clique of :math:`n` nodes has :math:`n(
+    """Determines if the input graph is a clique. A clique of :math:`n` nodes has exactly :math:`n(
     n-1)/2` edges.
 
     Example usage:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -193,8 +193,8 @@ def c_0(clique: list, graph: nx.Graph):
         >>> from strawberryfields.apps.graph import utils
         >>> import networkx as nx
         >>> graph = nx.complete_graph(10)
-        >>> subgraph = [0, 1, 2, 3, 4]
-        >>> utils.c_0(subgraph, graph)
+        >>> clique = [0, 1, 2, 3, 4]
+        >>> utils.c_0(clique, graph)
         [5, 6, 7, 8, 9]
 
     Args:
@@ -233,8 +233,8 @@ def c_1(clique: list, graph: nx.Graph):
         >>> from strawberryfields.apps.graph import utils
         >>> import networkx as nx
         >>> graph = nx.wheel_graph(5)
-        >>> subgraph = [0, 1, 2]  # these nodes form a clique
-        >>> utils.c_1(subgraph, graph)
+        >>> clique = [0, 1, 2]
+        >>> utils.c_1(clique, graph)
         [(1, 3), (2, 4)]
 
     Args:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -195,7 +195,7 @@ def c_0(clique: list, graph: nx.Graph):
         [5, 6, 7, 8, 9]
 
     Args:
-        clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique.
+        clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): The input graph.
 
     Returns:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -151,8 +151,8 @@ def is_subgraph(subgraph: Iterable, graph: nx.Graph):
 
 
 def is_clique(graph: nx.Graph) -> bool:
-    """Determines if the input graph is a clique. A clique of :math:`n` nodes has
-     :math:`n(n-1)/2` edges.
+    """Determines if the input graph is a clique. A clique of :math:`n` nodes has :math:`n(
+    n-1)/2` edges.
 
     Example usage:
 

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -239,7 +239,7 @@ def c_1(clique: list, graph: nx.Graph):
         graph (nx.Graph): the input graph
 
     Returns:
-       list[int]: A list of tuples. The first node in the tuple is the node in the clique and the
+       list[tuple(int)]: A list of tuples. The first node in the tuple is the node in the clique and the
        second node is the outside node it can be swapped with.
    """
     if not is_clique(graph.subgraph(clique)):

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -152,7 +152,7 @@ def is_subgraph(subgraph: Iterable, graph: nx.Graph):
 
 def is_clique(graph: nx.Graph) -> bool:
     """Determines if the input graph is a clique. A clique of :math:`n` nodes has
-     :math:`n*(n-1)/2` edges.
+     :math:`n(n-1)/2` edges.
 
     Example usage:
 

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -156,16 +156,14 @@ def is_clique(graph: nx.Graph) -> bool:
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import utils
-        >>> import networkx as nx
-        >>> graph = nx.complete_graph(10)
-        >>> utils.is_clique(graph)
-        True
-        >>> graph = nx.empty_graph(10)
-        >>> utils.is_clique(graph)
-        False
+    >>> from strawberryfields.apps.graph import utils
+    >>> import networkx as nx
+    >>> graph = nx.complete_graph(10)
+    >>> utils.is_clique(graph)
+    True
+    >>> graph = nx.empty_graph(10)
+    >>> utils.is_clique(graph)
+    False
 
     Args:
         graph (nx.Graph): the input graph
@@ -188,14 +186,12 @@ def c_0(clique: list, graph: nx.Graph):
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import utils
-        >>> import networkx as nx
-        >>> graph = nx.complete_graph(10)
-        >>> clique = [0, 1, 2, 3, 4]
-        >>> utils.c_0(clique, graph)
-        [5, 6, 7, 8, 9]
+    >>> from strawberryfields.apps.graph import utils
+    >>> import networkx as nx
+    >>> graph = nx.complete_graph(10)
+    >>> clique = [0, 1, 2, 3, 4]
+    >>> utils.c_0(clique, graph)
+    [5, 6, 7, 8, 9]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
@@ -228,14 +224,12 @@ def c_1(clique: list, graph: nx.Graph):
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import utils
-        >>> import networkx as nx
-        >>> graph = nx.wheel_graph(5)
-        >>> clique = [0, 1, 2]
-        >>> utils.c_1(clique, graph)
-        [(1, 3), (2, 4)]
+    >>> from strawberryfields.apps.graph import utils
+    >>> import networkx as nx
+    >>> graph = nx.wheel_graph(5)
+    >>> clique = [0, 1, 2]
+    >>> utils.c_1(clique, graph)
+    [(1, 3), (2, 4)]
 
     Args:
          clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -199,7 +199,7 @@ def c_0(clique: list, graph: nx.Graph):
         graph (nx.Graph): The input graph.
 
     Returns:
-        list[int]: A list containing the :math:`C_0` nodes for the clique.
+        list[int]: a list containing the :math:`C_0` nodes for the clique
 
     """
     if not is_clique(graph.subgraph(clique)):

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -156,14 +156,9 @@ def is_clique(graph: nx.Graph) -> bool:
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import utils
-    >>> import networkx as nx
     >>> graph = nx.complete_graph(10)
-    >>> utils.is_clique(graph)
+    >>> is_clique(graph)
     True
-    >>> graph = nx.empty_graph(10)
-    >>> utils.is_clique(graph)
-    False
 
     Args:
         graph (nx.Graph): the input graph
@@ -186,11 +181,9 @@ def c_0(clique: list, graph: nx.Graph):
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import utils
-    >>> import networkx as nx
     >>> graph = nx.complete_graph(10)
     >>> clique = [0, 1, 2, 3, 4]
-    >>> utils.c_0(clique, graph)
+    >>> c_0(clique, graph)
     [5, 6, 7, 8, 9]
 
     Args:
@@ -224,11 +217,9 @@ def c_1(clique: list, graph: nx.Graph):
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import utils
-    >>> import networkx as nx
     >>> graph = nx.wheel_graph(5)
     >>> clique = [0, 1, 2]
-    >>> utils.c_1(clique, graph)
+    >>> c_1(clique, graph)
     [(1, 3), (2, 4)]
 
     Args:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -192,7 +192,7 @@ def c_0(clique: list, graph: nx.Graph):
         >>> graph = nx.complete_graph(10)
         >>> subgraph = [0, 1, 2, 3, 4]
         >>> utils.c_0(subgraph, graph)
-        [5, 6, 7, 8, 9, 9]
+        [5, 6, 7, 8, 9]
 
     Args:
         clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique.

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -163,12 +163,15 @@ def is_clique(graph: nx.Graph) -> bool:
         >>> graph = nx.complete_graph(10)
         >>> utils.is_clique(graph)
         True
+        >>> graph = nx.empty_graph(10)
+        >>> utils.is_clique(graph)
+        False
 
     Args:
-        graph (nx.Graph): The input graph.
+        graph (nx.Graph): the input graph
 
     Returns:
-        bool: ``True`` if input graph is a clique and ``False`` otherwise.
+        bool: ``True`` if input graph is a clique and ``False`` otherwise
     """
     edges = graph.edges
     nodes = graph.order()
@@ -196,7 +199,7 @@ def c_0(clique: list, graph: nx.Graph):
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
-        graph (nx.Graph): The input graph.
+        graph (nx.Graph): the input graph
 
     Returns:
         list[int]: a list containing the :math:`C_0` nodes for the clique
@@ -235,7 +238,7 @@ def c_1(clique: list, graph: nx.Graph):
         [(1, 3), (2, 4)]
 
     Args:
-        clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique
+         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
 
     Returns:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -223,7 +223,7 @@ def c_1(clique: list, graph: nx.Graph):
     [(1, 3), (2, 4)]
 
     Args:
-         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
+        clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
 
     Returns:

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -151,13 +151,24 @@ def is_subgraph(subgraph: Iterable, graph: nx.Graph):
 
 
 def is_clique(graph: nx.Graph) -> bool:
-    """Determines if the input graph is a clique. A clique of n nodes has :math:`n*(n-1)/2` edges.
+    """Determines if the input graph is a clique. A clique of :math:`n` nodes has
+     :math:`n*(n-1)/2` edges.
+
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import utils
+        >>> import networkx as nx
+        >>> graph = nx.complete_graph(10)
+        >>> utils.is_clique(graph)
+        True
 
     Args:
-        graph (nx.Graph): The input graph
+        graph (nx.Graph): The input graph.
 
     Returns:
-        bool: ``True`` if input graph is a clique and ``False`` otherwise
+        bool: ``True`` if input graph is a clique and ``False`` otherwise.
     """
     edges = graph.edges
     nodes = graph.order()
@@ -169,14 +180,27 @@ def c_0(clique: list, graph: nx.Graph):
     """Generates the set :math:`C_0` of nodes that are connected to all nodes in the input
     clique subgraph.
 
-    The set :math:`C_0` is defined in :cite:`pullan2006phased`.
+    The set :math:`C_0` is defined in :cite:`pullan2006phased` and is used to determine nodes
+    that can be added to the current clique to grow it into a larger one.
+
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import utils
+        >>> import networkx as nx
+        >>> graph = nx.complete_graph(10)
+        >>> subgraph = [0, 1, 2, 3, 4]
+        >>> utils.c_0(subgraph, graph)
+        [5, 6, 7, 8, 9, 9]
 
     Args:
-        clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique
-        graph (nx.Graph): the input graph
+        clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique.
+        graph (nx.Graph): The input graph.
 
     Returns:
-        list[int]: A list containing the :math:`C_0` nodes for the clique
+        list[int]: A list containing the :math:`C_0` nodes for the clique.
+
     """
     if not is_clique(graph.subgraph(clique)):
         raise ValueError("Input subgraph is not a clique")
@@ -196,16 +220,27 @@ def c_1(clique: list, graph: nx.Graph):
     """Generates the set :math:`C_1` of nodes that are connected to all but one of the nodes in
     the input clique subgraph
 
-    The set :math:`C_1` is defined in :cite:`pullan2006phased`.
+    The set :math:`C_1` is defined in :cite:`pullan2006phased` and is used to determine outside
+    nodes that can be swapped with clique nodes to create a new clique.
+
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import utils
+        >>> import networkx as nx
+        >>> graph = nx.wheel_graph(5)
+        >>> subgraph = [0, 1, 2]  # these nodes form a clique
+        >>> utils.c_1(subgraph, graph)
+        [(1, 3), (2, 4)]
 
     Args:
         clique (list[int]): A subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
 
     Returns:
-       list[int]: A list of tuples ``[(i_clique, i), (j_clique, j),...,(k_clique, k)]``. Here
-       ``i,j,...,k`` are the nodes in :math:`C_1`, while ``i_clique, j_clique,...,k_clique`` are the
-        nodes in the clique they can be swapped with.
+       list[int]: A list of tuples. The first node in the tuple is the node in the clique and the
+       second node is the outside node it can be swapped with.
    """
     if not is_clique(graph.subgraph(clique)):
         raise ValueError("Input subgraph is not a clique")


### PR DESCRIPTION
Adding examples of function use in small code snippets can really help the reader get a quick understanding of the function. We would like to do this for functions in the applications layer, and this PR provides code snippets for max-clique based functions in `graph.utils` and also the `graph.resize.clique_swap` function.