### PR TITLE
Fix sidebar when adverts are showing

### DIFF
--- a/doc/xanadu_theme/static/xanadu.css_t
+++ b/doc/xanadu_theme/static/xanadu.css_t
@@ -23,6 +23,7 @@ body {
 }
 
 #left-column {
+  z-index: 2000;
   float: left;
   position: fixed;
   height: 100%;
@@ -540,7 +541,7 @@ div.sphinxsidebar input {
 }
 
 .search-block {
-  z-index: 1;
+  z-index: 0;
   position: sticky;
   top: 64px;
   background-color: #eee;


### PR DESCRIPTION
Readthedocs is currently placing adverts: https://docs.readthedocs.io/en/stable/advertising/ethical-advertising.html

This results in a small banner at the bottom of the documentation.

One problem is that it covers the last entry in our table of contents sidebar - currently the apps layer tutorials. This PR ensures that the banner ad no longer covers this entry.

It also fixes a minor bug in the behaviour of the search box when scrolling in the sidebar.