### PR TITLE
Add plotly to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ quantum-blackbird
 thewalrus>=0.7
 toml
 appdirs
+plotly==4.4.1


### PR DESCRIPTION
This PR adds Plotly to the developer `requirements.txt` (but not to `setup.py`!). Plotly is used for applications in Strawberry Fields.