### PR TITLE
Apps: add module to SF __init__

### DIFF
--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -86,12 +86,13 @@ def version():
     return __version__
 
 
-def about():  # pylint: disable=import-outside-toplevel
+def about():
     """About box for Strawberry Fields.
 
     Prints the installed version numbers for SF and its dependencies,
     and some system info. Please include this information in bug reports.
     """
+    # pylint: disable=import-outside-toplevel
     import sys
     import platform
     import os

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -67,6 +67,7 @@ from .engine import (Engine, LocalEngine)
 from .io import save, load
 from .program import Program
 from ._version import __version__
+import strawberryfields.apps
 
 __all__ = ["Engine", "LocalEngine", "Program", "version", "save", "load", "about", "cite"]
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -67,7 +67,7 @@ from .engine import (Engine, LocalEngine)
 from .io import save, load
 from .program import Program
 from ._version import __version__
-import strawberryfields.apps
+from . import apps
 
 __all__ = ["Engine", "LocalEngine", "Program", "version", "save", "load", "about", "cite"]
 
@@ -86,7 +86,7 @@ def version():
     return __version__
 
 
-def about():
+def about():  # pylint: disable=import-outside-toplevel
     """About box for Strawberry Fields.
 
     Prints the installed version numbers for SF and its dependencies,

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -63,11 +63,11 @@ Top-level functions
 Code details
 ~~~~~~~~~~~~
 """
-from .engine import (Engine, LocalEngine)
-from .io import save, load
-from .program import Program
-from ._version import __version__
 from . import apps
+from ._version import __version__
+from .engine import Engine, LocalEngine
+from .io import load, save
+from .program import Program
 
 __all__ = ["Engine", "LocalEngine", "Program", "version", "save", "load", "about", "cite"]
 


### PR DESCRIPTION
We normally suggest users can import the applications layer through commands like:
```python
from strawberryfields.apps import clique
```

However, users may end up on occasion using:
```python
import strawberryfields as sf

sf.apps.clique.grow(...)
```

This PR allows for this.