### PR TITLE
Provide local search algorithm for maximum clique

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -880,3 +880,12 @@
   year={2006},
   publisher={Springer}
 }
+
+@article{pullan2006dynamic,
+  title={Dynamic local search for the maximum clique problem},
+  author={Pullan, Wayne and Hoos, Holger H},
+  journal={Journal of Artificial Intelligence Research},
+  volume={25},
+  pages={159--185},
+  year={2006}
+}

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -41,7 +41,7 @@ Summary
     local_search
 
 Code details
-------------
+^^^^^^^^^^^^
 """
 import networkx as nx
 

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -59,8 +59,8 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
     and selects one candidate node from :math:`C_0` to make a larger clique. Plateau search is
     performed with the :func:`~.clique_swap` function, which evaluates the set :math:`C_1` of
     nodes in the remainder of the graph that are connected to all but one of the nodes in the
-    clique, and selects one candidate from :math:`C_1` and its corresponding unconnected node in
-    the clique to swap.
+    clique. The function then proceeds to select one candidate from :math:`C_1` and swap it with
+    its corresponding node in the clique.
 
     The iterative applications of growth and search are applied until either the specified number
     of iterations has been carried out or when a dead end has been reached. The function reaches
@@ -76,8 +76,8 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
         graph (nx.Graph): the input graph
         iterations (int): number of steps in the algorithm
         node_select (str): method of selecting nodes during swap and growth. Can be either
-        ``"uniform"`` for uniform random selection or ``"degree"`` for degree-based selection.
-        Defaults to ``"uniform"``
+            ``"uniform"`` for uniform random selection or ``"degree"`` for degree-based selection.
+            Defaults to ``"uniform"``
 
     Returns:
        list[int]: the largest cliques found by the algorithm

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -53,23 +53,32 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
 
     This function implements a version of the local search algorithm given in
     :ref:`pullan2006dynamic` and :ref:`pullan2006phased`. It proceeds by iteratively applying
-    phases of greedy growth and plateau search to the input clique subgraph. Growth is achieved
-    using the :func:`~.clique_grow` function, which repeatedly evaluates the set :math:`C_0` of
-    nodes in the remainder of the graph that are connected to all nodes in the clique,
-    and selects one candidate node from :math:`C_0` to make a larger clique. Plateau search is
-    performed with the :func:`~.clique_swap` function, which evaluates the set :math:`C_1` of
-    nodes in the remainder of the graph that are connected to all but one of the nodes in the
-    clique. The function then proceeds to select one candidate from :math:`C_1` and swap it with
-    its corresponding node in the clique.
+    phases of greedy growth and plateau search to the input clique subgraph.
+
+    **Growth phase**
+
+    Growth is achieved using the :func:`~.clique_grow` function, which repeatedly evaluates the
+    set :math:`C_0` of nodes in the remainder of the graph that are connected to all nodes in the
+    clique, and selects one candidate node from :math:`C_0` to make a larger clique.
+
+    **Search phase**
+
+    Plateau search is performed with the :func:`~.clique_swap` function, which evaluates the set
+    :math:`C_1` of nodes in the remainder of the graph that are connected to all but one of the
+    nodes in the clique. The function then proceeds to select one candidate from :math:`C_1` and
+    swap it with its corresponding node in the clique.
+
+    Whenever the sets :math:`C_0` and :math:`C_1` used during growth and swapping have more than
+    one element, there must be a choice of which node to add or swap. This choice is specified
+    with the ``node_select`` argument, with node selection based on uniform randomness and node
+    degree supported. Degree-based node selection involves picking the node with the greatest
+    degree, with ties settled by uniform random choice.
+
+    **Stopping**
 
     The iterative applications of growth and search are applied until either the specified number
     of iterations has been carried out or when a dead end has been reached. The function reaches
-    a dead end when it is unable to perform any new swaps or growth. Whenever the sets
-    :math:`C_0` and :math:`C_1` used during growth and swapping have more than one element,
-    there must be a choice of which node to add or swap. This choice is specified with the
-    ``node_select`` argument, with node selection based on uniform randomness and node degree
-    supported. Degree-based node selection involves picking the node with the greatest degree,
-    with ties settled by uniform random choice.
+    a dead end when it is unable to perform any new swaps or growth.
 
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -52,7 +52,7 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
     """Use local search algorithm to identify large cliques.
 
     This function implements a version of the local search algorithm given in
-    :ref:`pullan2006dynamic` and :ref:`pullan2006phased`. It proceeds by iteratively applying
+    :cite:`pullan2006dynamic` and :cite:`pullan2006phased`. It proceeds by iteratively applying
     phases of greedy growth and plateau search to the input clique subgraph.
 
     **Growth phase**

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -80,6 +80,14 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
     of iterations has been carried out or when a dead end has been reached. The function reaches
     a dead end when it is unable to perform any new swaps or growth.
 
