### PR TITLE
GBS: Add ability to simulate losses in GBS

### DIFF
--- a/examples_gbs/run_tutorial_sample.py
+++ b/examples_gbs/run_tutorial_sample.py
@@ -12,13 +12,14 @@ Sampling from GBS
 -----------------
 
 A GBS device can be programmed to sample from any symmetric matrix :math:`A`. To sample,
-we must specify both the mean number of photons being generated in the device and the form of
+we must specify the mean number of photons being generated in the device and optionally the form of
 detection used at the output: threshold detection or photon-number resolving (PNR) detection.
 Threshold detectors are restricted to measuring whether photons have arrived at the detector,
-whereas PNR detectors are able to count the number of photons.
+whereas PNR detectors are able to count the number of photons. Photon loss can also be specified
+with the ``loss`` argument.
 
-Let's take a look at both types of sampling methods. We can generate samples from a random 5-dimensional
-symmetric matrix:
+Let's take a look at both types of sampling methods. We can generate samples from a random
+5-dimensional symmetric matrix:
 """
 
 from strawberryfields.gbs import sample

--- a/strawberryfields/gbs/data.py
+++ b/strawberryfields/gbs/data.py
@@ -72,6 +72,8 @@ Each dataset contains a variety of metadata relevant to the sampling:
 
 - ``modes``: number of modes in the GBS device or, equivalently, number of nodes in the graph
 
+Note that datasets are simulated without photon loss.
+
 Loading data
 ^^^^^^^^^^^^
 

--- a/strawberryfields/gbs/sample.py
+++ b/strawberryfields/gbs/sample.py
@@ -29,8 +29,8 @@ Generating samples
 An :math:`M` mode GBS device can be programmed by specifying an :math:`(M \times M)`-dimensional
 symmetric matrix :math:`A` :cite:`bradler2018gaussian`. Running this device results in samples
 that carry relevant information about the encoded matrix :math:`A`. When sampling, one must also
-specify the mean number of photons in the device and the form of detection used at the output:
-threshold detection or photon-number-resolving (PNR) detection.
+specify the mean number of photons in the device, the form of detection used at the output:
+threshold detection or photon-number-resolving (PNR) detection, as well as the amount of loss.
 
 The :func:`sample` function provides a simulation of sampling from GBS:
 
@@ -41,7 +41,10 @@ Here, each output sample is an :math:`M`-dimensional list. If threshold detectio
 (``threshold = True``), each element of a sample is either a zero (denoting no photons detected)
 or a one (denoting one or more photons detected), conventionally called a "click".
 If photon-number resolving (PNR) detection is used (``threshold = False``) then elements of a
-sample are non-negative integers counting the number of photons detected in each mode.
+sample are non-negative integers counting the number of photons detected in each mode. The ``loss``
+parameter allows for simulation of photon loss in the device, which is the most common form of
+noise in quantum photonics. Here, ``loss = 0`` describes ideal loss-free GBS, while generally
+``0 <= loss <= 1`` describes the proportion of photons lost while passing through the device.
 
 Samples can be postselected based upon their total number of photons or clicks and the ``numpy``
 random seed used to generate samples can be fixed:

--- a/strawberryfields/gbs/sample.py
+++ b/strawberryfields/gbs/sample.py
@@ -108,7 +108,7 @@ import strawberryfields as sf
 
 
 def sample(
-    A: np.ndarray, n_mean: float, n_samples: int = 1, threshold: bool = True, loss: float = 0
+    A: np.ndarray, n_mean: float, n_samples: int = 1, threshold: bool = True, loss: float = 0.0
 ) -> list:
     r"""Generate simulated samples from GBS encoded with a symmetric matrix :math:`A`.
 

--- a/strawberryfields/gbs/similarity.py
+++ b/strawberryfields/gbs/similarity.py
@@ -328,7 +328,7 @@ def event_cardinality(photon_number: int, max_count_per_mode: int, modes: int) -
 
 
 def prob_orbit_mc(
-    graph: nx.Graph, orbit: list, n_mean: float = 5, samples: int = 1000, loss: float = 0
+    graph: nx.Graph, orbit: list, n_mean: float = 5, samples: int = 1000, loss: float = 0.0
 ) -> float:
     r"""Gives a Monte Carlo estimate of the GBS probability of a given orbit according to the input
     graph.
@@ -389,7 +389,7 @@ def prob_event_mc(
     max_count_per_mode: int,
     n_mean: float = 5,
     samples: int = 1000,
-    loss: float = 0,
+    loss: float = 0.0,
 ) -> float:
     r"""Gives a Monte Carlo estimate of the GBS probability of a given event according to the input
     graph.
