### PR TITLE
Provide applications layer in docs and polish max clique documentation

### DIFF
--- a/doc/code/apps/graph.max_clique.rst
+++ b/doc/code/apps/graph.max_clique.rst
@@ -1,0 +1,2 @@
+.. automodule:: strawberryfields.apps.graph.max_clique
+    :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -173,3 +173,4 @@ Strawberry Fields is **free** and **open source**, released under the Apache Lic
    code/apps/graph.resize
    code/apps/graph.sample
    code/apps/graph.utils
+   code/apps/graph.max_clique

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -161,3 +161,15 @@ Strawberry Fields is **free** and **open source**, released under the Apache Lic
    code/backend.gaussian
    code/backend.fock
    code/backend.tf
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Applications Layer
+   :hidden:
+
+   code/apps/sample
+   code/apps/graph.dense
+   code/apps/graph.resize
+   code/apps/graph.sample
+   code/apps/graph.utils

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -49,7 +49,7 @@ from strawberryfields.apps.graph import resize
 
 
 def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "uniform") -> list:
-    """Use local search algorithm to identify large cliques.
+    """Local search algorithm for identifying large cliques.
 
     This function implements a version of the local search algorithm given in
     :cite:`pullan2006dynamic` and :cite:`pullan2006phased`. It proceeds by iteratively applying

