### PR TITLE
Symbolic parameter / TF compatibility, documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Bug fixes
 
+* Symbolic Operation parameters are now compatible with TensorFlow 2.0 objects.
+  [#282](https://github.com/XanaduAI/strawberryfields/pull/282)
+
 * Added `sympy>=1.5` to the list of dependencies.
   Removed the `sympy.functions.atan2` workaround now that SymPy has been fixed.
   [#280](https://github.com/XanaduAI/strawberryfields/pull/280)

--- a/doc/code/sf_program.rst
+++ b/doc/code/sf_program.rst
@@ -1,0 +1,17 @@
+sf.program
+==========
+
+.. currentmodule:: strawberryfields.program
+
+.. warning::
+
+    Unless you are a Strawberry Fields developer, you likely do not need
+    to use these classes directly.
+
+    See the :class:`~strawberryfields.Program` class for
+    details on Strawberry Fields programs.
+
+
+.. automodapi:: strawberryfields.program
+    :no-heading:
+    :include-all-objects:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -179,5 +179,6 @@ Strawberry Fields is **free** and **open source**, released under the Apache Lic
    code/sf_decompositions
    code/sf_engine
    code/sf_io
+   code/sf_program
    code/sf_program_utils
    code/sf_parameters

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -25,7 +25,7 @@ Circuits
 
     circuits/glossary
 
-In Strawberry Fields, photonic quantum circuits are represented as :class:`~.Program`
+In Strawberry Fields, photonic quantum circuits are represented as :class:`~strawberryfields.Program`
 objects. By creating a program, quantum operations can be applied, measurements performed,
 and the program can then be simulated using the various Strawberry Fields backends.
 
@@ -37,7 +37,7 @@ and the program can then be simulated using the various Strawberry Fields backen
 Creating a quantum program
 --------------------------
 
-To construct a photonic quantum circuit in Strawberry Fields, a :class:`~.Program` object
+To construct a photonic quantum circuit in Strawberry Fields, a :class:`~strawberryfields.Program` object
 must be created, and operations applied.
 
 .. code-block:: python3
@@ -77,8 +77,8 @@ the same structure as the above example; in particular,
 
 .. note::
 
-    The contents of a program can be viewed by calling :meth:`.Program.print` method,
-    or output as a qcircuit :math:`\LaTeX{}` document by using the :meth:`.Program.draw_circuit`
+    The contents of a program can be viewed by calling the :meth:`~strawberryfields.Program.print` method,
+    or output as a qcircuit :math:`\LaTeX{}` document by using the :meth:`~strawberryfields.Program.draw_circuit`
     method.
 
 .. seealso::
@@ -178,26 +178,27 @@ for accessing the results of your program execution:
 Symbolic parameters
 -------------------
 
-The quantum operations can take both numerical and symbolic parameters. The latter fall into two types:
+The quantum operations can take both numerical and symbolic parameters.
+The latter fall into two types:
 
-* **Measured parameters**: Certain quantum programs require that
+* **Measured parameters**: Certain quantum programs (e.g. quantum teleportation) require that
   operations can be conditioned on measurement results obtained during the execution of the
   program. In this case the parameter value is not known until the measurement is made
-  (or simulated). The latest measurement result of qumode ``i`` is referred to as ``q[i].par``.
+  (or simulated). The latest measurement result of qumode ``i`` is available via ``q[i].par``.
 
 * **Free parameters**: A *parametrized circuit template* is a program that
-  depends on a number of free parameters. These parameters are bound to new fixed
+  depends on a number of free parameters. These parameters can be bound to new fixed
   values each time the program is executed.
-  The free parameters are created accessed using the :meth:`Program.params` method.
+  The free parameters are created and accessed using the
+  :meth:`~strawberryfields.Program.params` method.
 
-The symbolic parameters can be combined and transformed using basic algebraic operations and
-common mathematical functions in the ``strawberryfields.parameters.parfuncs`` namespace.
+The symbolic parameters can be combined and transformed using basic algebraic operations, and
+the mathematical functions in the :data:`strawberryfields.math` namespace.
 
 .. code-block:: python3
 
     import strawberryfields as sf
     from strawberryfields import ops
-    from strawberryfields.parameters import parfuncs as pf
 
     # create a 2-mode quantum program
     prog = sf.Program(2)
@@ -209,7 +210,7 @@ common mathematical functions in the ``strawberryfields.parameters.parfuncs`` na
     with prog.context as q:
         ops.Dgate(a ** 2)    | q[0]  # free parameter
         ops.MeasureX         | q[0]  # measure qumode 0, the result is used in the next operation
-        ops.Sgate(1 - pf.sin(q[0].par)) | q[1]  # measured parameter
+        ops.Sgate(1 - sf.math.sin(q[0].par)) | q[1]  # measured parameter
         ops.MeasureFock()    | q[1]
 
     # intialize the Fock backend
@@ -222,7 +223,7 @@ common mathematical functions in the ``strawberryfields.parameters.parfuncs`` na
 Compilation
 -----------
 
-The :class:`~.Program` object also provides *compilation* methods, that
+The :class:`~strawberryfields.Program` object also provides *compilation* methods, that
 automatically transform your circuit into an *equivalent* circuit with
 a particular layout or topology. For example, the ``gbs`` compile target will
 compile a circuit consisting of Gaussian operations and Fock measurements

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -45,7 +45,7 @@ must be created, and operations applied.
     import strawberryfields as sf
     from strawberryfields import ops
 
-    # create a 3 mode quantum program
+    # create a 3-mode quantum program
     prog = sf.Program(3)
 
     with prog.context as q:
@@ -70,6 +70,10 @@ the same structure as the above example; in particular,
   .. code-block:: python3
 
       ops.GateName(arg1, arg2) | (q[i], q[j], ...)
+
+  where ``ops.GateName`` is a quantum operation, ``arg1, arg2`` are its parameters,
+  and the right-hand side of the vertical bar lists the qumode(s) on which the operation
+  will act.
 
 .. note::
 
@@ -169,6 +173,50 @@ for accessing the results of your program execution:
     the trace of your program after simulation remains reasonably close to 1,
     by calling :meth:`state.trace() <.BaseFockState.trace>`. If the trace is much less than 1, you
     will need to increase the cutoff dimension.
+
+
+Symbolic parameters
+-------------------
+
+The quantum operations can take both numerical and symbolic parameters. The latter fall into two types:
+
+* **Measured parameters**: Certain quantum programs require that
+  operations can be conditioned on measurement results obtained during the execution of the
+  program. In this case the parameter value is not known until the measurement is made
+  (or simulated). The latest measurement result of qumode ``i`` is referred to as ``q[i].par``.
+
+* **Free parameters**: A *parametrized circuit template* is a program that
+  depends on a number of free parameters. These parameters are bound to new fixed
+  values each time the program is executed.
+  The free parameters are created accessed using the :meth:`Program.params` method.
+
+The symbolic parameters can be combined and transformed using basic algebraic operations and
+common mathematical functions in the ``strawberryfields.parameters.parfuncs`` namespace.
+
+.. code-block:: python3
+
+    import strawberryfields as sf
+    from strawberryfields import ops
+    from strawberryfields.parameters import parfuncs as pf
+
+    # create a 2-mode quantum program
+    prog = sf.Program(2)
+
+    # create a free parameter named 'a'
+    a = prog.params('a')
+
+    # define the program
+    with prog.context as q:
+        ops.Dgate(a ** 2)    | q[0]  # free parameter
+        ops.MeasureX         | q[0]  # measure qumode 0, the result is used in the next operation
+        ops.Sgate(1 - pf.sin(q[0].par)) | q[1]  # measured parameter
+        ops.MeasureFock()    | q[1]
+
+    # intialize the Fock backend
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': 5})
+
+    # run the program, with the free parameter 'a' bound to the value 0.9
+    result = eng.run(prog, args={'a': 0.9})
 
 
 Compilation

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -3,17 +3,23 @@ import strawberryfields as sf
 from strawberryfields.ops import *
 import tensorflow as tf
 
+raise NotImplementedError('This example is unavailable until SF supports TensorFlow 2.0.')
+
+
 # initialize engine and program objects
 eng = sf.Engine(backend="tf", backend_options={"cutoff_dim": 7})
 circuit = sf.Program(1)
 
-alpha = tf.Variable(0.1)
-with circuit.context as q:
-    Dgate(alpha) | q[0]
-results = eng.run(circuit, run_options={"eval": False})
+tf_alpha = tf.Variable(0.1)
+tf_phi = tf.Variable(0.1)
 
-# loss is probability for the Fock state n=1
-prob = results.state.fock_prob([1])
+alpha, phi = circuit.params('alpha', 'phi')
+with circuit.context as q:
+    Dgate(alpha, phi) | q[0]
+results = eng.run(circuit, args={'alpha': tf_alpha, 'phi': tf_phi}, run_options={"eval": False})
+
+# loss is probability for the coherent state |alpha=1>
+prob = results.state.fidelity_coherent([1.0])
 loss = -prob  # negative sign to maximize prob
 
 # Set up optimization

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -26,6 +26,7 @@ from ._version import __version__
 from .engine import Engine, LocalEngine
 from .io import load, save
 from .program import Program
+from .parameters import par_funcs as math
 
 __all__ = ["Engine", "LocalEngine", "Program", "version", "save", "load", "about", "cite"]
 
@@ -56,7 +57,7 @@ def about():
 
         >>> sf.about()
         Strawberry Fields: a Python library for continuous-variable quantum circuits.
-        Copyright 2018-2019 Xanadu Quantum Technologies Inc.
+        Copyright 2018-2020 Xanadu Quantum Technologies Inc.
 
         Python version:            3.6.8
         Platform info:             Linux-5.0.0-36-generic-x86_64-with-debian-buster-sid
@@ -64,7 +65,9 @@ def about():
         Strawberry Fields version: 0.12.0-dev
         Numpy version:             1.17.4
         Scipy version:             1.3.0
-        The Walrus version:        0.10.0-dev
+        Sympy version:             1.5
+        NetworkX version:          2.4
+        The Walrus version:        0.10.0
         Blackbird version:         0.2.1
         TensorFlow version:        2.0.0
     """
@@ -81,7 +84,7 @@ def about():
 
     # a QuTiP-style infobox
     print('\nStrawberry Fields: a Python library for continuous-variable quantum circuits.')
-    print('Copyright 2018-2019 Xanadu Quantum Technologies Inc.\n')
+    print('Copyright 2018-2020 Xanadu Quantum Technologies Inc.\n')
 
     print('Python version:            {}.{}.{}'.format(*sys.version_info[0:3]))
     print('Platform info:             {}'.format(platform.platform()))

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -31,7 +31,7 @@ import strawberryfields.decompositions as dec
 from .backends.states import BaseFockState, BaseGaussianState
 from .backends.shared_ops import changebasis
 from .program_utils import (Command, RegRef, MergeFailure)
-from .parameters import (par_regref_deps, par_str, par_evaluate, par_is_symbolic, parfuncs as pf)
+from .parameters import (par_regref_deps, par_str, par_evaluate, par_is_symbolic, par_funcs as pf)
 
 # pylint: disable=abstract-method
 # pylint: disable=protected-access

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -170,7 +170,7 @@ def par_evaluate(params):
 
         # using lambdify we can also substitute np.ndarrays and tf.Tensors for the atoms
         atoms = list(p.atoms(MeasuredParameter, FreeParameter))
-        func = sympy.lambdify(atoms, p, ['numpy'])
+        func = sympy.lambdify(atoms, p, par_evaluate.lambdify_printer)
         vals = [k._eval_evalf(None) for k in atoms]
         return func(*vals)
 
@@ -178,6 +178,9 @@ def par_evaluate(params):
     if scalar:
         return ret[0]
     return ret
+
+# default printer for lambdify to use (we also use 'tensorflow' for TF objects)
+par_evaluate.lambdify_printer = ['numpy']
 
 
 def par_is_symbolic(p):

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -13,90 +13,7 @@
 # limitations under the License.
 
 """
-Quantum programs
-================
-
-**Module name:** :mod:`strawberryfields.program`
-
-.. currentmodule:: strawberryfields.program
-
 This module implements the :class:`Program` class which acts as a representation for quantum circuits.
-The Program object also acts as a context for defining the quantum circuit using the Python-embedded Blackbird syntax.
-
-A typical use looks like
-
-.. include:: example_use.rst
-
-The Program objects keep track of the state of the quantum register they act on, using a dictionary of :class:`RegRef` objects.
-The currently active register references can be accessed using the :meth:`~Program.register` method.
-
-
-Program methods
----------------
-
-.. currentmodule:: strawberryfields.program.Program
-
-.. autosummary::
-   context
-   register
-   num_subsystems
-   __len__
-   can_follow
-   append
-   lock
-   compile
-   optimize
-   print
-   draw_circuit
-   params
-   bind_params
-
-The following are internal Program methods. In most cases the user should not
-call these directly.
-
-.. autosummary::
-   __enter__
-   __exit__
-   _clear_regrefs
-   _add_subsystems
-   _delete_subsystems
-   _index_to_regref
-   _test_regrefs
-   _linked_copy
-
-
-**Module name:** :mod:`strawberryfields.program_utils`
-
-.. currentmodule:: strawberryfields.program_utils
-
-Helper classes
---------------
-
-.. autosummary::
-   Command
-   RegRef
-
-
-Utility functions
------------------
-
-.. autosummary::
-   list_to_grid
-   grid_to_DAG
-   list_to_DAG
-   DAG_to_list
-   group_operations
-   optimize_circuit
-
-
-Exceptions
-----------
-
-.. autosummary::
-   MergeFailure
-   CircuitError
-   RegRefError
-
 
 Quantum circuit representation
 ------------------------------
@@ -124,14 +41,6 @@ Three different (but equivalent) representations of the circuit are used.
 
 The three representations can be converted to each other
 using the functions :func:`list_to_grid`, :func:`grid_to_DAG` and :func:`DAG_to_list`.
-
-
-.. currentmodule:: strawberryfields.program
-
-
-Code details
-~~~~~~~~~~~~
-
 """
 # pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
 
@@ -157,7 +66,7 @@ class Program:
     * appending :doc:`/introduction/ops` to the program.
 
     Within the context, operations are appended to the program using the
-    syntax
+    Python-embedded Blackbird syntax
 
     .. code-block:: python3
 
@@ -201,6 +110,9 @@ class Program:
             ops.BSgate(0.43, 0.1) | (q[0], q[2])
             ops.BSgate(0.43, 0.1) | (q[1], q[2])
             ops.MeasureFock() | q
+
+    The program objects keep track of the state of the quantum register they act on, using a dictionary of :class:`RegRef` objects.
+    The currently active register references can be accessed using the :meth:`~Program.register` method.
 
     Args:
         num_subsystems (int, Program): Initial number of modes (subsystems) in the quantum register.

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -111,7 +111,6 @@ class Program:
             ops.BSgate(0.43, 0.1) | (q[1], q[2])
             ops.MeasureFock() | q
 
-    The program objects keep track of the state of the quantum register they act on, using a dictionary of :class:`RegRef` objects.
     The currently active register references can be accessed using the :meth:`~Program.register` method.
 
     Args:
@@ -140,6 +139,7 @@ class Program:
         """
 
         # create subsystem references
+        # Program keeps track of the state of the quantum register using a dictionary of :class:`RegRef` objects.
         if isinstance(num_subsystems, numbers.Integral):
             #: int: initial number of subsystems
             self.init_num_subsystems = num_subsystems

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -21,7 +21,7 @@ import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields import io
 from strawberryfields.program import Program, CircuitError
-from strawberryfields.parameters import MeasuredParameter, FreeParameter, par_is_symbolic, parfuncs as pf
+from strawberryfields.parameters import MeasuredParameter, FreeParameter, par_is_symbolic, par_funcs as pf
 
 
 pytestmark = pytest.mark.frontend

--- a/tests/frontend/test_parameters.py
+++ b/tests/frontend/test_parameters.py
@@ -18,7 +18,7 @@ import numpy as np
 
 #import strawberryfields as sf
 from strawberryfields.parameters import (par_is_symbolic, par_regref_deps, par_str, par_evaluate,
-                                         MeasuredParameter, FreeParameter, parfuncs as pf,
+                                         MeasuredParameter, FreeParameter, par_funcs as pf,
                                          ParameterError)
 from strawberryfields.program_utils import RegRef
 

--- a/tests/integration/test_parameters_integration.py
+++ b/tests/integration/test_parameters_integration.py
@@ -22,7 +22,7 @@ import numpy as np
 
 import strawberryfields.program_utils as pu
 from strawberryfields import ops
-from strawberryfields.parameters import ParameterError, parfuncs as pf
+from strawberryfields.parameters import ParameterError, par_funcs as pf
 
 
 # ops.Fock requires an integer parameter

--- a/tests/integration/test_tf_symbolic.py
+++ b/tests/integration/test_tf_symbolic.py
@@ -90,20 +90,22 @@ class TestOneModeSymbolic:
         val = q[0].val
         assert isinstance(val, tf.Tensor)
 
+    @pytest.mark.xfail(reason="Symbolic parameter system only works with TensorFlow 2 objects", raises=AttributeError, strict=True)
     def test_eng_run_with_session_and_feed_dict(self, setup_eng, batch_size, cutoff, tol):
         """Tests whether passing a tf Session and feed_dict
         through `eng.run` leads to proper numerical simulation."""
-        a = tf.Variable(0.5)
+        tf_a = tf.Variable(0.5)
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        tf_params = {'session': sess, 'feed_dict': {a: 0.0}}
+        tf_params = {'session': sess, 'feed_dict': {tf_a: 0.0}}
 
+        # NOTE this test worked before because the phase was zero, we only needed working arithmetic in that case
         eng, prog = setup_eng(1)
         x = prog.params('a')  # free parameter
         with prog.context as q:
-            Dgate(x) | q
+            Dgate(x, 1.3) | q
 
-        state = eng.run(prog, args={'a': a}, run_options=tf_params).state
+        state = eng.run(prog, args={'a': tf_a}, run_options=tf_params).state
 
         if state.is_pure:
             k = state.ket()

--- a/tests/integration/test_tf_symbolic.py
+++ b/tests/integration/test_tf_symbolic.py
@@ -14,13 +14,9 @@
 r"""
 Tests for the various Tensorflow-specific symbolic options of the frontend/backend.
 """
-# pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement
+# pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement,no-self-use
 
 import pytest
-
-# this test file is only supported by the TF backend
-pytestmark = pytest.mark.backends("tf")
-
 import numpy as np
 from scipy.special import factorial
 
@@ -34,6 +30,10 @@ else:
 
 from strawberryfields.ops import Dgate, MeasureX
 import strawberryfields.parameters
+
+
+# this test file is only supported by the TF backend
+pytestmark = pytest.mark.backends("tf")
 
 
 ALPHA = 0.5
@@ -109,11 +109,12 @@ class TestOneModeSymbolic:
             Dgate(x, y) | q
 
         # use TF to evaluate symbolic parameter expressions
-        strawberryfields.parameters.par_evaluate.lambdify_printer = ['tensorflow']
-        state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, run_options=tf_params).state
-
-        # restore the default
-        strawberryfields.parameters.par_evaluate.lambdify_printer = ['numpy']
+        try:
+            strawberryfields.parameters.par_evaluate.lambdify_printer = ['tensorflow']
+            state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, run_options=tf_params).state
+        finally:
+            # restore the default
+            strawberryfields.parameters.par_evaluate.lambdify_printer = ['numpy']
 
         if state.is_pure:
             k = state.ket()

