### PR TITLE
Remove duplicate automodapi pages for imported objects.

### DIFF
--- a/doc/code/sf.rst
+++ b/doc/code/sf.rst
@@ -4,5 +4,6 @@ sf
 .. currentmodule:: strawberryfields
 
 .. automodapi:: strawberryfields
-   :no-heading:
-   :include-all-objects:
+    :no-heading:
+    :include-all-objects:
+    :no-inheritance-diagram:

--- a/doc/code/sf.rst
+++ b/doc/code/sf.rst
@@ -4,3 +4,4 @@ sf
 .. currentmodule:: strawberryfields
 
 .. automodule:: strawberryfields
+   :members: about, cite, version

--- a/doc/code/sf.rst
+++ b/doc/code/sf.rst
@@ -3,7 +3,4 @@ sf
 
 .. currentmodule:: strawberryfields
 
-.. automodapi:: strawberryfields
-    :no-heading:
-    :include-all-objects:
-    :no-inheritance-diagram:
+.. automodule:: strawberryfields

--- a/doc/code/sf.rst
+++ b/doc/code/sf.rst
@@ -3,5 +3,6 @@ sf
 
 .. currentmodule:: strawberryfields
 
-.. automodule:: strawberryfields
-   :members: about, cite, version
+.. automodapi:: strawberryfields
+   :no-heading:
+   :include-all-objects:

--- a/doc/code/sf_backends.rst
+++ b/doc/code/sf_backends.rst
@@ -8,7 +8,7 @@ sf.backends
     Unless you are a Strawberry Fields developer, you likely do not need
     to use these classes directly.
 
-    See the general :class:`~strawberryfields.Engine` class for
+    See the :class:`.Engine` class for
     details on loading a particular backend for quantum program
     execution.
 

--- a/doc/code/sf_engine.rst
+++ b/doc/code/sf_engine.rst
@@ -8,10 +8,9 @@ sf.engine
     Unless you are a Strawberry Fields developer, you likely do not need
     to use these classes directly.
 
-    See the general :class:`~strawberryfields.Engine` class for
+    See the :class:`.Engine` class for
     details on creating a Strawberry Fields engine.
 
 .. automodapi:: strawberryfields.engine
     :no-heading:
     :include-all-objects:
-    :skip: Engine, Sequence, stack, shape, load_backend, NotApplicableError, BaseBackend

--- a/doc/code/sf_io.rst
+++ b/doc/code/sf_io.rst
@@ -6,13 +6,11 @@ sf.io
 .. warning::
 
     Unless you are a Strawberry Fields developer, you likely do not need
-    to use these classes directly.
+    to use these functions directly.
 
-    See the general :func:`~strawberryfields.save` and
-    :func:`~strawberryfields.load` functions for saving/loading Strawberry Fields
+    See the :func:`.save` and :func:`.load` functions for saving/loading Strawberry Fields
     quantum programs.
 
 .. automodapi:: strawberryfields.io
     :no-heading:
     :include-all-objects:
-    :skip: Program, par_is_symbolic, par_convert

--- a/doc/code/sf_parameters.rst
+++ b/doc/code/sf_parameters.rst
@@ -11,4 +11,4 @@ sf.parameters
 .. automodapi:: strawberryfields.parameters
     :no-heading:
     :include-all-objects:
-    :skip: Sequence, custom_funcs
+    :no-inherited-members:

--- a/doc/code/sf_program.rst
+++ b/doc/code/sf_program.rst
@@ -8,7 +8,7 @@ sf.program
     Unless you are a Strawberry Fields developer, you likely do not need
     to use these classes directly.
 
-    See the :class:`~strawberryfields.Program` class for
+    See the :class:`.Program` class for
     details on Strawberry Fields programs.
 
 

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -25,7 +25,7 @@ Circuits
 
     circuits/glossary
 
-In Strawberry Fields, photonic quantum circuits are represented as :class:`~strawberryfields.Program`
+In Strawberry Fields, photonic quantum circuits are represented as :class:`.Program`
 objects. By creating a program, quantum operations can be applied, measurements performed,
 and the program can then be simulated using the various Strawberry Fields backends.
 
@@ -37,7 +37,7 @@ and the program can then be simulated using the various Strawberry Fields backen
 Creating a quantum program
 --------------------------
 
