### PR TITLE
GBS Docs: Add plotting note to tutorial

### DIFF
--- a/examples_gbs/run_tutorial_dense.py
+++ b/examples_gbs/run_tutorial_dense.py
@@ -68,7 +68,7 @@ plotly.offline.plot(plot_graph, filename="planted.html")
 #
 # .. note::
 #     The command ``plotly.offline.plot()`` is used to display plots in the documentation. In
-#     practice, you can simply use ``graph.show()`` to view the graph.
+#     practice, you can simply use ``plot_graph.show()`` to view the graph.
 
 ##############################################################################
 # A more interesting challenge is to find dense subgraphs of different sizes; it is often

--- a/examples_gbs/run_tutorial_max_clique.py
+++ b/examples_gbs/run_tutorial_max_clique.py
@@ -33,12 +33,16 @@ import plotly
 TA = data.TaceAs()
 A = TA.adj
 TA_graph = nx.Graph(A)
-graph_fig = plot.graph(TA_graph)
-plotly.offline.plot(graph_fig, filename="TACE-AS.html")
+plot_graph = plot.graph(TA_graph)
+plotly.offline.plot(plot_graph, filename="TACE-AS.html")
 
 ##############################################################################
 # .. raw:: html
 #     :file: ../../examples_gbs/TACE-AS.html
+#
+# .. note::
+#     The command ``plotly.offline.plot()`` is used to display plots in the documentation. In
+#     practice, you can simply use ``plot_graph.show()`` to view your graph.
 
 ##############################################################################
 # Can you spot any cliques in the graph? It's not so easy using only your eyes! The TACE-AS graph

--- a/examples_gbs/run_tutorial_points.py
+++ b/examples_gbs/run_tutorial_points.py
@@ -90,6 +90,10 @@ plotly.offline.plot(plot_1, filename="Points.html")
 ##############################################################################
 # .. raw:: html
 #     :file: ../../examples_gbs/Points.html
+#
+# .. note::
+#     The command ``plotly.offline.plot()`` is used to display plots in the documentation. In
+#     practice, you can simply use ``plot_1.show()`` to view your graph.
 
 ##############################################################################
 # Outlier Detection

--- a/examples_gbs/run_tutorial_sample.py
+++ b/examples_gbs/run_tutorial_sample.py
@@ -78,12 +78,17 @@ adj = np.array(
 )
 
 graph = nx.Graph(adj)
+plot_graph = plot.graph(graph)
 
-plotly.offline.plot(plot.graph(graph), filename="random_graph.html")
+plotly.offline.plot(plot_graph, filename="random_graph.html")
 
 ##############################################################################
 # .. raw:: html
 #     :file: ../../examples_gbs/random_graph.html
+#
+# .. note::
+#     The command ``plotly.offline.plot()`` is used to display plots in the documentation. In
+#     practice, you can simply use ``plot_graph.show()`` to view your graph.
 #
 # This is a 6-node graph with the nodes ``[0, 1, 4, 5]`` fully connected to each other. We expect
 # to be able to sample dense subgraphs with high probability.

--- a/examples_gbs/run_tutorial_similarity.py
+++ b/examples_gbs/run_tutorial_similarity.py
@@ -66,6 +66,7 @@ plotly.offline.plot(plot_mutag_0, filename="MUTAG_0.html")
 ##############################################################################
 # .. raw:: html
 #     :file: ../../examples_gbs/MUTAG_0.html
+#
 # .. note::
 #     The command ``plotly.offline.plot()`` is used to display plots in the documentation. In
 #     practice, you can simply use ``plot_mutag_0.show()`` to view your graph.


### PR DESCRIPTION
The documentation currently has a workaround to use dynamic plotly plots:
First, the plot is saved:
```python
plot_graph = plot.graph(g)
plotly.offline.plot(plot_graph, filename="graph.html")
```
Then, the plot is loaded in `rst`:
```rst
# .. raw:: html
# :file: ../../examples_gbs/TACE-AS.html
```
However, when executing the script directly the user could simply call the following:
```python
plot.graph(g).show()
```

We have already added a note to `similarity` and `subgraph` tutorials to explain this. This PR adds the note to the remaining tutorials.