### PR TITLE
GBS Refactor: New search function for dense subgraphs

### DIFF
--- a/strawberryfields/gbs/subgraph.py
+++ b/strawberryfields/gbs/subgraph.py
@@ -150,7 +150,7 @@ def _update_subgraphs_list(l: list, t: tuple, max_count: int) -> None:
     """
     t = (t[0], sorted(set(t[1])))
 
-    for d, s in l:
+    for _d, s in l:
         if t[1] == s:
             return None
 
@@ -170,6 +170,8 @@ def _update_subgraphs_list(l: list, t: tuple, max_count: int) -> None:
             del l[-1]
             l.append(t)
             l.sort(reverse=True)
+
+    return None
 
 
 def resize(subgraph: list, graph: nx.Graph, min_size: int, max_size: int) -> dict:

--- a/strawberryfields/gbs/subgraph.py
+++ b/strawberryfields/gbs/subgraph.py
@@ -73,27 +73,47 @@ def search(
     for s in subgraphs:
         s = set(s)
         if not s.issubset(nodes):
-            print("List of subgraphs contains an invalid subgraph, continuing")
             continue
 
         r = resize(s, graph, min_size, max_size)
 
-        for size in size_range:
-            current = dense.get(size, default=[])
-
-            candidate = r.get(size)
-            sub = graph.subgraph(candidate)
-            sub_dens = nx.density(sub)
-
-            if len(current) < top_count:
-                current.append((sub_dens, sub))
-                current.sort()
-            elif sub_dens > min(current):
-                current.append((sub_dens, sub))
-                current.sort()
-                del current[-1]
+        _combine_dicts(dense, r, graph, top_count)
 
     return dense
+
+
+def _combine_dicts(main: dict, new: dict, graph: nx.Graph, top_count: int) -> None:
+
+    for size, candidate in new.items():
+        current = main.get(size)
+
+        sub = graph.subgraph(candidate)
+        sub_dens = nx.density(sub)
+
+        if current is None:
+            current = [(sub_dens, candidate)]
+            main[size] = current
+        else:
+            _add_to_list(current, candidate, sub_dens)
+
+
+def _add_candidate_subgraph(l: list, t: tuple, max_count: int) ->
+
+
+def _add_to_list(l: list, subgraph: list, density: float, top_count: int) -> None:
+
+    current_subgraphs = set(tuple(elem[1]) for elem in l)
+    subgraph = sorted(set(subgraph))
+
+    if not {tuple(subgraph)}.issubset(current_subgraphs):
+
+        if len(l) < top_count:
+            l.append((density, subgraph))
+            l.sort()
+        elif density > min(l)[0]:
+            l.append((density, subgraph))
+            l.sort()
+            del l[-1]
 
 
 def resize(subgraph: list, graph: nx.Graph, min_size: int, max_size: int) -> dict:

--- a/strawberryfields/gbs/subgraph.py
+++ b/strawberryfields/gbs/subgraph.py
@@ -19,37 +19,13 @@ Dense subgraph identification
 
 .. currentmodule:: strawberryfields.gbs.subgraph
 
-This module provides tools for users to identify dense subgraphs. Current functionality focuses
-on the densest-:math:`k` subgraph problem :cite:`arrazola2018using`, which is NP-hard. This
-problem considers an undirected graph :math:`G = (V, E)` of :math:`N` nodes :math:`V` and a list
-of edges :math:`E`, and sets the objective of finding a :math:`k`-vertex subgraph with the
-greatest density. In this setting, subgraphs :math:`G[S]` are defined by nodes :math:`S \subset
-V` and corresponding edges :math:`E_{S} \subseteq E` that have both endpoints in :math:`S`. The
-density of a subgraph is given by
+This module provides tools for users to idensity dense subgraphs.
 
-.. math:: d(G[S]) = \frac{2 |E_{S}|}{|S|(|S|-1)},
-
-where :math:`|\cdot|` denotes cardinality, and the densest-:math:`k` subgraph problem can be
-written succinctly as
-
-.. math:: {\rm argmax}_{S \in \mathcal{S}_{k}} d(G[S])
-
-with :math:`\mathcal{S}_{k}` the set of all possible :math:`k` node subgraphs. This problem grows
-combinatorially with :math:`{N \choose k}` and is NP-hard in the worst case.
-
-Heuristics
-----------
-
-The :func:`search` function provides access to heuristic algorithms for finding
-approximate solutions. At present, random search is the heuristic algorithm provided, accessible
-through the :func:`random_search` function. This algorithm proceeds by randomly generating a set
-of :math:`k` vertex subgraphs and selecting the densest.
+The :func:`search` function provides a heuristic algorithm for finding dense regions and proceeds
+by greedily resizing input subgraphs and keeping track of the densest found.
 
 .. autosummary::
     search
-    random_search
-    OPTIONS_DEFAULTS
-    METHOD_DICT
 
 Subgraph resizing
 -----------------
@@ -65,125 +41,59 @@ subgraphs. Resizing functionality is provided by the following function.
 Code details
 ^^^^^^^^^^^^
 """
