### PR TITLE
Docs S2gate consistent with backends

### DIFF
--- a/doc/introduction/intro_photonics/conventions/gates.rst
+++ b/doc/introduction/intro_photonics/conventions/gates.rst
@@ -290,7 +290,7 @@ Two-mode squeezing
    :class: defn
 
    .. math::
-      S_2(z) = \exp\left(z^* \a_1\a_2 -z \ad_1 \ad_2 \right) = \exp\left(r (e^{-i\phi} \a_1\a_2 -e^{i\phi} \ad_1 \ad_2 \right)
+      S_2(z) = \exp\left(z \ad_1 \ad_2 - z^* \a_1\a_2 \right) = \exp\left(r (e^{-i\phi} \ad_1\ad_2 -e^{i\phi} \a_1 \a_2 \right)
 
    where :math:`z=r e^{i \phi}` with :math:`r \geq 0` and :math:`\phi \in [0,2 \pi)`.
 


### PR DESCRIPTION
The description of the S2gate given in the docs is incosistent with the one in the backends.
This PR correct the docs so that they are consistent with the backends. I have checked the decomposition given in terms of BSgate and Sgates and it is correct.


The way to confirm that indeed we implement S2gate(r,phi) = \exp( r e^(i \phi) a^\dagger b^\dagger  - \hc) is to note that

S2gate(r,phi) |0,0> = |0,0> + r e^{i \phi} |1,1>  for  r<<1.

If instead one used what was written in the docs one would get  |0,0> - r e^{i \phi} |1,1>.