### PR TITLE
Require thewalrus>=0.9 to fix an import error in the apps module.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "scipy>=1.0.0",
     "networkx>=2.0",
     "quantum-blackbird>=0.2.0",
-    "thewalrus>=0.7",
+    "thewalrus>=0.9",
     "toml",
     "appdirs",
 ]


### PR DESCRIPTION
**Description of the Change:**

Bumps `thewalrus` dependency to version 0.9 to fix an import error in the apps module.
