### PR TITLE
Remove output string from plots

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,6 +77,7 @@ sphinx_gallery_conf = {
                             "%matplotlib inline"),
     # thumbnail size
     'thumbnail_size': (400, 400),
+    'capture_repr': (),
 }
 
 # Remove warnings that occur when generating the the tutorials


### PR DESCRIPTION
A [recent update](https://github.com/sphinx-gallery/sphinx-gallery/releases/tag/v0.5.0) to sphinx-gallery has caused an unwanted output box to appear when plotting:

![image](https://user-images.githubusercontent.com/49409390/69554269-8aa3d280-0f6f-11ea-9fc0-eb1e70c0d7f6.png)

This output is shown because sphinx-gallery now looks for a html and string representation on the last line of each codeblock. The string representation of `plotly.offline.plot(plot_1, filename="Points.html")` is just `'Points.html'` and this is hence what is shown in the output box.

This PR removes the unwanted output box by preventing sphinx-gallery from searching for the string representation. This is done just by telling sphinx-gallery to behave as it did before the update, as described here: https://sphinx-gallery.github.io/stable/configuration.html#capture-repr. The result is:

![image](https://user-images.githubusercontent.com/49409390/69554711-2e8d7e00-0f70-11ea-9e8f-40f3e27918e4.png)