-To construct a photonic quantum circuit in Strawberry Fields, a :class:`~strawberryfields.Program` object
+To construct a photonic quantum circuit in Strawberry Fields, a :class:`.Program` object
 must be created, and operations applied.
 
 .. code-block:: python3
@@ -56,13 +56,13 @@ must be created, and operations applied.
         ops.BSgate(0.43, 0.1) | (q[1], q[2])
         ops.MeasureFock() | q
 
-Here, we are creating a 3-mode program, and applying a :class:`~.Sgate` and
-a :class:`~.BSgate` to various modes. Constructing quantum circuits always follows
+Here, we are creating a 3-mode program, and applying a :class:`.Sgate` and
+a :class:`.BSgate` to various modes. Constructing quantum circuits always follows
 the same structure as the above example; in particular,
 
 * A ``with`` statement is used to populate the program with quantum operations.
 
-* ``Program.context`` is used within the ``with`` statement to return ``q``,
+* :attr:`Program.context` is used within the ``with`` statement to return ``q``,
   a representation of the quantum registers (qumodes or modes).
 
 * Quantum operations are applied to the modes of the program using the syntax
@@ -77,8 +77,8 @@ the same structure as the above example; in particular,
 
 .. note::
 
-    The contents of a program can be viewed by calling the :meth:`~strawberryfields.Program.print` method,
-    or output as a qcircuit :math:`\LaTeX{}` document by using the :meth:`~strawberryfields.Program.draw_circuit`
+    The contents of a program can be viewed by calling the :meth:`.Program.print` method,
+    or output as a qcircuit :math:`\LaTeX{}` document by using the :meth:`.Program.draw_circuit`
     method.
 
 .. seealso::
@@ -100,7 +100,7 @@ which is responsible for executing the program on a specified backend
     # Fock cutoff dimension (truncation) of 5
     eng = sf.Engine("fock", backend_options={"cutoff_dim": 5})
 
-:class:`~.Engine` accepts two arguments, the backend name, and a dictionary of
+:class:`.Engine` accepts two arguments, the backend name, and a dictionary of
 backend options. Available backends include:
 
 * The ``'fock'`` backend, written in NumPy.
@@ -125,7 +125,7 @@ backend options. Available backends include:
   using TensorFlow.
 
 Once the engine has been initialized, the quantum program can be executed on the
-selected backend via :meth:`~.Engine.run`:
+selected backend via :meth:`.Engine.run`:
 
 .. code-block:: python3
 
@@ -134,10 +134,10 @@ selected backend via :meth:`~.Engine.run`:
 Execution results
 -----------------
 
-The returned :class:`~Result` object provides several useful properties
+The returned :class:`.Result` object provides several useful properties
 for accessing the results of your program execution:
 
-* ``results.state``: The quantum state object contains details and methods
+* :attr:`.Result.state`: The quantum state object contains details and methods
   for manipulation of the final circuit state. Not available for remote
   backends.
 
@@ -151,7 +151,7 @@ for accessing the results of your program execution:
       >>> state.dm().shape # density matrix
       [5, 5, 5]
 
-* ``results.samples``: Measurement samples from any measurements performed.
+* :attr:`.Result.samples`: Measurement samples from any measurements performed.
 
   .. code-block:: pycon
 
@@ -190,7 +190,7 @@ The latter fall into two types:
   depends on a number of free parameters. These parameters can be bound to new fixed
   values each time the program is executed.
   The free parameters are created and accessed using the
-  :meth:`~strawberryfields.Program.params` method.
+  :meth:`.Program.params` method.
 
 The symbolic parameters can be combined and transformed using basic algebraic operations, and
 the mathematical functions in the :data:`strawberryfields.math` namespace.
@@ -223,8 +223,8 @@ the mathematical functions in the :data:`strawberryfields.math` namespace.
 Compilation
 -----------
 
