### PR TITLE
GBS Bug: Fix single shot sampling

### DIFF
--- a/strawberryfields/gbs/sample.py
+++ b/strawberryfields/gbs/sample.py
@@ -147,7 +147,12 @@ def sample(A: np.ndarray, n_mean: float, n_samples: int = 1, threshold: bool = T
         else:
             sf.ops.MeasureFock() | q
 
-    return eng.run(p, run_options={"shots": n_samples}).samples.tolist()
+    s = eng.run(p, run_options={"shots": n_samples}).samples
+
+    if n_samples == 1:
+        return [s]
+
+    return s.tolist()
 
 
 def postselect(samples: list, min_count: int, max_count: int) -> list:

--- a/tests/gbs/test_sample.py
+++ b/tests/gbs/test_sample.py
@@ -26,7 +26,6 @@ from strawberryfields.gbs import sample
 
 pytestmark = pytest.mark.gbs
 
-integration_sample_number = 2
 adj_dim_range = range(2, 6)
 
 
@@ -76,10 +75,11 @@ class TestSample:
 
 
 @pytest.mark.parametrize("dim", adj_dim_range)
+@pytest.mark.parametrize("integration_sample_number", [1, 2])
 class TestSampleIntegration:
     """Integration tests for the function ``strawberryfields.gbs.sample.sample``"""
 
-    def test_pnr_integration(self, adj):
+    def test_pnr_integration(self, adj, integration_sample_number):
         """Integration test to check if function returns samples of correct form, i.e., correct
         number of samples, correct number of modes, all non-negative integers """
         samples = np.array(
@@ -93,7 +93,7 @@ class TestSampleIntegration:
         assert samples.dtype == "int"
         assert (samples >= 0).all()
 
-    def test_threshold_integration(self, adj):
+    def test_threshold_integration(self, adj, integration_sample_number):
         """Integration test to check if function returns samples of correct form, i.e., correct
         number of samples, correct number of modes, all integers of zeros and ones """
         samples = np.array(


### PR DESCRIPTION
Currently, the `gbs.sample.sample()` function raises:
`AttributeError: 'list' object has no attribute 'tolist'`
when called with `n_samples = 1` (which, ironically, is actually the default).

This is because `eng.run`, which is called within `sample()`, returns:
- A list if `n_samples = 1`
- A numpy array if `n_samples > 1`

To fix this, we have changed the `sample()` function to internally check when `n_samples = 1` and when that is the case: for a sample `s`, return `[s]`. E.g., if the sample is `[0, 1, 3, 0]` the return is `[[0, 1, 3, 0]]`. Although this seems like an unnecessary embedding, it means that the output form of `sample()` doesn't change with `n_samples`, i.e., always `len(sample()) = n_samples` and the return is a list of samples.

Alternatively, we could change `sample()` to return:
- A list if `n_samples = 1`
- A list of lists OR numpy array if `n_samples > 1`
However, this is inconsistent and can confuse users (as it did with us!).

Tests have also been updated to check for the case when `n_samples = 1`.