### PR TITLE
Remove outdated hafnian dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ requirements = [
     "networkx>=2.0",
     "quantum-blackbird>=0.2.0",
     "python-dateutil>=2.8.0",
-    "hafnian>=0.6",
     "thewalrus>=0.7",
     "toml",
     "appdirs",


### PR DESCRIPTION
**Description of the Change:** Removes the outdated dependency on the `hafnian` library. This library was renamed to `thewalrus`, so the project effectively depends on two versions of the same library.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