-from typing import Optional, Tuple
-
 import networkx as nx
 import numpy as np
 
-from strawberryfields.gbs import sample
-
 
 def search(
-    graph: nx.Graph, nodes: int, iterations: int = 1, options: Optional[dict] = None
-) -> Tuple[float, list]:
-    """Find a dense subgraph of a given size.
+    subgraphs: list, graph: nx.Graph, min_size: int, max_size: int, top_count: int = 10
+) -> dict:
+    """Search for dense subgraphs within an input size range.
 
-    This function returns the densest `node-induced subgraph
-    <http://mathworld.wolfram.com/Vertex-InducedSubgraph.html>`__ of size ``nodes`` after
-    multiple repetitions. It uses heuristic optimization that combines search space exploration
-    with local searching. The heuristic method can be set with the ``options`` argument. Methods
-    can contain stochastic elements, where randomness can come from distributions including GBS.
-
-    All elements of the heuristic can be controlled with the ``options`` argument, which should be a
-    dict-of-dicts where the first level specifies the option type as a string-based key,
-    with corresponding value being a dictionary of options for that type. The option types are:
-
-    - ``"heuristic"``: specifying options used by optimization heuristic; corresponding
-      dictionary of options explained further :ref:`below <heuristic>`
-    - ``"backend"``: specifying options used by backend quantum samplers; corresponding
-      dictionary of options explained further in :mod:`~strawberryfields.gbs.sample`
-    - ``"resize"``: specifying options used by resizing method; corresponding dictionary of
-      options explained further in :mod:`~strawberryfields.gbs.resize`
-    - ``"sample"``: specifying options used in sampling; corresponding dictionary of options
-      explained further in :mod:`~strawberryfields.gbs.sample`
-
-    If unspecified, a default set of options is adopted for a given option type.
-
-    .. _heuristic:
-
-    The options dictionary corresponding to ``"heuristic"`` can contain any of the following:
-
-    .. glossary::
-
-        key: ``"method"``, value: *str* or *callable*
-            Value can be either a string selecting from a range of available methods or a
-            customized callable function. Options include:
-
-            - ``"random-search"``: a simple random search algorithm where many subgraphs are
-              selected and the densest one is chosen (default)
-            - *callable*: accepting ``(graph: nx.Graph, nodes: int, iterations: int, options:
-              dict)`` as arguments and returning ``Tuple[float, list]`` corresponding to the
-              density and list of nodes of the densest subgraph found, see :func:`random_search`
-              for an example
+    For each subgraph, this function resizes to the input range specified by ``min_size`` and
+    ``max_size`` and keeps track of the ``top_count`` number of densest subgraphs identified for
+    each size.
 
     Args:
+        subgraphs (list[list[int]]): a list of subgraphs specified by their nodes
         graph (nx.Graph): the input graph
-        nodes (int): the size of desired dense subgraph
-        iterations (int): number of iterations to use in algorithm
-        options (dict[str, dict[str, Any]]): dict-of-dicts specifying options in different parts
-            of heuristic search algorithm; defaults to :const:`OPTIONS_DEFAULTS`
+        min_size (int): minimum size for subgraph to be resized to
+        max_size (int): maximum size for subgraph to be resized to
+        top_count (int): maximum number of densest subgraphs to keep track of for each size
 
     Returns:
-        tuple[float, list]: the density and list of nodes corresponding to the densest subgraph
-        found
+        dict[int, tuple(float, list[int])]: a dictionary of different sizes, each containing a
+        list of subgraphs reported as a tuple of subgraph density and subgraph nodes
     """
-    options = {**OPTIONS_DEFAULTS, **(options or {})}
+    nodes = graph.nodes()
+    size_range = range(min_size, max_size + 1)
 
-    method = options["heuristic"]["method"]
+    dense = {}
 
-    if not callable(method):
-        method = METHOD_DICT[method]
+    for s in subgraphs:
+        s = set(s)
+        if not s.issubset(nodes):
+            print("List of subgraphs contains an invalid subgraph, continuing")
+            continue
 
-    return method(graph=graph, nodes=nodes, iterations=iterations, options=options)
+        r = resize(s, graph, min_size, max_size)
 
+        for size in size_range:
+            current = dense.get(size, default=[])
 
-def random_search(
-    graph: nx.Graph, nodes: int, iterations: int = 1, options: Optional[dict] = None
-) -> Tuple[float, list]:
-    """Random search algorithm for finding dense subgraphs of a given size.
+            candidate = r.get(size)
+            sub = graph.subgraph(candidate)
+            sub_dens = nx.density(sub)
 