--- a/tests/integration/test_tf_symbolic.py
+++ b/tests/integration/test_tf_symbolic.py
@@ -102,19 +102,14 @@ class TestOneModeSymbolic:
         tf_params = {'session': sess, 'feed_dict': {tf_a: 0.0, tf_phi: 1.0}}
 
         # NOTE this test worked before because the phase was a number, we only needed working tf.Tensor arithmetic in that case.
-        # Now also the pf.exp function has to work on tf.Tensors.
+        # Now also the exp function has to work on tf.Tensors.
         eng, prog = setup_eng(1)
         x, y = prog.params('a', 'phi')  # free parameters
         with prog.context as q:
             Dgate(x, y) | q
 
         # use TF to evaluate symbolic parameter expressions
-        try:
-            strawberryfields.parameters.par_evaluate.lambdify_printer = ['tensorflow']
-            state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, run_options=tf_params).state
-        finally:
-            # restore the default
-            strawberryfields.parameters.par_evaluate.lambdify_printer = ['numpy']
+        state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, run_options=tf_params).state
 
         if state.is_pure:
             k = state.ket()

--- a/tests/integration/test_utils_integration.py
+++ b/tests/integration/test_utils_integration.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Integration tests for the utils.py module"""
-import pytest
 
+# pylint: disable=pointless-statement,expression-not-assigned,no-self-use
+
+import pytest
 import numpy as np
 
 try:
@@ -30,6 +32,7 @@ import strawberryfields.utils as utils
 from strawberryfields.backends.fockbackend.ops import squeezing as sq_U
 from strawberryfields.backends.fockbackend.ops import displacement as disp_U
 from strawberryfields.backends.fockbackend.ops import beamsplitter as bs_U
+
 
 ALPHA = np.linspace(-0.15, 0.2, 4) + np.linspace(-0.2, 0.1, 4) * 1j
 R = np.linspace(0, 0.21, 4)
@@ -110,6 +113,7 @@ class TestInitialStatesAgreeGaussian:
 
 @pytest.fixture
 def bsize(batch_size):
+    """Utility fixture for handling both batched and non-batched modes."""
     return 1 if batch_size is None else batch_size
 
 
@@ -142,8 +146,6 @@ class TestInitialStatesAgreeFock:
         """Test coherent function matches Fock backends"""
         eng, prog = setup_eng(1)
         a = 0.32 + 0.1j
-        r = 0.112
-        phi = 0.123
 
         with prog.context as q:
             ops.Dgate(a) | q[0]
@@ -206,7 +208,7 @@ class TestInitialStatesAgreeFock:
 
         assert np.allclose(expected, ket, atol=tol, rtol=0)
 
-    def test_fock_state(self, setup_eng, hbar, cutoff, bsize, pure, tol):
+    def test_fock_state(self, setup_eng, cutoff, bsize, pure, tol):
         """Test fock state function matches Fock backends"""
         eng, prog = setup_eng(1)
         n = 2
@@ -225,7 +227,7 @@ class TestInitialStatesAgreeFock:
 
         assert np.allclose(expected, ket, atol=tol, rtol=0)
 
-    def test_cat_state(self, setup_eng, hbar, cutoff, bsize, pure, tol):
+    def test_cat_state(self, setup_eng, cutoff, bsize, pure, tol):
         """Test cat state function matches Fock backends"""
         eng, prog = setup_eng(1)
         a = 0.32 + 0.1j
@@ -254,11 +256,13 @@ class TestInitialStatesAgreeFock:
 
 @utils.operation(1)
 def prepare_state(v1, q):
+    """Single-mode state preparation."""
     ops.Dgate(v1) | q
 
 
 @utils.operation(2)
 def entangle_states(q):
+    """Two-mode entangled state preparation."""
     ops.Sgate(-2) | q[0]
     ops.Sgate(2) | q[1]
     ops.BSgate(np.pi / 4, 0) | (q[0], q[1])
@@ -272,7 +276,6 @@ class TestTeleportationOperationTest:
     def test_teleportation_fidelity(self, setup_eng):
         """Test teleportation algorithm gives correct fid when using operations"""
         eng, prog = setup_eng(3)
-        tol = 0.1
         with prog.context as q:
             prepare_state(0.5 + 0.2j) | q[0]
             entangle_states() | (q[1], q[2])
@@ -312,6 +315,7 @@ class TestTeleportationOperationTest:
 
 @pytest.fixture
 def backend_name(setup_backend_pars):
+    """The name of the currently tested backend."""
     return setup_backend_pars[0]
 
 
@@ -417,7 +421,7 @@ class TestExtractUnitary:
         assert np.allclose(final_state, expected_state, atol=tol, rtol=0)
 
     def test_extract_arbitrary_unitary_two_modes_vectorized(
-        self, setup_eng, cutoff, batch_size, tol
+            self, setup_eng, cutoff, batch_size, tol
     ):
         """Test that arbitrary unitary extraction works for 2 mode when vectorized"""
         bsize = 1
@@ -462,7 +466,7 @@ class TestExtractUnitary:
         assert np.allclose(final_state, expected_state, atol=tol, rtol=0)
 
     def test_extract_arbitrary_unitary_two_modes_not_vectorized(
-        self, setup_eng, cutoff, tol
+            self, setup_eng, cutoff, tol
     ):
         """Test that arbitrary unitary extraction works for 2 mode"""
         S = ops.Sgate(0.4, -1.2)
@@ -633,9 +637,7 @@ class TestExtractChannelTwoMode:
 
         assert np.allclose(final_rho, rho, atol=tol, rtol=0)
 
-    def test_extract_liouville_channel_vectorize(
-        self, setup_two_mode_circuit, cutoff, tol
-    ):
+    def test_extract_liouville_channel_vectorize(self, setup_two_mode_circuit, cutoff, tol):
         """Test that Liouville channel extraction works for 2 mode vectorized"""
         prog, rho, initial_state = setup_two_mode_circuit
         rho = np.einsum("abcd->acbd", rho).reshape(cutoff ** 2, cutoff ** 2)


### PR DESCRIPTION
**Context:**

The symbolic parameter system should be able to handle TensorFlow objects being passed through it,  without actually depending on TF. This can be done using the `tensorflow` printer in SymPy. SymPy requires TF 2.0 to work.

**Description of the Change:**

* Symbolic parameter syntax and use is described in the docs.
* TF objects can now appear as `Operation` parameters only by binding free parameters to them when the `Program` is run.
* TF-related symbolic parameter tests and examples are fixed and temporarily disabled, until SF has been migrated to TF 2.0.
* Symbolic parameters are now consistently evaluated right before the backend API call, not before.

**Benefits:**

Once the TF 2.0 migration is done, SF can again be used in symbolic TF computations.

**Related GitHub Issues:**

* Will eventually solve #271
* Closes #161 (because now TF objects can only enter a program as free symbolic parameters)