### PR TITLE
Adding numba to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sympy>=1.5
 networkx>=2.0
 quantum-blackbird>=0.2.0
 https://xanadu-wheels.s3.amazonaws.com/thewalrus-0.11.0.dev0%2B20200129152745-cp36-cp36m-manylinux1_x86_64.whl
+numba>=0.48.0
 toml
 appdirs
 tensorflow==1.3

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
     "networkx>=2.0",
     "quantum-blackbird>=0.2.0",
     "thewalrus>=0.10",
+    "numba",
     "toml",
     "appdirs",
 ]


### PR DESCRIPTION
**Context:**
This attempts to solve #304.

**Description of the Change:**
Adds the `numba` requirement as >=0.48.

**Benefits:**
SF can be imported.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#304 