-    The algorithm proceeds by sampling subgraphs according to the
-    :func:`~strawberryfields.gbs.sample.subgraphs` function. The resultant subgraphs
-    are resized using :func:`resize` to be of size ``nodes``. The densest subgraph is then
-    selected among all the resultant subgraphs. Specified``options`` must be of the form given in
-    :func:`search`.
+            if len(current) < top_count:
+                current.append((sub_dens, sub))
+                current.sort()
+            elif sub_dens > min(current):
+                current.append((sub_dens, sub))
+                current.sort()
+                del current[-1]
 
-    Args:
-        graph (nx.Graph): the input graph
-        nodes (int): the size of desired dense subgraph
-        iterations (int): number of iterations to use in algorithm
-        options (dict[str, dict[str, Any]]): dict-of-dicts specifying options in different parts
-            of heuristic search algorithm; defaults to :const:`OPTIONS_DEFAULTS`
-
-    Returns:
-        tuple[float, list]: the density and list of nodes corresponding to the densest subgraph
-        found
-    """
-    options = {**OPTIONS_DEFAULTS, **(options or {})}
-
-    samples = sample.sample(
-        nx.to_numpy_array(graph), n_mean=nodes, n_samples=iterations, threshold=True
-    )
-
-    samples = sample.to_subgraphs(samples, graph)
-    samples = [resize(s, graph, min_size=nodes, max_size=nodes)[nodes] for s in samples]
-
-    density_and_samples = [(nx.density(graph.subgraph(s)), s) for s in samples]
-
-    return max(density_and_samples)
-
-
-METHOD_DICT = {"random-search": random_search}
-"""dict[str, func]: Included methods for finding dense subgraphs. The dictionary keys are strings
-describing the method, while the dictionary values are callable functions corresponding to the
-method."""
-
-OPTIONS_DEFAULTS = {"heuristic": {"method": random_search}}
-"""dict[str, dict[str, Any]]: Options for dense subgraph identification heuristics. Composed of a
-dictionary of dictionaries with the first level specifying the option type, selected from keys
-``"heuristic"`` and ``"resize"``, with the corresponding value a dictionary of options for that
-type.
-"""
+    return dense
 
 
 def resize(subgraph: list, graph: nx.Graph, min_size: int, max_size: int) -> dict:

--- a/strawberryfields/gbs/subgraph.py
+++ b/strawberryfields/gbs/subgraph.py
@@ -173,8 +173,8 @@ def _update_dict(d: dict, d_new: dict, max_count: int) -> None:
         d (dict[int, list[tuple[float, list[int]]]]): dictionary of subgraph sizes and
             corresponding list of subgraph tuples
         d_new (dict[int, tuple[float, list[int]]]): dictionary of subgraph sizes and corresponding
-        subgraph tuples that are candidates to be added to the list
-        max_count (int):  the maximum length of subgraph tuple list
+            subgraph tuples that are candidates to be added to the list
+        max_count (int):  the maximum length of every subgraph tuple list
 
     Returns:
         None: this function modifies ``d`` in place

--- a/strawberryfields/gbs/subgraph.py
+++ b/strawberryfields/gbs/subgraph.py
@@ -158,6 +158,32 @@ def _update_subgraphs_list(l: list, t: tuple, max_count: int) -> None:
             l.append(t)
 
 
+def _update_dict(d: dict, d_new: dict, max_count: int) -> None:
+    """Updates dictionary ``d`` with subgraph tuples contained in ``d_new``.
+
+    Subgraph tuples are a pair of values: a float specifying the subgraph density and a list of
+    integers specifying the subgraph nodes. Both ``d`` and ``d_new`` are dictionaries over
+    different subgraph sizes. The values of ``d`` are lists of subgraph tuples containing the top
+    densest subgraphs for a given size, with maximum length ``max_count``. The values of
+    ``d_new`` are candidate subgraph tuples that can be the result of resizing an input subgraph
+    over a range using :func:`resize`. We want to add these candidates to the list of subgraph
+    tuples in ``d`` to build up our collection of dense subgraphs.
+
+    Args:
+        d (dict[int, list[tuple[float, list[int]]]]): dictionary of subgraph sizes and
+            corresponding list of subgraph tuples
+        d_new (dict[int, tuple[float, list[int]]]): dictionary of subgraph sizes and corresponding
+        subgraph tuples that are candidates to be added to the list
+        max_count (int):  the maximum length of subgraph tuple list
+
+    Returns:
+        None: this function modifies ``d`` in place
+    """
+    for size, t in d_new.items():
+        l = d.setdefault(size, [t])
+        _update_subgraphs_list(l, t, max_count)
+
+
 def resize(subgraph: list, graph: nx.Graph, min_size: int, max_size: int) -> dict:
     """Resize a subgraph to a range of input sizes.
 

