### PR TITLE
Update python version for building in RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-    version: 3.6
+    version: 3.7
     install:
         - requirements: doc/requirements.txt
         - method: pip


### PR DESCRIPTION
The `latest` (master) branch in RTD is currently failing to build.
Upgrading the version of python specified to build the docs from `3.6` to `3.7` seems to fix things.