### PR TITLE
Custom contraction for beamsplitter, two-mode squeezing and diagonal operators

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Added The Walrus implementations for the displacement, squeezing and beamsplitter 
   operations to improve speed.
   [#287](https://github.com/XanaduAI/strawberryfields/pull/287)
+  
+* Added custom tensor contractions for the beamsplitter and the two-mode squeeze
+  gate as well as faster application of diagonal gate matrices.
+  [#292](https://github.com/XanaduAI/strawberryfields/pull/292)
 
 ### Bug fixes
 

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -23,6 +23,7 @@ from itertools import product
 import numpy as np
 from numpy import sqrt, pi
 from scipy.special import factorial as bang
+from numba.typed import List
 
 from . import ops
 
@@ -314,7 +315,14 @@ class Circuit():
         """
         Applies a beamsplitter.
         """
-        self._apply_gate(ops.beamsplitter(t, r, phi, self._trunc), [mode1, mode2])
+        mat = ops.beamsplitter(t, r, phi, self._trunc)
+
+        modes = List()
+        modes.append(mode1)
+        modes.append(mode2)
+
+        args = [mat, self._state, self._pure, modes, self._num_modes, self._trunc]
+        self._state = ops.apply_twomode_gate(*args, gate="BSgate")
 
     def squeeze(self, r, theta, mode):
         """
@@ -326,7 +334,15 @@ class Circuit():
         """
         Applies a two-mode squeezing gate.
         """
-        self._apply_gate(ops.two_mode_squeezing(r, theta, self._trunc), [mode1, mode2])
+        # self._apply_gate(ops.two_mode_squeezing(r, theta, self._trunc), [mode1, mode2])
+        mat = ops.two_mode_squeezing(r, theta, self._trunc)
+
+        modes = List()
+        modes.append(mode1)
+        modes.append(mode2)
+
+        args = [mat, self._state, self._pure, modes, self._num_modes, self._trunc]
+        self._state = ops.apply_twomode_gate(*args, gate="S2gate")
 
     def kerr_interaction(self, kappa, mode):
         """

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -348,7 +348,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
         mat (array[complex]): The numeric operator to be applied to the state, of shape `[trunc]*(2*n)`
         state (array[complex]): The state that the operator is applied to
         pure (bool): whether the state is pure or mixed
-        modes (list[int]): A list of modes to which the BS is applied
+        modes (list[int]): the list of modes to which the operator is applied on
         n (int): The total number of modes
         trunc (int): The Hilbert space truncation/cutoff
         gate (str): the gate which should be called (BSgate, S2gate)

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -358,6 +358,9 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     Returns:
         array[complex]: state after application of the two-mode operation
     """
+    # the transpositions below are necessary for using the jitted apply-gate
+    # functions by moving and grouping the modes on which the gate is applied
+    # to the front indices, since the other modes can then simply be ignored
     if pure:
         t1 = modes[0]
         t2 = modes[1]

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -351,7 +351,8 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
         modes (list[int]): the list of modes to which the operator is applied on
         n (int): The total number of modes
         trunc (int): The Hilbert space truncation/cutoff
-        gate (str): the gate which should be called (BSgate, S2gate)
+        gate (str): The gate that is being applied. This argument determines the selection rules that
+            are used. Options are ``"BSgate"`` and ``"S2gate"``.
 
     Returns:
         ndarray: State where the two-mode operation has been applied

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -355,7 +355,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
             are used. Options are ``"BSgate"`` and ``"S2gate"``.
 
     Returns:
-        ndarray: State where the two-mode operation has been applied
+        array[complex]: state after application of the two-mode operation
     """
     if pure:
         t1 = modes[0]

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -253,7 +253,8 @@ def apply_gate_BLAS(mat, state, pure, modes, n, trunc):
         ret = np.zeros([trunc for i in range(n)], dtype=def_type)
         for i in product(*([range(trunc) for j in range(n - size)])):
             if diag:
-                ret[i] = np.multiply(matview.diagonal(), view[i].ravel()).reshape(stshape)
+                mat_diag = matview.diagonal()
+                ret[i] = np.multiply(mat_diag, view[i].ravel()).reshape(stshape)
             else:
                 ret[i] = np.dot(matview, view[i].ravel()).reshape(stshape)
 
@@ -281,7 +282,7 @@ def apply_gate_BLAS(mat, state, pure, modes, n, trunc):
     ret = np.zeros([trunc for i in range(n*2)], dtype=def_type)
     for i in product(*([range(trunc) for j in range((n - size)*2)])):
         if diag:
-            mat_diag = mat.diagonal().reshape(-1, 1)
+            mat_diag = matview.diagonal().reshape(-1, 1)
             ret[i] = np.multiply(mat_diag, np.multiply(view[i].reshape((dim, dim)), dagger(mat_diag))).reshape(stshape + stshape)
         else:
             ret[i] = np.dot(matview, np.dot(view[i].reshape((dim, dim)), dagger(matview))).reshape(stshape + stshape)

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -224,12 +224,6 @@ def apply_gate_BLAS(mat, state, pure, modes, n, trunc):
     if reshaping is efficient this should be faster.
     """
 
-    # checks if mat is diagonal
-    if mat.ndim == 2:
-        diag = np.all(mat == np.diag(np.diagonal(mat)))
-    else:
-        diag = False
-
     size = len(modes)
     dim = trunc**size
     stshape = [trunc for i in range(size)]
@@ -238,6 +232,9 @@ def apply_gate_BLAS(mat, state, pure, modes, n, trunc):
     # |m1><m1| |m2><m2| ... |mn><mn| -> |m1>|m2>...|mn><m1|<m2|...<mn|
     transpose_list = [2*i for i in range(size)] + [2*i + 1 for i in range(size)]
     matview = np.transpose(mat, transpose_list).reshape((dim, dim))
+
+    # checks if matview is diagonal and, if so, use faster contractions
+    diag = np.all(matview == np.diag(np.diagonal(matview)))
 
     if pure:
         if n == 1:

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -342,7 +342,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     """Applies a two-mode gate to a state.
 
     Applies the specified two-mode gate to the state using custom tensor contractions and
-    the numba compiler for faster application.
+    the Numba compiler for faster application.
 
     Args:
         mat (ndarray): The BS operator to be applied to the state

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -341,7 +341,7 @@ def apply_gate_einsum(mat, state, pure, modes, n, trunc):
 def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     """Applies a two-mode gate to a state.
 
-    Applies the two-mode gate to the state using custom tensor contractions and
+    Applies the specified two-mode gate to the state using custom tensor contractions and
     the numba compiler for faster application.
 
     Args:

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -339,7 +339,7 @@ def apply_gate_einsum(mat, state, pure, modes, n, trunc):
 
 
 def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
-    """Applies a two-mode gate to a state
+    """Applies a two-mode gate to a state.
 
     Applies the two-mode gate to the state using custom tensor contractions and
     the numba compiler for faster application.

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -346,7 +346,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
 
     Args:
         mat (array[complex]): The numeric operator to be applied to the state, of shape `[trunc]*(2*n)`
-        state (ndarray): The state that the BS is applied to
+        state (array[complex]): The state that the operator is applied to
         pure (bool): If the state is pure or mixed
         modes (list[int]): A list of modes to which the BS is applied
         n (int): The total number of modes

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -345,7 +345,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     the Numba compiler for faster application.
 
     Args:
-        mat (ndarray): The BS operator to be applied to the state
+        mat (array[complex]): The numeric operator to be applied to the state, of shape `[trunc]*(2*n)`
         state (ndarray): The state that the BS is applied to
         pure (bool): If the state is pure or mixed
         modes (list[int]): A list of modes to which the BS is applied

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -223,6 +223,7 @@ def apply_gate_BLAS(mat, state, pure, modes, n, trunc):
     einsum doesn't actually use BLAS but rather a c implementation. In theory
     if reshaping is efficient this should be faster.
     """
+    # pylint: disable=too-many-branches
 
     size = len(modes)
     dim = trunc**size

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -428,8 +428,9 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     return ret
 
 
+# ignored in covtest (doesn't work well with the jit decorator)
 @jit(nopython=True)
-def _apply_BS(mat, state, trunc):
+def _apply_BS(mat, state, trunc):  # pragma: no cover
     r"""Applies the BS gate to the first bra in state.
 
     The beamsplitter matrix elements :math:`B_{ij}^{kl}` satisfy the selection
@@ -458,8 +459,9 @@ def _apply_BS(mat, state, trunc):
     return ret
 
 
+# ignored in covtest (doesn't work well with the jit decorator)
 @jit(nopython=True)
-def _apply_S2(mat, state, trunc):
+def _apply_S2(mat, state, trunc):  # pragma: no cover
     r"""Applies the S2 gate to the first bra in state.
 
     The two-mode squeeze matrix elements :math:`T_{ij}^{kl}` satisfy the selection

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -420,7 +420,8 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
             state = _apply_S2(mat.conj(), state, trunc)
 
         else:
-            raise NotImplementedError
+            raise NotImplementedError("Currently, selection rules are only implemented for the BSgate "
+                                      "and the S2gate. The {} gate is not supported".format(gate))
 
         state = state.transpose(switch_list_2)
         ret = state.transpose(transpose_list)

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -347,7 +347,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
     Args:
         mat (array[complex]): The numeric operator to be applied to the state, of shape `[trunc]*(2*n)`
         state (array[complex]): The state that the operator is applied to
-        pure (bool): If the state is pure or mixed
+        pure (bool): whether the state is pure or mixed
         modes (list[int]): A list of modes to which the BS is applied
         n (int): The total number of modes
         trunc (int): The Hilbert space truncation/cutoff

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -389,7 +389,7 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
 
         # moves the modes on which the gate should be applied to the
         # front indices of the state, for mode 1 and 2 respectively
-        # e.g. from [i1, j1, i2, j2, i3, j3] --> [i2, j2, i3, j3, i1, j1] 
+        # e.g. from [i1, j1, i2, j2, i3, j3] --> [i2, j2, i3, j3, i1, j1]
         # if the gate is applied to modes 2 and 3
         switch_list_1 = np.arange(2 * n)
         switch_list_2 = np.arange(2 * n)

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -375,7 +375,8 @@ def apply_twomode_gate(mat, state, pure, modes, n, trunc, gate="BSgate"):
         elif gate == "S2gate":
             state = _apply_S2(mat, state, trunc)
         else:
-            raise NotImplementedError
+            raise NotImplementedError("Currently, selection rules are only implemented for the BSgate "
+                                      "and the S2gate. The {} gate is not supported".format(gate)")
 
         state = state.transpose(switch_list_2)
         ret = state.transpose(switch_list_1)

--- a/tests/backend/test_beamsplitter_operation.py
+++ b/tests/backend/test_beamsplitter_operation.py
@@ -165,7 +165,7 @@ class TestModeSubsets:
     def test_beamsplitter_on_mode_subset(
             self, setup_backend, mag_alpha, t, r_phi, cutoff, pure, tol
     ):
-        """Tests that apply the BS on different mode subsets."""
+        """Tests applying the beamsplitter on different mode subsets."""
 
         phase_alpha = np.pi / 5
         alpha = mag_alpha * np.exp(1j * phase_alpha)

--- a/tests/backend/test_twomode_squeezing_operation.py
+++ b/tests/backend/test_twomode_squeezing_operation.py
@@ -74,3 +74,28 @@ class TestTwomodeSqueezing:
                     tmsv2 = get_amplitude(k, r, p) * np.conj(get_amplitude(l, r, p))
 
                     assert np.allclose(state.data[t], tmsv2, atol=tol, rtol=0)
+
+
+    @pytest.mark.parametrize("r", MAG)
+    @pytest.mark.parametrize("p", PHASE)
+    def test_squeezing_on_mode_subset(self, setup_backend, r, p, cutoff, pure, tol):
+        r""" Test two-mode squeezing on vacuum-state for both pure states and
+        mixed states on different mode subsets with the amplitude given by
+	        :math:`\delta_{kl} \frac{e^{in\phi} \tanh^n{r}}{\cosh{r}}`
+        """
+        z = r * np.exp(1j * p)
+        n_modes = 4
+        for modes in it.combinations(range(n_modes), 2):
+            backend = setup_backend(n_modes)
+            backend.two_mode_squeeze(z, *modes)
+
+            state = backend.state()
+
+            state_data = state.reduced_dm(list(modes))
+
+            for k in it.product(range(cutoff), repeat=2):
+                for l in it.product(range(cutoff), repeat=2):
+                    t = (k[0], l[0], k[1], l[1])
+                    tmsv2 = get_amplitude(k, r, p) * np.conj(get_amplitude(l, r, p))
+
+                    assert np.allclose(state_data[t], tmsv2, atol=tol, rtol=0)

--- a/tests/backend/test_twomode_squeezing_operation.py
+++ b/tests/backend/test_twomode_squeezing_operation.py
@@ -26,6 +26,7 @@ import numpy as np
 
 PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 MAG = np.linspace(0.0, 0.2, 5, endpoint=False)
+MODES = list(it.combinations(range(4), 2))
 
 
 def get_amplitude(k, r, p):
@@ -78,24 +79,24 @@ class TestTwomodeSqueezing:
 
     @pytest.mark.parametrize("r", MAG)
     @pytest.mark.parametrize("p", PHASE)
-    def test_squeezing_on_mode_subset(self, setup_backend, r, p, cutoff, pure, tol):
+    @pytest.mark.parametrize("modes", MODES)
+    def test_squeezing_on_mode_subset(self, setup_backend, r, p, modes, cutoff, pure, tol):
         r""" Test two-mode squeezing on vacuum-state for both pure states and
         mixed states on different mode subsets with the amplitude given by
 	        :math:`\delta_{kl} \frac{e^{in\phi} \tanh^n{r}}{\cosh{r}}`
         """
         z = r * np.exp(1j * p)
-        n_modes = 4
-        for modes in it.combinations(range(n_modes), 2):
-            backend = setup_backend(n_modes)
-            backend.two_mode_squeeze(z, *modes)
 
-            state = backend.state()
+        backend = setup_backend(4)
+        backend.two_mode_squeeze(z, *modes)
 
-            state_data = state.reduced_dm(list(modes))
+        state = backend.state()
 
-            for k in it.product(range(cutoff), repeat=2):
-                for l in it.product(range(cutoff), repeat=2):
-                    t = (k[0], l[0], k[1], l[1])
-                    tmsv2 = get_amplitude(k, r, p) * np.conj(get_amplitude(l, r, p))
+        state_data = state.reduced_dm(list(modes))
 
-                    assert np.allclose(state_data[t], tmsv2, atol=tol, rtol=0)
+        for k in it.product(range(cutoff), repeat=2):
+            for l in it.product(range(cutoff), repeat=2):
+                t = (k[0], l[0], k[1], l[1])
+                tmsv2 = get_amplitude(k, r, p) * np.conj(get_amplitude(l, r, p))
+
+                assert np.allclose(state_data[t], tmsv2, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
The beamsplitter  and two-mode squeezing operation have special symmetries, namely SU(2) and SU(1,1). This implies that their matrix elements B_{nm}^{kl}, T_{ij}^{kl} satisfy the selection rules

![image](https://user-images.githubusercontent.com/991946/73875187-d5b94c00-4822-11ea-98a8-26fb47331197.png)

This implies that one can contract pure states (without loss of generality we assume only two modes) using one less loop as follows
![image](https://user-images.githubusercontent.com/991946/73875247-f681a180-4822-11ea-9bbf-8dec1819a546.png)
and 
![image](https://user-images.githubusercontent.com/991946/73875263-01d4cd00-4823-11ea-8de1-2effa308411e.png)
where c_{ij} is the tensor representing the two mode state and n is the cutoff in Fock space.
Similarly for a mixed state one should be able to do the update of the state using two less summations.

These observations should result in significant savings when acting beamsplitters and two-mode squeezing in the Fock backend.

**Description of the Change:**
Added a new apply_twomode_gate function to the fockbackend that can be used instead of apply_gate_BLAS for faster tensor contraction calculations for the beamsplitter gate and the two-mode squeeze gate. It is powered by the numba compiler making it much faster than before.

The beamsplitter and the two-mode squeeze functions in the circuit class now calls the apply_twomode_gate function in the fockbackend.

Add functionality to apply_gate_BLAS that checks if the operator is diagonal (fast) and, if so, performs faster applications of the gates.

**Note:** the new tests for the mode subsets (e.g. running the BSgate on modes [1, 3] in a 4-mode circuit) do not work with the tensorflow backend, which I believe is a problem with the tf-backend and not the tests. That's why the beamsplitter test is in a separate class although it would fit into the already existing TestFockRepresentation class.

**Benefits:**
Much faster calculations of the tensor contractions for the beamsplitter, the two-mode squeeze gate and all diagonal (single-mode and multimode) operations.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
closes #291 