+    Example usage:
+
+    >>> graph = nx.lollipop_graph(4, 1)
+    >>> graph.add_edge(4, 2)
+    >>> clique = [3, 4]
+    >>> local_search(clique, graph, iterations=10)
+    [0, 1, 2, 3]
+
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -54,14 +54,13 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
     This function implements a version of the local search algorithm given in
     :ref:`pullan2006dynamic` and :ref:`pullan2006phased`. It proceeds by iteratively applying
     phases of greedy growth and plateau search to the input clique subgraph. Growth is achieved
-    using the :func:`~strawberryfields.apps.graph.resize.clique_grow` function, which repeatedly
-    evaluates the set :math:`C_0` of nodes in the remainder of the graph that are connected to
-    all nodes in the clique, and selects one candidate node from :math:`C_0` to make a larger
-    clique. Plateau search is performed with the
-    :func:`~strawberryfields.apps.graph.resize.clique_swap` function, which evaluates the set
-    :math:`C_1` of nodes in the remainder of the graph that are connected to all but one of the
-    nodes in the clique, and selects one candidate from :math:`C_1` and its corresponding
-    unconnected node in the clique to swap.
+    using the :func:`~.clique_grow` function, which repeatedly evaluates the set :math:`C_0` of
+    nodes in the remainder of the graph that are connected to all nodes in the clique,
+    and selects one candidate node from :math:`C_0` to make a larger clique. Plateau search is
+    performed with the :func:`~.clique_swap` function, which evaluates the set :math:`C_1` of
+    nodes in the remainder of the graph that are connected to all but one of the nodes in the
+    clique, and selects one candidate from :math:`C_1` and its corresponding unconnected node in
+    the clique to swap.
 
     The iterative applications of growth and search are applied until either the specified number
     of iterations has been carried out or when a dead end has been reached. The function reaches

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -95,5 +95,5 @@ def local_search(
 
     if grow == swap or iterations == 0:
         return swap
-    else:
-        return local_search(swap, graph, iterations, node_select)
+
+    return local_search(swap, graph, iterations, node_select)

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -1,0 +1,98 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Maximum clique
+==============
+
+**Module name:** :mod:`strawberryfields.apps.graph.max_clique`
+
+.. currentmodule:: strawberryfields.apps.graph.max_clique
+
+This module provides tools for users to identify large cliques in graphs. A clique is a subgraph
+where all nodes are connected to each other. The maximum clique problem is to identify the
+largest clique in a graph. The problem is NP-Hard in a worst-case setting, which is why it is
+valuable to develop better algorithms to tackle it.
+
+The core of this module is a local search algorithm that proceeds as follows:
+
+#. A small clique in the graph is identified. The initial clique can be a single node, or it can
+   be obtained by shrinking a random subgraph, for example obtained from GBS.
+#. The clique is grown as much as possible by adding nodes connected to all nodes in the clique.
+#. When no more growth is possible, a node in the clique is swapped with a node outside of it.
+
+Steps 2-3 are repeated until a pre-determined number of steps have been completed, or until no
+more growth or swaps are possible.
+
+Summary
+-------
+
+.. autosummary::
+    local_search
+
+Code details
+------------
+"""
+import networkx as nx
+
+from strawberryfields.apps.graph import resize
+
+
+def local_search(clique: list, graph: nx.Graph, iterations: int = 100, node_select: str =
+"uniform") -> list:
+    """Use local search algorithm to identify large cliques.
+
+    This function implements a version of the local search algorithm given in
+    :ref:`pullan2006dynamic` and :ref:`pullan2006phased`. It proceeds by iteratively applying
+    phases of greedy growth and plateau search to the input clique subgraph. Growth is achieved
+    using the :func:`~strawberryfields.apps.graph.resize.clique_grow` function, which repeatedly
+    evaluates the set :math:`C_0` of nodes in the remainder of the graph that are connected to
+    all nodes in the clique, and selects one candidate node from :math:`C_0` to make a larger
+    clique. Plateau search is performed with the
+    :func:`~strawberryfields.apps.graph.resize.clique_swap` function, which evaluates the set
+    :math:`C_1` of nodes in the remainder of the graph that are connected to all but one of the
+    nodes in the clique, and selects one candidate from :math:`C_1` and its corresponding
+    unconnected node in the clique to swap.
+
+    The iterative applications of growth and search are applied until either the specified number
+    of iterations has been carried out or when a dead end has been reached. The function reaches
+    a dead end when it is unable to perform any new swaps or growth. Whenever the sets
+    :math:`C_0` and :math:`C_1` used during growth and swapping have more than one element,
+    there must be a choice of which node to add or swap. This choice is specified with the
+    ``node_select`` argument, with node selection based on uniform randomness and node degree
+    supported. Degree-based node selection involves picking the node with the greatest degree,
+    with ties settled by uniform random choice.
+
+    Args:
+        clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
+        graph (nx.Graph): the input graph
+        iterations (int): number of steps in the algorithm; defaults to 100
+        node_select (str): method of selecting nodes during swap and growth. Can be either
+        ``"uniform"`` for uniform random selection or ``"degree"`` for degree-based selection.
+        Defaults to ``"uniform"``
+
+    Returns:
+       list[int]: the largest cliques found by the algorithm
+    """
+    if iterations < 1:
+        raise ValueError("Number of iterations must be a positive int")
+
+    grow = resize.clique_grow(clique, graph, node_select=node_select)
+    swap = resize.clique_swap(grow, graph, node_select=node_select)
+
+    iterations -= 1
+
+    if grow == swap or iterations == 0:
+        return swap
+    else:
+        return local_search(swap, graph, iterations, node_select)

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -48,8 +48,9 @@ import networkx as nx
 from strawberryfields.apps.graph import resize
 
 
-def local_search(clique: list, graph: nx.Graph, iterations: int = 100, node_select: str =
-"uniform") -> list:
+def local_search(
+    clique: list, graph: nx.Graph, iterations: int = 100, node_select: str = "uniform"
+) -> list:
     """Use local search algorithm to identify large cliques.
 
     This function implements a version of the local search algorithm given in

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -90,7 +90,7 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
 
     iterations -= 1
 
-    if grow == swap or iterations == 0:
+    if set(grow) == set(swap) or iterations == 0:
         return swap
 
     return local_search(swap, graph, iterations, node_select)

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -48,9 +48,7 @@ import networkx as nx
 from strawberryfields.apps.graph import resize
 
 
-def local_search(
-    clique: list, graph: nx.Graph, iterations: int = 100, node_select: str = "uniform"
-) -> list:
+def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "uniform") -> list:
     """Use local search algorithm to identify large cliques.
 
     This function implements a version of the local search algorithm given in
@@ -77,7 +75,7 @@ def local_search(
     Args:
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
-        iterations (int): number of steps in the algorithm; defaults to 100
+        iterations (int): number of steps in the algorithm
         node_select (str): method of selecting nodes during swap and growth. Can be either
         ``"uniform"`` for uniform random selection or ``"degree"`` for degree-based selection.
         Defaults to ``"uniform"``

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -22,6 +22,8 @@ import numpy as np
 from strawberryfields.apps.graph import max_clique
 from strawberryfields.apps.graph import resize
 
+pytestmark = pytest.mark.apps
+
 
 def patch_random_choice(x):
     """Dummy function for ``np.random.choice`` to make output deterministic. This dummy function

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -44,7 +44,7 @@ class TestLocalSearch:
         """Test if function raises a ``ValueError`` when a non-positive number of iterations is
         specified"""
         with pytest.raises(ValueError, match="Number of iterations must be a positive int"):