@@ -490,7 +490,7 @@ def feature_vector_mc(
     max_count_per_mode: int = 2,
     n_mean: float = 5,
     samples: int = 1000,
-    loss: float = 0,
+    loss: float = 0.0,
 ) -> list:
     r"""Calculates feature vector using Monte Carlo estimation of event probabilities according to the
     input graph.

--- a/strawberryfields/gbs/similarity.py
+++ b/strawberryfields/gbs/similarity.py
@@ -356,6 +356,12 @@ def prob_orbit_mc(
     Returns:
         float: estimated orbit probability
     """
+    if samples < 1:
+        raise ValueError("Number of samples must be at least one")
+    if n_mean < 0:
+        raise ValueError("Mean photon number must be non-negative")
+    if not 0 <= loss <= 1:
+        raise ValueError("Loss parameter must take a value between zero and one")
 
     modes = graph.order()
     photons = sum(orbit)
@@ -418,6 +424,16 @@ def prob_event_mc(
     Returns:
         float: estimated orbit probability
     """
+    if samples < 1:
+        raise ValueError("Number of samples must be at least one")
+    if n_mean < 0:
+        raise ValueError("Mean photon number must be non-negative")
+    if not 0 <= loss <= 1:
+        raise ValueError("Loss parameter must take a value between zero and one")
+    if photon_number < 0:
+        raise ValueError("Photon number must not be below zero")
+    if max_count_per_mode < 0:
+        raise ValueError("Maximum number of photons per mode must be non-negative")
 
     modes = graph.order()
     A = nx.to_numpy_array(graph)
@@ -476,8 +492,8 @@ def feature_vector_sampling(
     if min(event_photon_numbers) < 0:
         raise ValueError("Cannot request events with photon number below zero")
 
-    if max_count_per_mode < 1:
-        raise ValueError("Maximum number of photons per mode must be at least one")
+    if max_count_per_mode < 0:
+        raise ValueError("Maximum number of photons per mode must be non-negative")
 
     n_samples = len(samples)
 
@@ -521,12 +537,16 @@ def feature_vector_mc(
         list[float]: a feature vector of event probabilities in the same order as
         ``event_photon_numbers``
     """
-
+    if samples < 1:
+        raise ValueError("Number of samples must be at least one")
+    if n_mean < 0:
+        raise ValueError("Mean photon number must be non-negative")
+    if not 0 <= loss <= 1:
+        raise ValueError("Loss parameter must take a value between zero and one")
     if min(event_photon_numbers) < 0:
         raise ValueError("Cannot request events with photon number below zero")
-
-    if max_count_per_mode < 1:
-        raise ValueError("Maximum number of photons per mode must be at least one")
+    if max_count_per_mode < 0:
+        raise ValueError("Maximum number of photons per mode must be non-negative")
 
     return [
         prob_event_mc(graph, photons, max_count_per_mode, n_mean, samples, loss)

--- a/strawberryfields/gbs/similarity.py
+++ b/strawberryfields/gbs/similarity.py
@@ -95,6 +95,9 @@ approximation:
     prob_orbit_mc
     prob_event_mc
 
+Similar to the :func:`~.gbs.sample.sample` function, the MC estimators include a ``loss`` argument
+to specify the proportion of photons lost in the simulated GBS device.
+
 One canonical method of constructing a feature vector is to pick event probabilities
 :math:`p_{k} := p_{E_{k, n_{\max}}}` with all events :math:`E_{k, n_{\max}}` having a maximum
 photon count :math:`n_{\max}` in each mode. If :math:`\mathbf{k}` is the vector of selected events,

--- a/tests/gbs/test_sample.py
+++ b/tests/gbs/test_sample.py
@@ -117,7 +117,7 @@ class TestSample:
         cov = state.cov()
         disp = state.displacement()
 
-        assert np.allclose(cov, np.eye(2 * dim))
+        assert np.allclose(cov, 0.5 * state.hbar * np.eye(2 * dim))
         assert np.allclose(disp, np.zeros(dim))
 
 

--- a/tests/gbs/test_sample.py
+++ b/tests/gbs/test_sample.py
@@ -52,6 +52,12 @@ class TestSample:
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             sample.sample(A=adj, n_mean=-1.0, n_samples=1)
 
+    def test_invalid_loss(self, adj):
+        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
+        of range"""
+        with pytest.raises(ValueError, match="Loss parameter must take a value between zero and"):
+            sample.sample(A=adj, n_mean=1.0, n_samples=1, loss=2)
+
     def test_threshold(self, monkeypatch, adj):
         """Test if function correctly creates the SF program for threshold GBS."""
         mock_eng_run = mock.MagicMock()
@@ -73,6 +79,46 @@ class TestSample:
             p_func = mock_eng_run.call_args[0][0]
 
         assert isinstance(p_func.circuit[-1].op, sf.ops.MeasureFock)
+
+    def test_loss(self, monkeypatch, adj):
+        """Test if function correctly creates the SF program for lossy GBS."""
+        mock_eng_run = mock.MagicMock()
+
+        with monkeypatch.context() as m:
+            m.setattr(sf.Engine, "run", mock_eng_run)
+            sample.sample(A=adj, n_mean=1, threshold=False, loss=0.5)
+            p_func = mock_eng_run.call_args[0][0]
+
+        assert isinstance(p_func.circuit[-2].op, sf.ops.LossChannel)
+
+    def test_no_loss(self, monkeypatch, adj):
+        """Test if function correctly creates the SF program for GBS without loss."""
+        mock_eng_run = mock.MagicMock()
+
+        with monkeypatch.context() as m:
+            m.setattr(sf.Engine, "run", mock_eng_run)
+            sample.sample(A=adj, n_mean=1, threshold=False)
+            p_func = mock_eng_run.call_args[0][0]
+
+        assert not all([isinstance(op, sf.ops.LossChannel) for op in p_func.circuit])
+
+    def test_all_loss(self, monkeypatch, adj, dim):
+        """Test if function samples from the vacuum when maximum loss is applied."""
+        mock_eng_run = mock.MagicMock()
+
+        with monkeypatch.context() as m:
+            m.setattr(sf.Engine, "run", mock_eng_run)
+            sample.sample(A=adj, n_mean=1, threshold=False, loss=1)
+            p_func = mock_eng_run.call_args[0][0]
+
+        eng = sf.LocalEngine(backend="gaussian")
+
+        state = eng.run(p_func).state
+        cov = state.cov()
+        disp = state.displacement()
+
+        assert np.allclose(cov, np.eye(2 * dim))
+        assert np.allclose(disp, np.zeros(dim))
 
 
 @pytest.mark.parametrize("dim", adj_dim_range)

--- a/tests/gbs/test_similarity.py
+++ b/tests/gbs/test_similarity.py
@@ -286,7 +286,7 @@ class TestProbOrbitMC:
         cov = state.cov()
         disp = state.displacement()
 
-        assert np.allclose(cov, np.eye(2 * dim))
+        assert np.allclose(cov, 0.5 * state.hbar * np.eye(2 * dim))
         assert np.allclose(disp, np.zeros(dim))
 
 
@@ -355,7 +355,7 @@ class TestProbEventMC:
         cov = state.cov()
         disp = state.displacement()
 
-        assert np.allclose(cov, np.eye(2 * dim))
+        assert np.allclose(cov, 0.5 * state.hbar * np.eye(2 * dim))
         assert np.allclose(disp, np.zeros(dim))
 
 

--- a/tests/gbs/test_similarity.py
+++ b/tests/gbs/test_similarity.py
@@ -225,6 +225,27 @@ def test_event_cardinality(photons, max_count, modes, expected):
 class TestProbOrbitMC:
     """Tests for the function ``strawberryfields.gbs.similarity.prob_orbit_mc.``"""
 
+    def test_invalid_samples(self):
+        """Test if function raises a ``ValueError`` when a number of samples less than one is
+        requested."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Number of samples must be at least one"):
+            similarity.prob_orbit_mc(g, [1, 1, 1, 1], samples=0)
+
+    def test_invalid_n_mean(self):
+        """Test if function raises a ``ValueError`` when the mean photon number is specified to
+        be negative."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
+            similarity.prob_orbit_mc(g, [1, 1, 1, 1], n_mean=-1)
+
+    def test_invalid_loss(self):
+        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
+        of range."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Loss parameter must take a value between zero and"):
+            similarity.prob_orbit_mc(g, [1, 1, 1, 1], loss=2)
+
     def test_mean_computation_orbit(self, monkeypatch):
         """Tests if the calculation of the sample mean is performed correctly. The test
         monkeypatches the fock_prob function so that the probability is the same for each sample and
@@ -292,6 +313,39 @@ class TestProbOrbitMC:
 
 class TestProbEventMC:
     """Tests for the function ``strawberryfields.gbs.similarity.prob_event_mc.``"""
+
+    def test_invalid_samples(self):
+        """Test if function raises a ``ValueError`` when a number of samples less than one is
+        requested."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Number of samples must be at least one"):
+            similarity.prob_event_mc(g, 2, 2, samples=0)
+
+    def test_invalid_n_mean(self):
+        """Test if function raises a ``ValueError`` when the mean photon number is specified to
+        be negative."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
+            similarity.prob_event_mc(g, 2, 2, n_mean=-1)
+
+    def test_invalid_loss(self):
+        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
+        of range."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Loss parameter must take a value between zero and"):
+            similarity.prob_event_mc(g, 2, 2, loss=2)
+
+    def test_invalid_photon_number(self):
+        """Test if function raises a ``ValueError`` when a photon number below zero is specified"""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Photon number must not be below zero"):
+            similarity.prob_event_mc(g, -1, 2)
+
+    def test_low_count(self):
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Maximum number of photons"):
+            similarity.prob_event_mc(g, 2, -1)
 
     def test_prob_vacuum_event(self):
         """Tests if the function gives the right probability for an event with zero photons when
@@ -368,11 +422,10 @@ class TestFeatureVectorSampling:
         with pytest.raises(ValueError, match="Cannot request events with photon number below zero"):
             similarity.feature_vector_sampling([[1, 1, 0], [1, 0, 1]], [-1, 4], 1)
 
-    def test_bad_max_count(self):
-        """Test if function raises a ``ValueError`` when input a non-positive value for the
-        maximum photon count per mode."""
-        with pytest.raises(ValueError, match="Maximum number of photons per mode must be at least"):
-            similarity.feature_vector_sampling([[1, 1, 0], [1, 0, 1]], [2, 4], 0)
+    def test_low_count(self):
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        with pytest.raises(ValueError, match="Maximum number of photons"):
+            similarity.feature_vector_sampling([[1, 1, 0], [1, 0, 1]], [2, 4], -1)
 
     def test_correct_distribution(self, monkeypatch):
         """Test if function correctly constructs the feature vector corresponding to some hard