--- a/tests/gbs/test_subgraph.py
+++ b/tests/gbs/test_subgraph.py
@@ -43,29 +43,6 @@ g = nx.Graph(p.adj)
         res = subgraph.search(s, g, 10, 20)
         print(res.keys())'''
 
-class TestAddToList:
-    """Tests for the function ``subgraph._add_to_list``"""
-
-    l = [(0.09284148990494756, [1, 2, 5, 9]), (0.16013443604938415, [0, 1, 2, 5]), (0.38803386506300297, [0, 2, 3, 6]), (0.4132105226731848, [0, 1, 3, 6]), (0.5587798561345368, [3, 6, 8, 9]), (0.7017410327600858, [
-0, 4, 7, 9]), (0.8360847995330193, [2, 3, 5, 9]), (0.8768364522184167, [0, 1, 4, 8]), (0.9011700496489199, [2, 5, 6, 9]), (0.9183222696574376, [0, 3, 4, 6])]
-
-
-    def test_already_contained(self):
-        """Test if function does not act on list if fed a subgraph that is already there"""
-        l = self.l.copy()
-        subgraph._add_to_list(l, [1, 2, 5, 9], 0.09284148990494756, 15)
-        assert l == self.l
-
-    def test_simple_add(self):
-        """Test if function simply adds a new tuple if ``len(l)`` does not exceed ``top_count``"""
-        s = [0, 1, 2, 3]
-        d = 0.7017410327600858
-        l = self.l.copy()
-        l_ideal = sorted(l + [(d, s)])
-        subgraph._add_to_list(l, [0, 1, 2, 3], 0.7017410327600858, 15)
-        assert l_ideal == l
-
-
 
 class TestUpdateSubgraphsList:
     """Tests for the function ``subgraph._update_subgraphs_list``"""
@@ -157,6 +134,35 @@ class TestUpdateSubgraphsList:
 
         subgraph._update_subgraphs_list(l, self.t_below_min_density, max_count=max_count)
         assert l == self.l
+
+
+def test_update_dict(monkeypatch):
+    """Test if the function ``subgraph._update_dict`` correctly combines a hard-coded dictionary
+    with another dictionary of candidate subgraph tuples."""
+
+    d = {3: [(0.8593365162004337, [1, 4, 6]), (0.7834607649769199, [0, 1, 9]), (0.6514468663852714, [1, 8, 9])],
+         4: [(0.5738321520630872, [1, 5, 7, 9]), (0.4236138075085395, [5, 6, 7, 8])]
+         }
+
+    d_new = {3: (0.4509829558474371, [2, 3, 7]), 4: (0.13609407922395578, [4, 5, 7, 8]),
+             5: (0.7769987961311593, [4, 6, 7, 8, 9])}
+
+    d_ideal = {3: [(0.8593365162004337, [1, 4, 6]), (0.7834607649769199, [0, 1, 9]),
+                   (0.6514468663852714, [1, 8, 9]), (0.4509829558474371, [2, 3, 7])],
+               4: [(0.5738321520630872, [1, 5, 7, 9]), (0.4236138075085395, [5, 6, 7, 8]),
+                   (0.13609407922395578, [4, 5, 7, 8])],
+               5: [(0.7769987961311593, [4, 6, 7, 8, 9])]
+               }
+
+    def patch_update_subgraphs_list(l, t, _max_count):
+        if l != [t]:
+            l.append(t)
+
+    with monkeypatch.context() as m:
+        m.setattr(subgraph, "_update_subgraphs_list", patch_update_subgraphs_list)
+        subgraph._update_dict(d, d_new, max_count=10)
+
+    assert d == d_ideal
 
 
 class TestResize:


### PR DESCRIPTION
This updates the `search` function in the `subgraph` module. Now:

- The function accepts samples as an input rather than options dictionaries to specify how sampling should happen
- The user can input a _range_ of subgraph sizes to search over and the function outputs dense subgraphs found in this range
- The output is a dictionary of different subgraph sizes, with values being a sorted list of those subgraphs.

This PR wraps up our plan to refactor the dense subgraph module, following from: https://github.com/XanaduAI/strawberryfields/pull/207 and https://github.com/XanaduAI/strawberryfields/pull/209.