### PR TITLE
Bring requirements.txt in to line with setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 networkx>=2.0
-numpy>=1.16.3
+numpy>=1.17.4
 scipy>=1.0.0
 tensorflow==1.3
 tensorflow-tensorboard>=0.1.8
-quantum-blackbird
-thewalrus>=0.7
+quantum-blackbird>=0.2.0
+thewalrus>=0.9
 toml
 appdirs
 plotly==4.4.1


### PR DESCRIPTION
The `requirements.txt` file also had a minimum version of `thewalrus` that is not sufficient. I have also updated the other requirements to at least match those in `setup.py`