-            max_clique.local_search(clique=[0, 1, 2, 3], graph=nx.empty_graph(5), iterations=-1)
+            max_clique.local_search(clique=[0, 1, 2, 3], graph=nx.complete_graph(5), iterations=-1)
 
     def test_max_iterations(self, monkeypatch):
         """Test if function stops after 5 iterations despite not being in a dead end (i.e., when

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -1,0 +1,30 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Unit tests for strawberryfields.apps.graph.max_clique
+"""
+# pylint: disable=no-self-use,unused-argument
+import pytest
+
+from strawberryfields.apps.graph import max_clique
+
+
+class TestLocalSearch:
+    """Tests for the function ``max_clique.local_search``"""
+
+    def test_bad_iterations(self, graph):
+        """Test if function raises a ``ValueError`` when a non-positive number of iterations is
+        specified"""
+        with pytest.raises(ValueError, match="Number of iterations must be a positive int"):
+            max_clique.local_search(clique=[0, 1, 2, 3], graph=graph, iterations=-1)

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -66,7 +66,7 @@ class TestLocalSearch:
         """Test if function stops when in a dead end (i.e., ``grow == swap``) such that no
         swapping is possible. This is achieved by monkeypatching ``clique_grow`` and
         ``clique_swap`` so that they simply return the same clique as fed in, which should cause
-        the local search algorithm to conclude that it is already in a dead and and return the
+        the local search algorithm to conclude that it is already in a dead end and return the
         same clique."""
 
         graph = nx.complete_graph(5)
@@ -75,7 +75,7 @@ class TestLocalSearch:
         with monkeypatch.context() as m:
             m.setattr(resize, "clique_grow", patch_clique_resize)
             m.setattr(resize, "clique_swap", patch_clique_resize)
-            result = max_clique.local_search(clique, graph)
+            result = max_clique.local_search(clique, graph, iterations=100)
 
         assert result == clique
 
