### PR TITLE
Apps: Update subgraph functions to accept node weights

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,8 @@
   [#270](https://github.com/XanaduAI/strawberryfields/pull/270)
 
 * Adds support in the applications layer for node-weighted graphs. Users can sample from graphs
-  with node weights using the WAW encoding.
+  with node weights using the WAW encoding and input node weights into search algorithms in the
+  `subgraph` module.
   [295](https://github.com/XanaduAI/strawberryfields/pull/295)
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,7 @@
   with node weights using the WAW encoding and input node weights into search algorithms in the
   `subgraph` module.
   [295](https://github.com/XanaduAI/strawberryfields/pull/295)
+  [297](https://github.com/XanaduAI/strawberryfields/pull/297)
 
 ### Improvements
 * Added two-mode squeezed operation support as a primitive, rather than simply

--- a/strawberryfields/apps/clique.py
+++ b/strawberryfields/apps/clique.py
@@ -125,7 +125,7 @@ def search(
         graph (nx.Graph): the input graph
         iterations (int): number of steps in the algorithm
         node_select (str, list or array): method of selecting nodes during swap and growth. Can
-            be ``"uniform"`` (default), ``"degree"``, or a numpy array or list.
+            be ``"uniform"`` (default), ``"degree"``, or a NumPy array or list.
 
     Returns:
        list[int]: the largest clique found by the algorithm
@@ -177,7 +177,7 @@ def grow(
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
         node_select (str, list or array): method of selecting nodes from :math:`C_0` during
-            growth. Can be ``"uniform"`` (default), ``"degree"``, or a numpy array or list.
+            growth. Can be ``"uniform"`` (default), ``"degree"``, or a NumPy array or list.
 
     Returns:
         list[int]: a new clique subgraph of equal or larger size than the input
@@ -253,7 +253,7 @@ def swap(
         clique (list[int]): a subgraph specified by a list of nodes; the subgraph must be a clique
         graph (nx.Graph): the input graph
         node_select (str, list or array): method of selecting incoming nodes from :math:`C_1`
-            during swapping. Can be ``"uniform"`` (default), ``"degree"``, or a numpy array or list.
+            during swapping. Can be ``"uniform"`` (default), ``"degree"``, or a NumPy array or list.
 
     Returns:
         list[int]: a new clique subgraph of equal size as the input
@@ -323,7 +323,7 @@ def shrink(
         subgraph (list[int]): a subgraph specified by a list of nodes
         graph (nx.Graph): the input graph
         node_select (str, list or array): method of settling ties when more than one node of
-            equal degree can be removed. Can be ``"uniform"`` (default), or a numpy array or list.
+            equal degree can be removed. Can be ``"uniform"`` (default), or a NumPy array or list.
 
     Returns:
         list[int]: a clique of size smaller than or equal to the input subgraph

--- a/strawberryfields/apps/subgraph.py
+++ b/strawberryfields/apps/subgraph.py
@@ -103,7 +103,7 @@ def search(
         max_size (int): maximum size to search for dense subgraphs
         max_count (int): maximum number of densest subgraphs to keep track of for each size
         node_select (str, list or array): method of settling ties when more than one node of
-            equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
+            equal degree can be added/removed. Can be ``"uniform"`` (default), or a NumPy array or
             list containing node weights.
 
     Returns:
@@ -261,7 +261,7 @@ def resize(
         min_size (int): minimum size for subgraph to be resized to
         max_size (int): maximum size for subgraph to be resized to
         node_select (str, list or array): method of settling ties when more than one node of
-            equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
+            equal degree can be added/removed. Can be ``"uniform"`` (default), or a NumPy array or
             list containing node weights.
 
     Returns:
@@ -341,8 +341,8 @@ def _validate_inputs(
     This function checks:
         - if ``subgraph`` is a valid subgraph of ``graph``;
         - if ``min_size`` and ``max_size`` are sensible numbers;
-        - if ``node_select`` is either ``"uniform"`` or a numpy array or list;
-        - if, when ``node_select`` is a numpy array or list, that it is the correct size and that
+        - if ``node_select`` is either ``"uniform"`` or a NumPy array or list;
+        - if, when ``node_select`` is a NumPy array or list, that it is the correct size and that
           ``node_select`` is changed to ``"weight"``.
 
     This function returns the updated ``node_select`` and a dictionary mapping nodes to their
@@ -354,7 +354,7 @@ def _validate_inputs(
         min_size (int): minimum size for subgraph to be resized to
         max_size (int): maximum size for subgraph to be resized to
         node_select (str, list or array): method of settling ties when more than one node of
-            equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
+            equal degree can be added/removed. Can be ``"uniform"`` (default), or a NumPy array or
             list containing node weights.
 
     Returns:

--- a/strawberryfields/apps/subgraph.py
+++ b/strawberryfields/apps/subgraph.py
@@ -39,12 +39,13 @@ Subgraph resizing
 ^^^^^^^^^^^^^^^^^
 
 The key element of the :func:`search` algorithm is the resizing of each subgraph, allowing a
-range of subgraph sizes to be tracked. Resizing proceeds by greedily adding or removing nodes to
-a subgraph one-at-a-time. Node selection is carried out by picking the node with the greatest
-or least degree with respect to to the subgraph. This function returns a dictionary over the
-range of sizes specified, with each value being the corresponding resized subgraph.
+range of subgraph sizes to be tracked. Resizing proceeds in the :func:`resize` function by greedily
+adding or removing nodes to a subgraph one-at-a-time. Node selection is carried out by picking
+the node with the greatest or least degree with respect to the subgraph. This function returns a
+dictionary over the range of sizes specified, with each value being the corresponding resized
+subgraph.
 
-Whenever there are multiple candidate nodes with the same density, there must be a choice of
+Whenever there are multiple candidate nodes with the same degree, there must be a choice of
 which node to add or remove. The supported choices are:
 
 - Select among candidate nodes uniformly at random;
@@ -78,7 +79,8 @@ def search(
 
     - ``"uniform"`` (default): uniform randomly choose a node from the candidates;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
-      from the candidates with the lowest weight, settling ties by uniform random choice.
+      from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
+      settling ties by uniform random choice.
 
     **Example usage:**
 
@@ -238,7 +240,8 @@ def resize(
 
     - ``"uniform"`` (default): uniform randomly choose a node from the candidates;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
-      from the candidates with the lowest weight, settling ties by uniform random choice.
+      from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
+      settling ties by uniform random choice.
 
     **Example usage:**
 

--- a/strawberryfields/apps/subgraph.py
+++ b/strawberryfields/apps/subgraph.py
@@ -262,14 +262,19 @@ def resize(
             grow_nodes = grow_subgraph.nodes()
             complement_nodes = nodes - grow_nodes
 
-            degrees = [
-                (c, graph.subgraph(list(grow_nodes) + [c]).degree()[c]) for c in complement_nodes
-            ]
-            np.random.shuffle(degrees)
+            degrees = np.array(
+                [(c, graph.subgraph(list(grow_nodes) + [c]).degree()[c]) for c in complement_nodes]
+            )
+            degrees_max = np.argwhere(degrees[:, 1] == degrees[:, 1].max()).flatten()
 
-            to_add = max(degrees, key=lambda x: x[1])
-            grow_subgraph.add_node(to_add[0])
+            if node_select == "uniform":
+                to_add_index = np.random.choice(degrees_max)
+            elif node_select == "weight":
+                weights = np.array([w[degrees[n][0]] for n in degrees_max])
+                to_add_index = np.random.choice(np.where(weights == weights.max())[0])
 
+            to_add = degrees[to_add_index][0]
+            grow_subgraph.add_node(to_add)
             new_size = grow_subgraph.order()
 
             if min_size <= new_size <= max_size:

--- a/strawberryfields/apps/subgraph.py
+++ b/strawberryfields/apps/subgraph.py
@@ -77,7 +77,7 @@ def search(
     equal degree to add to or remove from the subgraph. The method of selecting the node is
     specified by the ``node_select`` argument, which can be either:
 
-    - ``"uniform"`` (default): uniform randomly choose a node from the candidates;
+    - ``"uniform"`` (default): choose a node from the candidates uniformly at random;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
       from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
       settling ties by uniform random choice.
@@ -238,7 +238,7 @@ def resize(
     add to or remove from the subgraph. The method of selecting the node is specified by the
     ``node_select`` argument, which can be either:
 
-    - ``"uniform"`` (default): uniform randomly choose a node from the candidates;
+    - ``"uniform"`` (default): choose a node from the candidates uniformly at random;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
       from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
       settling ties by uniform random choice.

--- a/strawberryfields/apps/subgraph.py
+++ b/strawberryfields/apps/subgraph.py
@@ -52,7 +52,7 @@ which node to add or remove. The supported choices are:
 - Select the candidate node with the greatest node weight, settling remaining ties uniformly at
   random.
 """
-from typing import Union
+from typing import Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -80,7 +80,7 @@ def search(
     - ``"uniform"`` (default): choose a node from the candidates uniformly at random;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
       from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
-      settling ties by uniform random choice.
+      settling remaining ties by uniform random choice.
 
     **Example usage:**
 
@@ -104,7 +104,7 @@ def search(
         max_count (int): maximum number of densest subgraphs to keep track of for each size
         node_select (str, list or array): method of settling ties when more than one node of
             equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
-            list.
+            list containing node weights.
 
     Returns:
         dict[int, list[tuple[float, list[int]]]]: a dictionary of different sizes, each containing a
@@ -241,7 +241,7 @@ def resize(
     - ``"uniform"`` (default): choose a node from the candidates uniformly at random;
     - A list or array: specifying the node weights of the graph, resulting in choosing the node
       from the candidates with the highest weight (when growing) and lowest weight (when shrinking),
-      settling ties by uniform random choice.
+      settling remaining ties by uniform random choice.
 
     **Example usage:**
 
@@ -262,7 +262,7 @@ def resize(
         max_size (int): maximum size for subgraph to be resized to
         node_select (str, list or array): method of settling ties when more than one node of
             equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
-            list.
+            list containing node weights.
 
     Returns:
         dict[int, list[int]]: a dictionary of different sizes with corresponding subgraph
@@ -335,8 +335,31 @@ def _validate_inputs(
     min_size: int,
     max_size: int,
     node_select: Union[str, np.ndarray, list] = "uniform",
-):
-    """Input validation for the ``resize`` function."""
+) -> Tuple:
+    """Validates input for the ``resize`` function.
+
+    This function checks:
+        - if ``subgraph`` is a valid subgraph of ``graph``;
+        - if ``min_size`` and ``max_size`` are sensible numbers;
+        - if ``node_select`` is either ``"uniform"`` or a numpy array or list;
+        - if, when ``node_select`` is a numpy array or list, that it is the correct size and that
+          ``node_select`` is changed to ``"weight"``.
+
+    This function returns the updated ``node_select`` and a dictionary mapping nodes to their
+    corresponding weights (weights default to unity if not specified).
+
+    Args:
+        subgraph (list[int]): a subgraph specified by a list of nodes
+        graph (nx.Graph): the input graph
+        min_size (int): minimum size for subgraph to be resized to
+        max_size (int): maximum size for subgraph to be resized to
+        node_select (str, list or array): method of settling ties when more than one node of
+            equal degree can be added/removed. Can be ``"uniform"`` (default), or a numpy array or
+            list containing node weights.
+
+    Returns:
+        tuple[str, dict]: the updated ``node_select`` and a dictionary of node weights
+    """
     if not subgraph.issubset(graph.nodes()):
         raise ValueError("Input is not a valid subgraph")
     if min_size < 1:

--- a/tests/apps/test_subgraph.py
+++ b/tests/apps/test_subgraph.py
@@ -362,3 +362,22 @@ class TestResize:
                 resized_subgraph = resized[3]
                 removed_node = list(set(s) - set(resized_subgraph))[0]
                 assert removed_node == i
+
+    @pytest.mark.parametrize("dim", range(4, 10))
+    def test_correct_resize_weight(self, dim):
+        """Test if function correctly resizes on a fixed example where the ideal resizing is
+        known and node-weight based selection is used to settle ties. The example is a complete
+        graph with a starting subgraph of the first ``dim - 2`` nodes. The task is to resize to
+        one node smaller and larger. The nodes weights are monotonically increasing with node
+        label. In the shrink step, the 0 node should be removed. In the grow step, the ``dim -
+        1`` node should be added."""
+        g = nx.complete_graph(dim)
+        s = list(range(dim - 2))
+        min_size = dim - 3
+        max_size = dim - 1
+        w = list(range(dim))
+
+        ideal = {dim - 2: s, dim - 1: s + [dim - 1], dim - 3: list(range(1, dim - 2))}
+        resized = subgraph.resize(s, g, min_size, max_size, node_select=w)
+
+        assert ideal == resized

--- a/tests/apps/test_subgraph.py
+++ b/tests/apps/test_subgraph.py
@@ -29,13 +29,14 @@ pytestmark = pytest.mark.apps
 
 p_planted = data.Planted()
 g_planted = nx.Graph(p_planted.adj)
+planted_weights = list(range(p_planted.modes))
 
 
 @pytest.fixture()
-def process_planted(min_size, max_size, max_count, n_samples):
+def process_planted(min_size, max_size, max_count, n_samples, node_select):
     """Fixture for loading samples from the Planted dataset"""
     samples = p_planted[:n_samples]
-    d = subgraph.search(samples, g_planted, min_size, max_size, max_count)
+    d = subgraph.search(samples, g_planted, min_size, max_size, max_count, node_select)
     return d
 
 
@@ -43,6 +44,7 @@ def process_planted(min_size, max_size, max_count, n_samples):
 @pytest.mark.parametrize("max_size", [6, 7])
 @pytest.mark.parametrize("max_count", [2, 4])
 @pytest.mark.parametrize("n_samples", [200])
+@pytest.mark.parametrize("node_select", ["uniform", planted_weights])
 @pytest.mark.usefixtures("process_planted")
 class TestSearch:
     """Tests for the function ``subgraph.search``"""

--- a/tests/apps/test_subgraph.py
+++ b/tests/apps/test_subgraph.py
@@ -250,32 +250,51 @@ class TestUpdateSubgraphsList:
         assert l == self.l
 
 
-class TestResize:
-    """Tests for the function ``subgraph.resize``"""
+class TestValidate:
+    """Tests for the function ``subgraph._validate_inputs``"""
 
     def test_input_not_subgraph(self):
         """Test if function raises a ``ValueError`` when input is not a subgraph"""
         dim = 5
         with pytest.raises(ValueError, match="Input is not a valid subgraph"):
-            subgraph.resize([dim + 1], nx.complete_graph(dim), 2, 3)
+            subgraph._validate_inputs({dim + 1}, nx.complete_graph(dim), 2, 3)
 
     def test_invalid_min_size(self):
         """Test if function raises a ``ValueError`` when an invalid min_size is requested"""
         dim = 5
         with pytest.raises(ValueError, match="min_size must be at least 1"):
-            subgraph.resize([0, 1], nx.complete_graph(dim), 0, 3)
+            subgraph._validate_inputs({0, 1}, nx.complete_graph(dim), 0, 3)
 
     def test_invalid_max_size(self):
         """Test if function raises a ``ValueError`` when an invalid max_size is requested"""
         dim = 5
         with pytest.raises(ValueError, match="max_size must be less than number of nodes in graph"):
-            subgraph.resize([0, 1], nx.complete_graph(dim), 2, dim)
+            subgraph._validate_inputs({0, 1}, nx.complete_graph(dim), 2, dim)
 
     def test_invalid_max_vs_min(self):
         """Test if function raises a ``ValueError`` when max_size is less than min_size"""
         dim = 5
         with pytest.raises(ValueError, match="max_size must not be less than min_size"):
-            subgraph.resize([0, 1], nx.complete_graph(dim), 4, 3)
+            subgraph._validate_inputs({0, 1}, nx.complete_graph(dim), 4, 3)
+
+    def test_bad_weights(self):
+        """Test if function raises a ``ValueError`` when a vector of node weights input to
+        ``node_select`` is not of the same dimension as the input graph."""
+        dim = 5
+        w = [1] * (dim - 1)
+        with pytest.raises(ValueError, match="Number of node weights must match number of nodes"):
+            subgraph._validate_inputs({0, 1}, nx.complete_graph(dim), 2, 3, node_select=w)
+
+    def test_bad_node_select(self):
+        """Tests if function raises a ``ValueError`` when input an invalid ``node_select``
+        argument"""
+        dim = 5
+        with pytest.raises(ValueError, match="Node selection method not recognized"):
+            subgraph._validate_inputs({0, 1}, nx.complete_graph(dim), 2, 3, node_select="")
+
+
+class TestResize:
+    """Tests for the function ``subgraph.resize``"""
 
     @pytest.mark.parametrize("dim", [7, 8])
     @pytest.mark.parametrize(

--- a/tests/apps/test_subgraph.py
+++ b/tests/apps/test_subgraph.py
@@ -298,6 +298,12 @@ class TestValidate:
 class TestResize:
     """Tests for the function ``subgraph.resize``"""
 
+    def choice(self, x, element):
+        """For patching numpy random choice to return a fixed element."""
+        if isinstance(x, int):
+            return element
+        return x[element]
+
     @pytest.mark.parametrize("dim", [7, 8])
     @pytest.mark.parametrize(
         "min_size,max_size",
@@ -351,13 +357,8 @@ class TestResize:
         g = nx.complete_graph(dim)
         s = [0, 1, 2, 3]
 
-        def choice(x, element):
-            if isinstance(x, int):
-                return element
-            return x[element]
-
         for i in range(4):
-            choice_i = functools.partial(choice, element=i)
+            choice_i = functools.partial(self.choice, element=i)
             with monkeypatch.context() as m:
                 m.setattr(np.random, "choice", choice_i)
                 resized = subgraph.resize(s, g, min_size=3, max_size=3)
@@ -401,12 +402,7 @@ class TestResize:
         max_size = dim - 1
         w = [1] * dim
 
-        def choice(x, element):
-            if isinstance(x, int):
-                return element
-            return x[element]
-
-        choice_elem = functools.partial(choice, element=elem)
+        choice_elem = functools.partial(self.choice, element=elem)
 
         ideal = {dim - 2: s, dim - 1: s + [dim - 2 + elem], dim - 3: list(set(s) - {elem})}
         with monkeypatch.context() as m:

--- a/tests/apps/test_subgraph.py
+++ b/tests/apps/test_subgraph.py
@@ -323,24 +323,22 @@ class TestResize:
         the problem of a 6-dimensional complete graph and a 4-node subgraph, with the objective
         of shrinking down to 3 nodes. In this case, any of the 4 nodes in the subgraph is an
         equally good candidate for removal since all nodes have the same degree. The test
-        monkeypatches the ``np.random.shuffle`` function to simply permute the list according to
-        an offset, e.g. for an offset of 2 the list [0, 1, 2, 3] gets permuted to [2, 3, 0,
-        1]. Using this we expect the node to be removed by ``resize`` in this case to have label
-        equal to the offset."""
+        monkeypatches the ``np.random.choice`` function to simply choose a fixed element,
+        e.g. the element 2 of the list [0, 1, 2, 3] will be 2. Using this we expect the node to
+        be removed by ``resize`` in this case to have label equal to the element."""
         dim = 6
         g = nx.complete_graph(dim)
         s = [0, 1, 2, 3]
 
-        def permute(l, offset):
-            d = len(l)
-            ll = l.copy()
-            for _i in range(d):
-                l[_i] = ll[(_i + offset) % d]
+        def choice(x, element):
+            if isinstance(x, int):
+                return element
+            return x[element]
 
         for i in range(4):
-            permute_i = functools.partial(permute, offset=i)
+            choice_i = functools.partial(choice, element=i)
             with monkeypatch.context() as m:
-                m.setattr(np.random, "shuffle", permute_i)
+                m.setattr(np.random, "choice", choice_i)
                 resized = subgraph.resize(s, g, min_size=3, max_size=3)
                 resized_subgraph = resized[3]
                 removed_node = list(set(s) - set(resized_subgraph))[0]


### PR DESCRIPTION
This PR adds support for node-weights in the search algorithms of the `subgraph` module.