-The :class:`~strawberryfields.Program` object also provides *compilation* methods, that
-automatically transform your circuit into an *equivalent* circuit with
+The :class:`.Program` object also provides the :meth:`.Program.compile` method that
+automatically transforms your circuit into an :term:`equivalent circuit` with
 a particular layout or topology. For example, the ``gbs`` compile target will
 compile a circuit consisting of Gaussian operations and Fock measurements
 into canonical Gaussian boson sampling form.

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -14,15 +14,13 @@
 """
 The Strawberry Fields codebase includes a number of complementary components.
 These can be separated into frontend components, applications layer,
-and backend components (all found within the :file:`strawberryfields.backends` submodule).
+and backend components (all found within the :mod:`strawberryfields.backends` submodule).
 
 .. image:: ../_static/sfcomponents.svg
     :align: center
     :width: 90%
     :target: javascript:void(0);
 
-
-.. currentmodule:: strawberryfields
 
 Classes
 -------
@@ -40,6 +38,8 @@ Functions
    cite
    ~strawberryfields.io.save
    ~strawberryfields.io.load
+
+----
 """
 from . import apps
 from ._version import __version__

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -20,26 +20,6 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
     :align: center
     :width: 90%
     :target: javascript:void(0);
-
-
-Classes
--------
-
-.. autosummary::
-   ~strawberryfields.program.Program
-   ~strawberryfields.engine.Engine
-
-Functions
----------
-
-.. autosummary::
-   version
-   about
-   cite
-   ~strawberryfields.io.save
-   ~strawberryfields.io.load
-
-----
 """
 from . import apps
 from ._version import __version__
@@ -48,7 +28,7 @@ from .io import load, save
 from .program import Program
 from .parameters import par_funcs as math
 
-__all__ = ["Engine", "LocalEngine", "Program", "version", "save", "load", "about", "cite"]
+__all__ = ["Engine", "Program", "version", "save", "load", "about", "cite"]
 
 
 #: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -20,6 +20,26 @@ and backend components (all found within the :file:`strawberryfields.backends` s
     :align: center
     :width: 90%
     :target: javascript:void(0);
+
+
+.. currentmodule:: strawberryfields
+
+Classes
+-------
+
+.. autosummary::
+   ~strawberryfields.program.Program
+   ~strawberryfields.engine.Engine
+
+Functions
+---------
+
+.. autosummary::
+   version
+   about
+   cite
+   ~strawberryfields.io.save
+   ~strawberryfields.io.load
 """
 from . import apps
 from ._version import __version__

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -471,7 +471,8 @@ class LocalEngine(BaseEngine):
             # the run options of successive programs
             # overwrite the run options of previous programs
             # in the list
-            [temp_run_options.update(p.run_options) for p in program]
+            for p in program:
+                temp_run_options.update(p.run_options)
         else:
             # single program to execute
             temp_run_options.update(program.run_options)
@@ -498,5 +499,6 @@ class LocalEngine(BaseEngine):
 
 
 class Engine(LocalEngine):
+    """dummy"""
     # alias for backwards compatibility
     __doc__ = LocalEngine.__doc__

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -19,11 +19,17 @@ One can think of each BaseEngine instance as a separate quantum computation.
 """
 
 import abc
-from collections.abc import Sequence
-from numpy import stack, shape
+import collections.abc
+
+import numpy as np
 
 from .backends import load_backend
 from .backends.base import (NotApplicableError, BaseBackend)
+
+
+
+__all__ = ["Result", "BaseEngine", "LocalEngine", "Engine"]
+
 
 
 class Result:
@@ -73,8 +79,8 @@ class Result:
         self._state = None
 
         # ``samples`` arrives as a list of arrays, need to convert here to a multidimensional array
-        if len(shape(samples)) > 1:
-            samples = stack(samples, 1)
+        if len(np.shape(samples)) > 1:
+            samples = np.stack(samples, 1)
         self._samples = samples
 
     @property
@@ -314,7 +320,7 @@ class BaseEngine(abc.ABC):
                 return [None] * dim
             return val
 
-        if not isinstance(program, Sequence):
+        if not isinstance(program, collections.abc.Sequence):
             program = [program]
 
         kwargs.setdefault("shots", 1)
@@ -460,7 +466,7 @@ class LocalEngine(BaseEngine):
         compile_options = compile_options or {}
         temp_run_options = {}
 
-        if isinstance(program, Sequence):
+        if isinstance(program, collections.abc.Sequence):
             # succesively update all run option defaults.
             # the run options of successive programs
             # overwrite the run options of previous programs

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -27,8 +27,8 @@ from .backends import load_backend
 from .backends.base import (NotApplicableError, BaseBackend)
 
 
-
-__all__ = ["Result", "BaseEngine", "LocalEngine", "Engine"]
+# for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
+__all__ = ["Result", "BaseEngine", "LocalEngine"]
 
 
 

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -25,6 +25,10 @@ import strawberryfields.parameters as sfpar
 from . import ops
 
 
+# for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
+__all__ = ['to_blackbird', 'to_program', 'loads']
+
+
 
 def to_blackbird(prog, version="1.0"):
     """Convert a Strawberry Fields Program to a Blackbird Program.

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -20,9 +20,10 @@ import os
 
 import blackbird
 
