### PR TITLE
Fix image URL on readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Features
 
 .. raw:: html
 
-    <img src="https://raw.githubusercontent.com/XanaduAI/strawberryfields/doc_restructure/doc/gallery/state_learner/StateLearning.gif" width="300px"  align="right">
+    <img src="https://raw.githubusercontent.com/XanaduAI/strawberryfields/master/doc/gallery/state_learner/StateLearning.gif" width="300px"  align="right">
 
 * An open-source software architecture for **photonic quantum computing**
 


### PR DESCRIPTION
**Context:**

The image URL in the readme appears to be pointing to a deleted branch.

**Description of the Change:**

Modify the image URL to point to master.

**Benefits:**

The image is displayed on the readme :slightly_smiling_face:
