### PR TITLE
sympy.functions.atan2 has been fixed in sympy 1.5, workaround removed.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,16 +6,20 @@
   This allows calculation of x and p quadrature
   probability distributions by integrating across the Wigner function.
   [#270](https://github.com/XanaduAI/strawberryfields/pull/270)
-  
+
 ### Improvements
 
 ### Bug fixes
+
+* Added `sympy>=1.5` to the list of dependencies.
+  Removed the `sympy.functions.atan2` workaround now that SymPy has been fixed.
+  [#280](https://github.com/XanaduAI/strawberryfields/pull/280)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Jack Ceroni
+Ville Bergholm, Jack Ceroni
 
 ---
 
@@ -43,7 +47,7 @@ Jack Ceroni
 
 * Correct URL for image in `README`
   [#273](https://github.com/XanaduAI/strawberryfields/pull/273)
- 
+
 * Add applications data to `MANIFEST.in`
   [#278](https://github.com/XanaduAI/strawberryfields/pull/278)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-networkx>=2.0
 numpy>=1.17.4
 scipy>=1.0.0
-tensorflow==1.3
-tensorflow-tensorboard>=0.1.8
+sympy>=1.5
+networkx>=2.0
 quantum-blackbird>=0.2.0
 thewalrus>=0.10
 toml
 appdirs
+tensorflow==1.3
+tensorflow-tensorboard>=0.1.8
 plotly==4.4.1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ with open("strawberryfields/_version.py") as f:
 requirements = [
     "numpy>=1.17.4",
     "scipy>=1.0.0",
+    "sympy>=1.5",
     "networkx>=2.0",
     "quantum-blackbird>=0.2.0",
     "thewalrus>=0.10",

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -64,7 +64,7 @@ def about():
         Strawberry Fields version: 0.12.0-dev
         Numpy version:             1.17.4
         Scipy version:             1.3.0
-        The Walrus version:           0.10.0-dev
+        The Walrus version:        0.10.0-dev
         Blackbird version:         0.2.1
         TensorFlow version:        2.0.0
     """
@@ -74,6 +74,8 @@ def about():
     import os
     import numpy
     import scipy
+    import sympy
+    import networkx
     import thewalrus
     import blackbird
 
@@ -87,7 +89,9 @@ def about():
     print('Strawberry Fields version: {}'.format(__version__))
     print('Numpy version:             {}'.format(numpy.__version__))
     print('Scipy version:             {}'.format(scipy.__version__))
-    print('The Walrus version:           {}'.format(thewalrus.__version__))
+    print('SymPy version:             {}'.format(sympy.__version__))
+    print('NetworkX version:          {}'.format(networkx.__version__))
+    print('The Walrus version:        {}'.format(thewalrus.__version__))
     print('Blackbird version:         {}'.format(blackbird.__version__))
 
     try:

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -18,8 +18,6 @@ The syntax is modeled after ProjectQ :cite:`projectq2016`.
 """
 from collections.abc import Sequence
 import copy
-import types
-import sys
 import warnings
 
 import numpy as np
@@ -37,6 +35,7 @@ from .parameters import (par_regref_deps, par_str, par_evaluate, par_is_symbolic
 
 # pylint: disable=abstract-method
 # pylint: disable=protected-access
+# pylint: disable=arguments-differ  # Measurement._apply introduces the "shots" argument
 
 # numerical tolerances
 _decomposition_merge_tol = 1e-13
@@ -369,7 +368,7 @@ class Channel(Transformation):
     maps and transformations.
     """
     # TODO decide how all Channels should treat the first parameter p[0]
-    # (see e.g. https://en.wikipedia.org/wiki/C0-semigroup), c.f. p[0] in ops.Gate
+    # (see e.g. https://en.wikipedia.org/wiki/C0-semigroup), cf. p[0] in ops.Gate
 
     def merge(self, other):
         if not self.__class__ == other.__class__:

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1172,14 +1172,7 @@ class CXgate(Gate):
     def _decompose(self, reg, **kwargs):
         s = self.p[0]
         r = pf.asinh(-s/2)
-        #theta = 0.5 * pf.atan2(-1.0 / pf.cosh(r), -pf.tanh(r))
-        # FIXME in sympy 1.4 atan2._eval_evalf() has a bug, it does not work with Symbol._eval_evalf().
-        # This is a workaround. When sympy is fixed (in version 1.5?), go back to using pf.atan2.
-        # See https://github.com/sympy/sympy/pull/17469
-        # If s<0 we need to add pi/2 to theta. If s==0, we need to avoid division by zero.
-        temp = 0.5 * pf.atan(1 / pf.sinh(r))  # NOTE s==0 will cause a division by zero when this is evaluated
-        theta = temp -pf.Heaviside(-s) * np.pi/2
-
+        theta = 0.5 * pf.atan2(-1.0 / pf.cosh(r), -pf.tanh(r))
         return [
             Command(BSgate(theta, 0), reg),
             Command(Sgate(r, 0), reg[0]),

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -102,15 +102,6 @@ import sympy
 import sympy.functions as sf
 
 
-# FIXME Workaround for missing numpy implementation of Heaviside, required by CXgate. Remove when no longer necessary.
-def heaviside(x):
-    """Heaviside step function."""
-    if x <= 0:
-        return 0
-    return 1
-
-custom_funcs = {'Heaviside': heaviside}
-
 
 def wrap_mathfunc(func):
     """Applies the wrapped sympy function elementwise to numpy arrays.
@@ -179,7 +170,7 @@ def par_evaluate(params):
 
         # using lambdify we can also substitute np.ndarrays and tf.Tensors for the atoms
         atoms = list(p.atoms(MeasuredParameter, FreeParameter))
-        func = sympy.lambdify(atoms, p, ['numpy', custom_funcs])
+        func = sympy.lambdify(atoms, p, ['numpy'])
         vals = [k._eval_evalf(None) for k in atoms]
         return func(*vals)
 

--- a/tests/integration/test_decompositions_integration.py
+++ b/tests/integration/test_decompositions_integration.py
@@ -554,7 +554,7 @@ class TestDecompositionsGaussianGates:
         eng.run(prog)
         assert np.all(eng.backend.is_vacuum(tol))
 
-    @pytest.mark.parametrize('s', np.linspace(-0.5, 0.6, 5))  # FIXME include 0 in testset when CXgate._decompose is fixed so that it can handle s=0
+    @pytest.mark.parametrize('s', np.linspace(-0.5, 0.5, 5))
     def test_CXgate_decomp_equal(self, setup_eng, s, tol):
         """Tests that the CXgate gives the same transformation as its decomposition."""
         eng, prog = setup_eng(2)
@@ -575,7 +575,7 @@ class TestDecompositionsGaussianGates:
         eng.run(prog)
         assert np.all(eng.backend.is_vacuum(tol))
 
-    @pytest.mark.parametrize('s', np.linspace(-0.5, 0.6, 5))  # FIXME include 0 in testset when CXgate._decompose is fixed so that it can handle s=0
+    @pytest.mark.parametrize('s', np.linspace(-0.5, 0.5, 5))
     def test_CZgate_decomp_equal(self, setup_eng, s, tol):
         """Tests that the CZgate gives the same transformation as its decomposition."""
         eng, prog = setup_eng(2)


### PR DESCRIPTION
**Context:**

In sympy 1.4, the `atan2` function has a bug in its implementation.  In PR #163 `sf.ops.CXgate` is implemented using a decomposition that needs `atan2`, so a workaround was used. The workaround could not handle the case `s=0`, however. The bug has been fixed in sympy 1.5.

**Description of the Change:**

* Adds `sympy >= 1.5` as an installation requirement (this was missing before)
* Removes the workaround code
* Modifies the tests so they test the `s=0` case as well.

**Benefits:**

The code is simplified, and can also handle the `s=0` case.
