### PR TITLE
Apps: Rename kernel to rbf_kernel

### DIFF
--- a/examples_apps/run_tutorial_points.py
+++ b/examples_apps/run_tutorial_points.py
@@ -47,7 +47,7 @@ R = np.array([(i, j) for i in range(20) for j in range(20)])
 # The rows of R are the coordinates of the points.
 #
 # Next step is to create the kernel matrix for the points of this discrete space. We call
-# the :func:`~.kernel` function which uses the *radial basis function* (RBF) kernel defined as:
+# the :func:`~.rbf_kernel` function which uses the *radial basis function* (RBF) kernel defined as:
 #
 # .. math::
 #     K_{i,j} = e^{-\|\bf{r}_i-\bf{r}_j\|^2/2\sigma^2},
@@ -70,7 +70,7 @@ R = np.array([(i, j) for i in range(20) for j in range(20)])
 #
 # Let's construct the RBF kernel with the parameter :math:`\sigma` set to 2.5.
 
-K = points.kernel(R, 2.5)
+K = points.rbf_kernel(R, 2.5)
 
 ##############################################################################
 # We generate 10 samples with an average number of 50 points per sample by calling
@@ -120,7 +120,7 @@ R = np.concatenate((clusters, noise))
 ##############################################################################
 # Then construct the kernel matrix and generate 10000 samples.
 
-K = points.kernel(R, 1.0)
+K = points.rbf_kernel(R, 1.0)
 
 samples = points.sample(K, 10.0, 10000)
 

--- a/strawberryfields/apps/points.py
+++ b/strawberryfields/apps/points.py
@@ -41,11 +41,22 @@ encodes information about the similarity between points. When this kernel matrix
 semidefinite, it is possible to use GBS to implement a *permanental* point process and employ
 fast classical algorithms to sample from the resulting distribution.
 
+One choice of kernel matrix is the radial basis function (RBF) kernel whose elements are computed
+as:
+
+.. math::
+    K_{i,j} = e^{-\|\bf{r}_i-\bf{r}_j\|^2/(2\sigma^2)},
+
+where :math:`\bf{r}_i` are the coordinates of point :math:`i`, :math:`\sigma` is a kernel
+parameter, and :math:`\|\cdot\|` denotes a choice of norm. The RBF kernel is positive
+semidefinite when the Euclidean norm is used, as is the case for the provided :func:`rbf_kernel`
+function.
+
 Summary
 -------
 
 .. autosummary::
-    kernel
+    rbf_kernel
     sample
 
 Code details
@@ -57,26 +68,20 @@ import scipy
 from thewalrus.csamples import generate_thermal_samples, rescale_adjacency_matrix_thermal
 
 
-def kernel(R: np.ndarray, sigma: float) -> np.ndarray:
-    r"""Calculate the kernel matrix from a set of input points.
-
-    We use the radial basis function (RBF) kernel whose elements are computed as:
-
-    .. math::
-        K_{i,j} = e^{-\|\bf{r}_i-\bf{r}_j\|^2/(2\sigma^2)},
-
-    where :math:`\bf{r}_i` are the coordinates of point :math:`i`, :math:`\sigma` is a kernel
-    parameter, and :math:`\|\cdot\|` denotes a choice of norm. The RBF kernel is positive
-    semidefinite when the Euclidean norm is used.
+def rbf_kernel(R: np.ndarray, sigma: float) -> np.ndarray:
+    r"""Calculate the RBF kernel matrix from a set of input points.
 
     The kernel parameter :math:`\sigma` is used to define the kernel scale. Points that are much
     further than :math:`\sigma` from each other lead to small entries of the kernel
     matrix, whereas points much closer than :math:`\sigma` generate large entries.
 
+    The Euclidean norm is used to measure distance in this function, resulting in a
+    positive-semidefinite kernel.
+
     **Example usage:**
 
     >>> R = np.array([[0, 1], [1, 0], [0, 0], [1, 1]])
-    >>> kernel (R, 1.0)
+    >>> rbf_kernel (R, 1.0)
     array([[1., 0.36787944, 0.60653066, 0.60653066],
            [0.36787944, 1., 0.60653066, 0.60653066],
            [0.60653066, 0.60653066, 1., 0.36787944],
@@ -87,7 +92,7 @@ def kernel(R: np.ndarray, sigma: float) -> np.ndarray:
         sigma (float): kernel parameter
 
     Returns:
-        K (array): the kernel matrix
+        K (array): the RBF kernel matrix
     """
     return np.exp(-(scipy.spatial.distance.cdist(R, R)) ** 2 / 2 / sigma ** 2)
 
@@ -95,8 +100,8 @@ def kernel(R: np.ndarray, sigma: float) -> np.ndarray:
 def sample(K: np.ndarray, n_mean: float, n_samples: int) -> list:
     """Sample subsets of points using the permanental point process.
 
-    Points can be encoded through a radial basis function kernel, provided in :func:`kernel`. Subsets
-    of points are sampled with probabilities that are proportional to the permanent of the
+    Points can be encoded through a radial basis function kernel, provided in :func:`rbf_kernel`.
+    Subsets of points are sampled with probabilities that are proportional to the permanent of the
     submatrix of the kernel selected by those points.
 
     This permanental point process is likely to sample points that are clustered together

--- a/tests/apps/test_points.py
+++ b/tests/apps/test_points.py
@@ -15,17 +15,17 @@ r"""Tests for the the point process functions"""
 
 import pytest
 import numpy as np
-from strawberryfields.apps.points import kernel, sample
+from strawberryfields.apps.points import rbf_kernel, sample
 
 
 pytestmark = pytest.mark.apps
 
 
-def test_kernel():
-    r"""Tests the correctness of the kernel matrix generated for a given set of point coordinates"""
+def test_rbf_kernel():
+    r"""Tests the correctness of the rbf_kernel matrix generated for a given set of point coordinates"""
 
     R = np.array([[0, 1], [1, 0], [0, 0], [1, 1]])
-    K = kernel(R, 1.0)
+    K = rbf_kernel(R, 1.0)
     Kref = np.array(
         [
             [1.0, 0.36787944, 0.60653066, 0.60653066],

--- a/tests/apps/test_points.py
+++ b/tests/apps/test_points.py
@@ -22,7 +22,8 @@ pytestmark = pytest.mark.apps
 
 
 def test_rbf_kernel():
-    r"""Tests the correctness of the rbf_kernel matrix generated for a given set of point coordinates"""
+    r"""Tests the correctness of the RBF kernel matrix generated for a given set of point
+    coordinates"""
 
     R = np.array([[0, 1], [1, 0], [0, 0], [1, 1]])
     K = rbf_kernel(R, 1.0)


### PR DESCRIPTION
Based on user feedback, we have decided to rename the `kernel` function in the `points` module to `rbf_kernel`. This helps specify the type of kernel used, which is the radial basis function kernel.