### PR TITLE
Add example code to docstrings for resize

### DIFF
--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -258,16 +258,14 @@ def clique_grow(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import resize
-    >>> import networkx as nx
     >>> graph = nx.complete_graph(10)
     >>> clique = [0, 1, 2, 3, 4]
-    >>> resize.clique_grow(clique, graph)
+    >>> clique_grow(clique, graph)
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     >>> graph = nx.lollipop_graph(5, 1)
     >>> graph.remove_edge(3, 4)
     >>> clique = [0, 1, 2]
-    >>> resize.clique_grow(clique, graph, node_select="degree")
+    >>> clique_grow(clique, graph, node_select="degree")
     [0, 1, 2, 4]
 
     Args:
@@ -368,11 +366,9 @@ def clique_shrink(subgraph: list, graph: nx.Graph) -> list:
 
     Example usage:
 
-    >>> from strawberryfields.apps.graph import resize
-    >>> import networkx as nx
     >>> graph = nx.barbell_graph(4, 0)
     >>> subgraph = [0, 1, 2, 3, 4, 5]
-    >>> resize.clique_shrink(subgraph, graph)
+    >>> clique_shrink(subgraph, graph)
     [0, 1, 2, 3]
 
     Args:

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -365,7 +365,7 @@ def clique_shrink(subgraph: list, graph: nx.Graph) -> list:
 
     Proceeds by removing nodes in the input subgraph one at a time until the result is a clique
     that satisfies :func:`~strawberryfields.apps.graph.utils.is_clique`. Upon each iteration,
-    this function selects the node with the lowest degree relative to the subgraph and removes it.
+    this function selects the node with lowest degree relative to the subgraph and removes it.
 
     Example usage:
 

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -256,6 +256,22 @@ def clique_grow(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
     supported. Degree-based node selection involves picking the node with the greatest degree,
     with ties settled by uniform random choice.
 
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import resize
+        >>> import networkx as nx
+        >>> graph = nx.complete_graph(10)
+        >>> clique = [0, 1, 2, 3, 4]
+        >>> resize.clique_grow(clique, graph)
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        >>> graph = nx.lollipop_graph(5, 1)
+        >>> graph.remove_edge(3, 4)
+        >>> clique = [0, 1, 2]
+        >>> resize.clique_grow(clique, graph, node_select="degree")
+        [0, 1, 2, 4]
+
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -258,19 +258,17 @@ def clique_grow(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import resize
-        >>> import networkx as nx
-        >>> graph = nx.complete_graph(10)
-        >>> clique = [0, 1, 2, 3, 4]
-        >>> resize.clique_grow(clique, graph)
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        >>> graph = nx.lollipop_graph(5, 1)
-        >>> graph.remove_edge(3, 4)
-        >>> clique = [0, 1, 2]
-        >>> resize.clique_grow(clique, graph, node_select="degree")
-        [0, 1, 2, 4]
+    >>> from strawberryfields.apps.graph import resize
+    >>> import networkx as nx
+    >>> graph = nx.complete_graph(10)
+    >>> clique = [0, 1, 2, 3, 4]
+    >>> resize.clique_grow(clique, graph)
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    >>> graph = nx.lollipop_graph(5, 1)
+    >>> graph.remove_edge(3, 4)
+    >>> clique = [0, 1, 2]
+    >>> resize.clique_grow(clique, graph, node_select="degree")
+    [0, 1, 2, 4]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
@@ -370,14 +368,12 @@ def clique_shrink(subgraph: list, graph: nx.Graph) -> list:
 
     Example usage:
 
-    .. code-block::
-
-        >>> from strawberryfields.apps.graph import resize
-        >>> import networkx as nx
-        >>> graph = nx.barbell_graph(4, 0)
-        >>> subgraph = [0, 1, 2, 3, 4, 5]
-        >>> resize.clique_shrink(subgraph, graph)
-        [0, 1, 2, 3]
+    >>> from strawberryfields.apps.graph import resize
+    >>> import networkx as nx
+    >>> graph = nx.barbell_graph(4, 0)
+    >>> subgraph = [0, 1, 2, 3, 4, 5]
+    >>> resize.clique_shrink(subgraph, graph)
+    [0, 1, 2, 3]
 
     Args:
         subgraph (list[int]): a subgraph specified by a list of nodes

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -368,6 +368,17 @@ def clique_shrink(subgraph: list, graph: nx.Graph) -> list:
     that satisfies :func:`~strawberryfields.apps.graph.utils.is_clique`. Upon each iteration,
     this function selects the node with the lowest degree relative to the subgraph and removes it.
 
+    Example usage:
+
+    .. code-block::
+
+        >>> from strawberryfields.apps.graph import resize
+        >>> import networkx as nx
+        >>> graph = nx.barbell_graph(4, 0)
+        >>> subgraph = [0, 1, 2, 3, 4, 5]
+        >>> resize.clique_shrink(subgraph, graph)
+        [0, 1, 2, 3]
+
     Args:
         subgraph (list[int]): a subgraph specified by a list of nodes
         graph (nx.Graph): the input graph

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -262,11 +262,6 @@ def clique_grow(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
     >>> clique = [0, 1, 2, 3, 4]
     >>> clique_grow(clique, graph)
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    >>> graph = nx.lollipop_graph(5, 1)
-    >>> graph.remove_edge(3, 4)
-    >>> clique = [0, 1, 2]
-    >>> clique_grow(clique, graph, node_select="degree")
-    [0, 1, 2, 4]
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique


### PR DESCRIPTION
Adding examples of function use in small code snippets can really help the reader get a quick understanding of the function. We would like to do this for functions in the applications layer, and this PR provides code snippets for max-clique based functions in `graph.resize`.