+import strawberryfields.program as sfp
+import strawberryfields.parameters as sfpar
 from . import ops
-from .program import Program
-from .parameters import par_is_symbolic, par_convert
+
 
 
 def to_blackbird(prog, version="1.0"):
@@ -60,7 +61,7 @@ def to_blackbird(prog, version="1.0"):
 
         else:
             for a in cmd.op.p:
-                if par_is_symbolic(a):
+                if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string
                     a = str(a)
                 op["args"].append(a)
@@ -85,7 +86,7 @@ def to_program(bb):
         # to initialize the Program object with.
         raise ValueError("Blackbird program contains no quantum operations!")
 
-    prog = Program(max(bb.modes)+1, name=bb.name)
+    prog = sfp.Program(max(bb.modes)+1, name=bb.name)
 
     # append the quantum operations
     with prog.context as q:
@@ -111,8 +112,8 @@ def to_program(bb):
 
                 # Convert symbolic expressions in args/kwargs containing measured and free parameters to
                 # symbolic expressions containing the corresponding MeasuredParameter and FreeParameter instances.
-                args = par_convert(args, prog)
-                vals = par_convert(kwargs.values(), prog)
+                args = sfpar.par_convert(args, prog)
+                vals = sfpar.par_convert(kwargs.values(), prog)
                 kwargs = dict(zip(kwargs.keys(), vals))
                 gate(*args, **kwargs) | regrefs  #pylint:disable=expression-not-assigned
             else:

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -124,9 +124,11 @@ def wrap_mathfunc(func):
         return func(*args)
     return wrapper
 
-#: SimpleNamespace: Namespace of mathematical functions for manipulating Parameters. Consists of all :mod:`sympy.functions` public members, which we wrap with :func:`wrap_mathfunc`.
-par_funcs = types.SimpleNamespace(**{name: wrap_mathfunc(getattr(sf, name)) for name in dir(sf) if name[0] != '_'})
 
+par_funcs = types.SimpleNamespace(**{name: wrap_mathfunc(getattr(sf, name)) for name in dir(sf) if name[0] != '_'})
+"""SimpleNamespace: Namespace of mathematical functions for manipulating Parameters.
+Consists of all :mod:`sympy.functions` public members, which we wrap with :func:`wrap_mathfunc`.
+"""
 
 
 class ParameterError(RuntimeError):

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -93,7 +93,7 @@ What we cannot do at the moment:
 """
 # pylint: disable=too-many-ancestors,unused-argument,protected-access
 
-from collections.abc import Sequence
+import collections.abc
 import functools
 import types
 
@@ -104,10 +104,10 @@ import sympy.functions as sf
 
 
 def wrap_mathfunc(func):
-    """Applies the wrapped sympy function elementwise to numpy arrays.
+    """Applies the wrapped sympy function elementwise to NumPy arrays.
 
-    Required because the sympy math functions cannot deal with numpy arrays.
-    We implement no broadcasting; if the first argument is a numpy array, we assume
+    Required because the sympy math functions cannot deal with NumPy arrays.
+    We implement no broadcasting; if the first argument is a NumPy array, we assume
     all the arguments are arrays of the same shape.
     """
     @functools.wraps(func)
@@ -137,16 +137,23 @@ class ParameterError(RuntimeError):
 
 
 def is_object_array(p):
-    """Returns True iff p is an object array."""
+    """Returns True iff p is an object array.
+
+    Args:
+        p (Any): object to be checked
+
+    Returns:
+        bool: True iff p is a NumPy object array
+    """
     return isinstance(p, np.ndarray) and p.dtype == object
 
 
 def par_evaluate(params):
     """Evaluate an Operation parameter sequence.
 
-    Any parameters descending from sympy.Basic are evaluated, others are returned as-is.
+    Any parameters descending from :class:`sympy.Basic` are evaluated, others are returned as-is.
     Evaluation means that free and measured parameters are replaced by their numeric values.
-    Numpy object arrays are evaluated elementwise.
+    NumPy object arrays are evaluated elementwise.
 
     Alternatively, evaluates a single parameter and returns its value.
 
@@ -157,7 +164,7 @@ def par_evaluate(params):
         list[Any]: evaluated parameters
     """
     scalar = False