--- a/strawberryfields/apps/graph/max_clique.py
+++ b/strawberryfields/apps/graph/max_clique.py
@@ -80,7 +80,7 @@ def local_search(clique: list, graph: nx.Graph, iterations, node_select: str = "
     of iterations has been carried out or when a dead end has been reached. The function reaches
     a dead end when it is unable to perform any new swaps or growth.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.lollipop_graph(4, 1)
     >>> graph.add_edge(4, 2)

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -255,7 +255,7 @@ def clique_grow(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
     supported. Degree-based node selection involves picking the node with the greatest degree,
     with ties settled by uniform random choice.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.complete_graph(10)
     >>> clique = [0, 1, 2, 3, 4]
@@ -314,7 +314,7 @@ def clique_swap(clique: list, graph: nx.Graph, node_select: str = "uniform") -> 
     supported. Degree-based node selection involves picking the node with the greatest degree,
     with ties settled by uniform random choice.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.wheel_graph(5)
     >>> graph.remove_edge(0, 4)
@@ -366,7 +366,7 @@ def clique_shrink(subgraph: list, graph: nx.Graph) -> list:
     that satisfies :func:`~strawberryfields.apps.graph.utils.is_clique`. Upon each iteration,
     this function selects the node with lowest degree relative to the subgraph and removes it.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.barbell_graph(4, 0)
     >>> subgraph = [0, 1, 2, 3, 4, 5]

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -26,6 +26,7 @@ algorithms for finding dense subgraphs and maximum cliques for the following ele
   size (functionality provided by :func:`~.sample_subgraphs`). Resizing can be used to realize a
   certain property, such as to reach a desired size (see :func:`resize_subgraphs`) or to resize
   to a clique (see :func:`clique_shrink`).
+
 - Heuristic algorithms can use graph resizing to explore the search space, for example growing and
   swapping a clique (see :func:`clique_grow` and :func:`clique_swap`).
 

--- a/strawberryfields/apps/graph/resize.py
+++ b/strawberryfields/apps/graph/resize.py
@@ -19,16 +19,15 @@ Graph resizing
 
 .. currentmodule:: strawberryfields.apps.graph.resize
 
-This module provides functionality for resizing of subgraphs. Samples from
-:func:`~strawberryfields.apps.sample.quantum_sampler` have a variable number of clicks (
-equivalently, the number of ones for samples with threshold detection). This results in subgraphs of
-a random size in :func:`~strawberryfields.apps.graph.sample.dense_subgraph_sampler_gbs`.
-However, some algorithms may want to work with subgraphs of a fixed size, necessitating the
-resizing of sample subgraphs.
+This module provides functionality for resizing of subgraphs. Subgraph resizing is used in
+algorithms for finding dense subgraphs and maximum cliques for the following elements:
 
-Resizing functionality is provided by the :func:`resize_subgraphs` function, allowing the user to
-make use of different methods for resizing. The available methods are specified in
-:func:`resize_subgraphs`.
+- Samples from GBS have a variable number of clicks, resulting in subgraph samples of variable
+  size (functionality provided by :func:`~.sample_subgraphs`). Resizing can be used to realize a
+  certain property, such as to reach a desired size (see :func:`resize_subgraphs`) or to resize
+  to a clique (see :func:`clique_shrink`).
+- Heuristic algorithms can use graph resizing to explore the search space, for example growing and
+  swapping a clique (see :func:`clique_grow` and :func:`clique_swap`).
 
 Summary
 -------

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -154,7 +154,7 @@ def is_clique(graph: nx.Graph) -> bool:
     """Determines if the input graph is a clique. A clique of :math:`n` nodes has exactly :math:`n(
     n-1)/2` edges.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.complete_graph(10)
     >>> is_clique(graph)
@@ -179,7 +179,7 @@ def c_0(clique: list, graph: nx.Graph):
     The set :math:`C_0` is defined in :cite:`pullan2006phased` and is used to determine nodes
     that can be added to the current clique to grow it into a larger one.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.complete_graph(10)
     >>> clique = [0, 1, 2, 3, 4]
@@ -215,7 +215,7 @@ def c_1(clique: list, graph: nx.Graph):
     The set :math:`C_1` is defined in :cite:`pullan2006phased` and is used to determine outside
     nodes that can be swapped with clique nodes to create a new clique.
 
-    Example usage:
+    **Example usage:**
 
     >>> graph = nx.wheel_graph(5)
     >>> clique = [0, 1, 2]

--- a/strawberryfields/apps/graph/utils.py
+++ b/strawberryfields/apps/graph/utils.py
@@ -210,7 +210,7 @@ def c_0(clique: list, graph: nx.Graph):
 
 def c_1(clique: list, graph: nx.Graph):
     """Generates the set :math:`C_1` of nodes that are connected to all but one of the nodes in
-    the input clique subgraph
+    the input clique subgraph.
 
     The set :math:`C_1` is defined in :cite:`pullan2006phased` and is used to determine outside
     nodes that can be swapped with clique nodes to create a new clique.
@@ -227,8 +227,8 @@ def c_1(clique: list, graph: nx.Graph):
         graph (nx.Graph): the input graph
 
     Returns:
-       list[tuple(int)]: A list of tuples. The first node in the tuple is the node in the clique and the
-       second node is the outside node it can be swapped with.
+       list[tuple(int)]: A list of tuples. The first node in the tuple is the node in the clique
+       and the second node is the outside node it can be swapped with.
    """
     if not is_clique(graph.subgraph(clique)):
         raise ValueError("Input subgraph is not a clique")

--- a/strawberryfields/apps/sample.py
+++ b/strawberryfields/apps/sample.py
@@ -28,8 +28,7 @@ choosing a symmetric input matrix to sample from :cite:`bradler2018gaussian`. Fo
 an :math:`N`-mode GBS device with threshold detectors generates samples that are binary strings
 of length ``N``. Various problems can be encoded in the matrix :math:`A` so that the output
 samples are informative and can be used as a form of randomness to improve solvers, as outlined
-in Refs. :cite:`arrazola2018using` and :cite:`arrazola2018quantum` and also shown in our
-:ref:`tutorial_dense_subgraph` tutorial.
+in Refs. :cite:`arrazola2018using` and :cite:`arrazola2018quantum`.
 
 On the other hand, the :func:`uniform_sampler` function allows users to generate samples where a
 subset of modes are selected using the uniform distribution.
@@ -57,22 +56,14 @@ from strawberryfields.apps.graph import utils
 QUANTUM_BACKENDS = ("gaussian",)
 """tuple[str]: Available quantum backends for sampling."""
 
-BACKEND_DEFAULTS = {
-    "remote": False,
-    "backend": "gaussian",
-    "threshold": True,
-    "postselect": 0,
-}
+BACKEND_DEFAULTS = {"remote": False, "backend": "gaussian", "threshold": True, "postselect": 0}
 """dict[str, Any]: Dictionary to specify default parameters of options in backend sampling for
 :func:`quantum_sampler`.
 """
 
 
 def quantum_sampler(
-    A: np.ndarray,
-    n_mean: float,
-    samples: int = 1,
-    backend_options: Optional[dict] = None,
+    A: np.ndarray, n_mean: float, samples: int = 1, backend_options: Optional[dict] = None
 ) -> list:
     r"""Generate samples from GBS
 
@@ -93,7 +84,7 @@ def quantum_sampler(
             ``QUANTUM_BACKENDS``, these are:
 
             - ``"gaussian"``: for simulating the output of a GBS device using the
-            :mod:`strawberryfields.backends.gaussianbackend`
+              :mod:`strawberryfields.backends.gaussianbackend`
 
         key: ``"threshold"``, value: *bool*
             Performs sampling using threshold (on/off click) detectors if ``True``
@@ -111,7 +102,7 @@ def quantum_sampler(
         n_mean (float): mean photon number
         samples (int): number of samples; defaults to 1
         backend_options (dict[str, Any]): dictionary specifying options used by backends during
-        sampling; defaults to :const:`BACKEND_DEFAULTS`
+            sampling; defaults to :const:`BACKEND_DEFAULTS`
 
     Returns:
         list[list[int]]: a list of length ``samples`` whose elements are length :math:`N` lists of
@@ -121,9 +112,7 @@ def quantum_sampler(
     backend_options = {**BACKEND_DEFAULTS, **(backend_options or {})}
 
     if not utils.is_undirected(A):
-        raise ValueError(
-            "Input must be a NumPy array corresponding to a symmetric matrix"
-        )
+        raise ValueError("Input must be a NumPy array corresponding to a symmetric matrix")
 
     if samples < 1:
         raise ValueError("Number of samples must be at least one")
@@ -171,9 +160,7 @@ def quantum_sampler(
     return s
 
 
-def _sample_sf(
-    p: sf.Program, shots: int = 1, backend_options: Optional[dict] = None
-) -> np.ndarray:
+def _sample_sf(p: sf.Program, shots: int = 1, backend_options: Optional[dict] = None) -> np.ndarray:
     """Generate samples from Strawberry Fields.
 
     Args:


### PR DESCRIPTION
The purpose of this PR is to make the applications layer accessible in the SF documentation by adding in as a table of contents. This does not include a full integration (e.g., giving more details about the apps layer in the top level `index.rst` file), which can be done at a later date once the applications layer matures.

This PR also includes a check through of the documentation for the recently added maximum clique functionality.