### PR TITLE
Fix issue #192 and part of #193 (decompositions.rectangular_*)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ### New features
 
-* Fixed bug in `strawberryfields.decompositions.rectangular_symmetric` so its
-  returned phases are all in the interval [0, 2*pi), and corrects the
-  function docstring.
-  [#196](https://github.com/XanaduAI/strawberryfields/pull/196)
-
 * Adds in first version of an applications layer aimed at solving problems using
   Gaussian boson sampling. This layer focuses on graph-based problems and
   currently has algorithms for the densest ``k``-subgraph problem.
@@ -77,6 +72,11 @@
   [#160](https://github.com/XanaduAI/strawberryfields/pull/160)
 
 ### Bug fixes
+
+* Fixed bug in `strawberryfields.decompositions.rectangular_symmetric` so its
+  returned phases are all in the interval [0, 2*pi), and corrects the
+  function docstring.
+  [#196](https://github.com/XanaduAI/strawberryfields/pull/196)
 
 * When using the `'gbs'` compilation target, the measured registers are now sorted in
   ascending order in the resulting compiled program.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### New features
 
+* Fixes bug in `strawberryfields.decompositions.rectangular_symmetric` so its
+  returned phases are all in the interval [0, 2*pi[, and corrects the
+  function docstring.
+
 * Adds in first version of an applications layer aimed at solving problems using
   Gaussian boson sampling. This layer focuses on graph-based problems and
   currently has algorithms for the densest ``k``-subgraph problem.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### New features
 
-* Fixes bug in `strawberryfields.decompositions.rectangular_symmetric` so its
-  returned phases are all in the interval [0, 2*pi[, and corrects the
+* Fixed bug in `strawberryfields.decompositions.rectangular_symmetric` so its
+  returned phases are all in the interval [0, 2*pi), and corrects the
   function docstring.
+  [#196](https://github.com/XanaduAI/strawberryfields/pull/196)
 
 * Adds in first version of an applications layer aimed at solving problems using
   Gaussian boson sampling. This layer focuses on graph-based problems and

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -450,8 +450,10 @@ def rectangular_symmetric(V, tol=1e-11):
         tuple[array]: returns a tuple of the form ``(tlist,np.diag(localV), None)``
             where:
 
-            * ``tlist``: list containing ``[n,m,internal_phase,external_phase,n_size]`` of the T unitaries needed
+            * ``tlist``: list containing ``[n, m, internal_phase, external_phase, n_size]`` of the T unitaries needed
             * ``localV``: Diagonal unitary matrix to be applied at the end of circuit
+            * ``None``: the value ``None``, in order to make the return
+              signature identical to the one of :func:`rectangular`.
     """
     tlist, diags, _ = rectangular_phase_end(V, tol)
     new_tlist, new_diags = [], np.ones(len(diags), dtype=diags.dtype)

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -370,7 +370,7 @@ def rectangular_phase_end(V, tol=1e-11):
 
         # The new parameters required for D',T' st. T^(-1)D = D'T'
         new_theta = theta
-        new_phi = np.fmod((alpha - beta + np.pi), 2*np.pi)
+        new_phi = (alpha - beta + np.pi) % (2 * np.pi)
         new_alpha = beta - phi + np.pi
         new_beta = beta
 
@@ -459,8 +459,8 @@ def rectangular_symmetric(V, tol=1e-11):
         em, en = int(i[0]), int(i[1])
         alpha, beta = np.angle(new_diags[em]), np.angle(new_diags[en])
         theta, phi = i[2], i[3]
-        external_phase = np.fmod((phi + alpha - beta), 2 * np.pi)
-        internal_phase = np.fmod((np.pi + 2.0 * theta), 2 * np.pi)
+        external_phase = (phi + alpha - beta) % (2 * np.pi)
+        internal_phase = (np.pi + 2.0 * theta) % (2 * np.pi)
         new_alpha = beta - theta + np.pi
         new_beta = 0*np.pi - theta + beta
         new_i = [i[0], i[1], internal_phase, external_phase, i[4]]

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -463,11 +463,16 @@ def rectangular_symmetric(V, tol=1e-11):
         theta, phi = i[2], i[3]
         external_phase = (phi + alpha - beta) % (2 * np.pi)
         internal_phase = (np.pi + 2.0 * theta) % (2 * np.pi)
+        # repeat modulo operations , otherwise the input unitary
+        # numpy.identity(20) yields an external_phase of exactly 2 * pi
+        external_phase %= (2 * np.pi)
+        internal_phase %= (2 * np.pi)
         new_alpha = beta - theta + np.pi
         new_beta = 0*np.pi - theta + beta
         new_i = [i[0], i[1], internal_phase, external_phase, i[4]]
         new_diags[em], new_diags[en] = np.exp(1j*new_alpha), np.exp(1j*new_beta)
         new_tlist = new_tlist + [new_i]
+
     new_diags = diags * new_diags
 
     return new_tlist, new_diags, None

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -453,7 +453,7 @@ def rectangular_symmetric(V, tol=1e-11):
             * ``tlist``: list containing ``[n, m, internal_phase, external_phase, n_size]`` of the T unitaries needed
             * ``localV``: Diagonal unitary matrix to be applied at the end of circuit
             * ``None``: the value ``None``, in order to make the return
-              signature identical to the one of :func:`rectangular`.
+              signature identical to :func:`rectangular`
     """
     tlist, diags, _ = rectangular_phase_end(V, tol)
     new_tlist, new_diags = [], np.ones(len(diags), dtype=diags.dtype)

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -308,6 +308,8 @@ class TestRectangularSymmetricDecomposition:
         tlist, diags, _ = dec.rectangular_symmetric(U)
         qrec = np.identity(nmax)
         for i in tlist:
+            assert i[2] >= 0 and i[2] < 2 * np.pi  # internal phase
+            assert i[3] >= 0 and i[3] < 2 * np.pi  # external phase
             qrec = dec.mach_zehnder(*i) @ qrec
         qrec = np.diag(diags) @ qrec
         assert np.allclose(U, qrec, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
The sign of the phases returned by `strawberryfields.decompositions.rectangular_symmetric` depended on algorithm details due to the incorrect use of `numpy.fmod` instead of the standard python modulo (`%`) operator. 

**Description of the Change:**
Fixes bug in `strawberryfields.decompositions.rectangular_symmetric` so its returned phases are all in the interval [0, 2*pi[, adds tests for this, and corrects a bug in the function docstring. 

**Benefits:**
The user can be sure that the returned phases are in the interval from 0 to 2 pi. 

**Possible Drawbacks:**
-

**Related GitHub Issues:**
#192 and part of #193