-    if not isinstance(params, Sequence):
+    if not isinstance(params, collections.abc.Sequence):
         scalar = True
         params = [params]
 
@@ -190,7 +197,8 @@ def par_is_symbolic(p):
     """Returns True iff p is a symbolic Operation parameter instance.
 
     If a parameter inherits :class:`sympy.Basic` it is symbolic.
-    An object array is symbolic if any of its elements are.
+    A NumPy object array is symbolic if any of its elements are.
+    All other objects are considered not symbolic parameters.
 
     Note that :data:`strawberryfields.math` functions applied to numerical (non-symbolic) parameters return
     symbolic parameters.

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -39,8 +39,12 @@ Three different (but equivalent) representations of the circuit are used.
   is empty, that is, consuming it in a topological order.
   Note that a topological order is not always unique, there may be several equivalent topological orders.
 
+.. currentmodule:: strawberryfields.program_utils
+
 The three representations can be converted to each other
 using the functions :func:`list_to_grid`, :func:`grid_to_DAG` and :func:`DAG_to_list`.
+
+.. currentmodule:: strawberryfields.program
 """
 # pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
 
@@ -55,6 +59,11 @@ import strawberryfields.circuitspecs as specs
 import strawberryfields.program_utils as pu
 from .program_utils import Command, RegRef, CircuitError, RegRefError
 from .parameters import FreeParameter, ParameterError
+
+
+
+__all__ = ["Program"]
+
 
 
 class Program:

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """
-This module implements the :class:`Program` class which acts as a representation for quantum circuits.
+This module implements the :class:`.Program` class which acts as a representation for quantum circuits.
 
 Quantum circuit representation
 ------------------------------
 
-The :class:`Command` instances in the circuit form a
+The :class:`.Command` instances in the circuit form a
 `strict partially ordered set <http://en.wikipedia.org/wiki/Partially_ordered_set#Strict_and_non-strict_partial_orders>`_
 in the sense that the order in which the operations have to be executed is usually not completely fixed.
 For example, operations acting on different subsystems always commute with each other.
@@ -62,7 +62,8 @@ from .parameters import FreeParameter, ParameterError
 
 
 
-__all__ = ["Program"]
+# for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
+__all__ = []
 
 
 


### PR DESCRIPTION
**Context:**

SF uses `automodapi` to document the code. For each module, automodapi creates one html page for the module, containing summary tables listing the classes and functions in the module namespace, and separate html pages for each class/function, with links between them. This has the side effect of sometimes creating duplicate pages: for example, if in module `A` we have `from B import X` , automodapi will generate two practically identical html pages for the class `X`, namely `A.X.html`  and `B.X.html`. Ideally we'd like to have only `B.X.html`.

Multiple html pages for the same object lead to warnings when building the docs, as Sphinx does not know to which page wildcard links of the form `.X` are supposed to point.

There are (at least) three ways to prevent automodapi from documenting a particular object:

1. Use `import B` and `B.X` instead of `from B import X`, so `X` never enters the namespace of the module `A`. This is also the import style recommended in most style guides due to its readability, but it can get a bit verbose.
2. Use `:skip: X` in the rst file for the module `A`. Goes against the principle of keeping the docs and the code in the same place.
3. Add the `__all__` attribute to the module `A`, do not list `X` in it. automodapi has an undocumented feature which makes it only document the objects listed in `__all__` if it is present.

A combination of methods 1 and 3 works for most modules.

**Description of the Change:**

* Some `:skip:` options removed, replaced with methods 1 and 3 as appropriate. Some still remain.
* Links shortened to basic wildcard form now that there are no duplicate doc pages anymore.
* `:no-inherited-members:` option added for classes inheriting classes from other libraries.
* Items imported by `__init__.py` are removed from the `__all__` attributes of their modules to avoid doc page duplication.
* Small doc improvements.

**Benefits:**

* No duplicate doc pages.
* Doc build process is now free of errors and warnings.
* Short wildcard links work.

**Possible Drawbacks:**

* Whenever a new item is imported to the top-level `__init__.py` namespace, it also needs to be manually removed from the `__all__` attribute of the module that defines it.