### PR TITLE
GBS: Fix sample warning

### DIFF
--- a/strawberryfields/gbs/sample.py
+++ b/strawberryfields/gbs/sample.py
@@ -99,6 +99,7 @@ use within heuristics for problems such as maximum clique (see :mod:`~.gbs.cliqu
 Code details
 ^^^^^^^^^^^^
 """
+import warnings
 from typing import Optional
 
 import networkx as nx
@@ -160,7 +161,9 @@ def sample(
         else:
             sf.ops.MeasureFock() | q
 
-    s = eng.run(p, run_options={"shots": n_samples}).samples
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, message="Cannot simulate non-")
+        s = eng.run(p, run_options={"shots": n_samples}).samples
 
     if n_samples == 1:
         return [s]


### PR DESCRIPTION
When running the `sample.sample()` function in the applications layer, the user is presented with the following warning:
![image](https://user-images.githubusercontent.com/49409390/67720556-a0db6480-f9aa-11e9-88a5-75df0ec28bdc.png)

While it might make sense to present the user with this error if they have designed an SF Program, it doesn't when calling `sample()` which creates the program/engine on their behalf.

This PR suppresses the warning in the `sample()` function.