### PR TITLE
Stop TF FutureWarnings

### DIFF
--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -91,6 +91,7 @@ Code details
 
 """
 import numbers
+import warnings
 
 from unittest import mock
 import numpy as np
@@ -99,7 +100,9 @@ from .program_utils import (RegRef, RegRefTransform)
 
 
 try:
-    import tensorflow as tf
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        import tensorflow as tf
     _tf_classes = (tf.Tensor, tf.Variable)
 except ImportError:
     tf = mock.MagicMock()

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -101,7 +101,7 @@ from .program_utils import (RegRef, RegRefTransform)
 
 try:
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=FutureWarning)
+        warnings.filterwarnings("ignore", category=FutureWarning, message=r"Passing \(type, 1\) or")
         import tensorflow as tf
     _tf_classes = (tf.Tensor, tf.Variable)
 except ImportError:


### PR DESCRIPTION
If TensorFlow 1.3 is installed, an import of Strawberry Fields results in:
![Annotation 2019-10-28 165831](https://user-images.githubusercontent.com/49409390/67717997-3d026d00-f9a5-11e9-8be3-7a4a6b526a64.png)
This happens even if the user is not using the TF engine.

Although we expect users not to need TF to use SF, many might have it installed if they have looked at using ML functionality in SF. They will then receive the above error whenever importing SF.

This PR prevents the FutureWarning errors from showing when importing SF with TF==1.3 installed.