@@ -405,6 +458,27 @@ class TestFeatureVectorSampling:
 class TestFeatureVectorMC:
     """Tests for the function ``strawberryfields.apps.graph.similarity.feature_vector_mc``"""
 
+    def test_invalid_samples(self):
+        """Test if function raises a ``ValueError`` when a number of samples less than one is
+        requested."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Number of samples must be at least one"):
+            similarity.feature_vector_mc(g, [2, 4], samples=0)
+
+    def test_invalid_n_mean(self):
+        """Test if function raises a ``ValueError`` when the mean photon number is specified to
+        be negative."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
+            similarity.feature_vector_mc(g, [2, 4], n_mean=-1)
+
+    def test_invalid_loss(self):
+        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
+        of range."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Loss parameter must take a value between zero and"):
+            similarity.feature_vector_mc(g, [2, 4], loss=2)
+
     def test_bad_event_photon_numbers_mc(self):
         """Test if function raises a ``ValueError`` when input a minimum photon number that is
         below zero."""
@@ -412,12 +486,11 @@ class TestFeatureVectorMC:
             graph = nx.complete_graph(4)
             similarity.feature_vector_mc(graph, [-1, 4], 1)
 
-    def test_bad_max_count_mc(self):
-        """Test if function raises a ``ValueError`` when input a non-positive value for the
-        maximum photon count per mode."""
-        with pytest.raises(ValueError, match="Maximum number of photons per mode must be at least"):
-            graph = nx.complete_graph(4)
-            similarity.feature_vector_mc(graph, [2, 4], 0)
+    def test_low_count(self):
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        g = nx.complete_graph(10)
+        with pytest.raises(ValueError, match="Maximum number of photons"):
+            similarity.feature_vector_mc(g, [2, 4], -1)
 
     def test_correct_vector_mc(self, monkeypatch):
         """Test if function correctly constructs the feature vector. The
@@ -428,7 +501,7 @@ class TestFeatureVectorMC:
             m.setattr(
                 similarity,
                 "prob_event_mc",
-                lambda graph, photons, max_count, n_mean, samples, loss: 1.0 / photons,
+                lambda _graph, photons, max_count, n_mean, samples, loss: 1.0 / photons,
             )
             graph = nx.complete_graph(8)
             fv = similarity.feature_vector_mc(graph, [2, 4, 8], 1)

--- a/tests/gbs/test_similarity.py
+++ b/tests/gbs/test_similarity.py
@@ -428,7 +428,7 @@ class TestFeatureVectorMC:
             m.setattr(
                 similarity,
                 "prob_event_mc",
-                lambda graph, photons, max_count, n_mean, samples: 1.0 / photons,
+                lambda graph, photons, max_count, n_mean, samples, loss: 1.0 / photons,
             )
             graph = nx.complete_graph(8)
             fv = similarity.feature_vector_mc(graph, [2, 4, 8], 1)


### PR DESCRIPTION
Since realistic GBS devices will have losses, it makes sense to provide this in the applications layer. Since loss is already part of SF, we only need to change the program fed to the SF Engine, as well as updating tests and docs.