### PR TITLE
Add apps data to manifest

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Correct URL for image in `README`
   [#273](https://github.com/XanaduAI/strawberryfields/pull/273)
 
+* Add applications data to `MANIFEST.in`
+  [#278](https://github.com/XanaduAI/strawberryfields/pull/278)
+
 ---
 
 # Release 0.12.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include LICENSE
 include examples/*
 include tests/*
 include strawberryfields/backends/data/*
+include strawberryfields/apps/data/*


### PR DESCRIPTION
The data added in the applications layer must be added to `MANIFEST.in` for it to be included in the sdist.