@@ -91,5 +91,5 @@ class TestLocalSearch:
         graph.add_edge(4, 2)
 
         clique = [3, 4]
-        result = max_clique.local_search(clique, graph)
+        result = max_clique.local_search(clique, graph, iterations=100)
         assert result == [0, 1, 2, 3]

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -79,7 +79,7 @@ class TestLocalSearch:
 
         assert result == clique
 
-    def test_complete_graph(self):
+    def test_expected_growth(self):
         """Test if function performs a growth and swap phase, followed by another growth and
         attempted swap phase. This is carried out by starting with a 4+1 node lollipop graph,
         adding a connection from node 4 to node 2 and starting with the [3, 4] clique. The local

--- a/tests/apps/test_graph_max_clique.py
+++ b/tests/apps/test_graph_max_clique.py
@@ -16,15 +16,80 @@ Unit tests for strawberryfields.apps.graph.max_clique
 """
 # pylint: disable=no-self-use,unused-argument
 import pytest
+import networkx as nx
+import numpy as np
 
 from strawberryfields.apps.graph import max_clique
+from strawberryfields.apps.graph import resize
+
+
+def patch_random_choice(x):
+    """Dummy function for ``np.random.choice`` to make output deterministic. This dummy function
+    just returns the element of ``x`` specified by ``element``."""
+    if isinstance(x, int):  # np.random.choice can accept an int or 1D array-like input
+        return 0
+
+    return x[0]
+
+
+def patch_clique_resize(clique, graph, node_select):
+    """Dummy function for ``clique_grow`` and ``clique_swap`` to make output unchanged."""
+    return clique
 
 
 class TestLocalSearch:
     """Tests for the function ``max_clique.local_search``"""
 
-    def test_bad_iterations(self, graph):
+    def test_bad_iterations(self):
         """Test if function raises a ``ValueError`` when a non-positive number of iterations is
         specified"""
         with pytest.raises(ValueError, match="Number of iterations must be a positive int"):
-            max_clique.local_search(clique=[0, 1, 2, 3], graph=graph, iterations=-1)
+            max_clique.local_search(clique=[0, 1, 2, 3], graph=nx.empty_graph(5), iterations=-1)
+
+    def test_max_iterations(self, monkeypatch):
+        """Test if function stops after 5 iterations despite not being in a dead end (i.e., when
+        ``grow != swap``). This is achieved by monkeypatching the ``np.random.choice`` call in
+        ``clique_grow`` and ``clique_swap`` so that for a 5-node wheel graph starting as a [0,
+        1] node clique, the algorithm simply oscillates between [0, 1, 2] and [0, 2, 3] for each
+        iteration of growth & swap. For odd iterations, we get [0, 2, 3]."""
+
+        graph = nx.wheel_graph(5)
+        clique = [0, 1]
+
+        with monkeypatch.context() as m:
+            m.setattr(np.random, "choice", patch_random_choice)
+            result = max_clique.local_search(clique, graph, iterations=5)
+
+        assert result == [0, 2, 3]
+
+    def test_dead_end(self, monkeypatch):
+        """Test if function stops when in a dead end (i.e., ``grow == swap``) such that no
+        swapping is possible. This is achieved by monkeypatching ``clique_grow`` and
+        ``clique_swap`` so that they simply return the same clique as fed in, which should cause
+        the local search algorithm to conclude that it is already in a dead and and return the
+        same clique."""
+
+        graph = nx.complete_graph(5)
+        clique = [0, 1, 2]
+
+        with monkeypatch.context() as m:
+            m.setattr(resize, "clique_grow", patch_clique_resize)
+            m.setattr(resize, "clique_swap", patch_clique_resize)
+            result = max_clique.local_search(clique, graph)
+
+        assert result == clique
+
+    def test_complete_graph(self):
+        """Test if function performs a growth and swap phase, followed by another growth and
+        attempted swap phase. This is carried out by starting with a 4+1 node lollipop graph,
+        adding a connection from node 4 to node 2 and starting with the [3, 4] clique. The local
+        search algorithm should first grow to [2, 3, 4] and then swap to either [0, 2, 3] or [1,
+        2, 3], and then grow again to [0, 1, 2, 3] and being unable to swap, hence returning [0,
+        1, 2, 3]"""
+
+        graph = nx.lollipop_graph(4, 1)
+        graph.add_edge(4, 2)
+
+        clique = [3, 4]
+        result = max_clique.local_search(clique, graph)
+        assert result == [0, 1, 2, 3]


### PR DESCRIPTION
We are providing the local search algorithm with periods of clique growth and clique swapping. This function takes in cliques one at a time, so the user can interface by:

1. generating subgraphs from GBS
2. shrinking them to cliques
3. feeding them through the local search function.

Time permitting, we may consider a subsequent PR which combines all these into a single function.