### PR TITLE
Change default hostname

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -7,6 +7,6 @@
 # Fill in your authentication
 authentication_token = None # example token form: 071cdcce-9241-4965-93af-4a4dbc739135
 # Fill in the hostname of the Cloud API
-hostname = "localhost"
+hostname = "platform.xanadu.ai"
 # Whether Strawberry Fields should use SSL to connect to the API
 use_ssl = true

--- a/default_config.toml
+++ b/default_config.toml
@@ -7,6 +7,6 @@
 # Fill in your authentication
 authentication_token = None # example token form: 071cdcce-9241-4965-93af-4a4dbc739135
 # Fill in the hostname of the Cloud API
-hostname = "platform.xanadu.ai"
+hostname = "platform.strawberryfields.ai"
 # Whether Strawberry Fields should use SSL to connect to the API
 use_ssl = true

--- a/doc/introduction/configuration.rst
+++ b/doc/introduction/configuration.rst
@@ -31,7 +31,7 @@ and has the following format:
     [api]
     # Options for the Strawberry Fields cloud API
     authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
-    hostname = "localhost"
+    hostname = "platform.xanadu.ai"
     use_ssl = true
     port = 443
 
@@ -44,7 +44,7 @@ Configuration options
     environment variable: ``SF_API_AUTHENTICATION_TOKEN``
 
 **hostname (str)** (*optional*)
-    The hostname of the server to connect to. Defaults to ``localhost``. Must
+    The hostname of the server to connect to. Defaults to ``platform.xanadu.ai``. Must
     be one of the allowed hosts. Corresponding environment variable:
     ``SF_API_HOSTNAME``
 

--- a/doc/introduction/configuration.rst
+++ b/doc/introduction/configuration.rst
@@ -31,7 +31,7 @@ and has the following format:
     [api]
     # Options for the Strawberry Fields cloud API
     authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
-    hostname = "platform.xanadu.ai"
+    hostname = "platform.strawberryfields.ai"
     use_ssl = true
     port = 443
 
@@ -44,7 +44,7 @@ Configuration options
     environment variable: ``SF_API_AUTHENTICATION_TOKEN``
 
 **hostname (str)** (*optional*)
-    The hostname of the server to connect to. Defaults to ``platform.xanadu.ai``. Must
+    The hostname of the server to connect to. Defaults to ``platform.strawberryfields.ai``. Must
     be one of the allowed hosts. Corresponding environment variable:
     ``SF_API_HOSTNAME``
 

--- a/doc/introduction/starship.rst
+++ b/doc/introduction/starship.rst
@@ -18,7 +18,7 @@ working directory. A typical file looks like this:
 .. code-block:: toml
 
     [api]
-    hostname = "platform.strawberryfields.ai"
+    hostname = "platform.xanadu.ai"
     authentication_token = "ElUFm3O6m6q1DXPmpi5g4hWEhYHXFxBc"
 
 You can generate this file interactively by using the ``starship`` command as follows, answering the questions in the prompts.
@@ -26,7 +26,7 @@ You can generate this file interactively by using the ``starship`` command as fo
 .. code-block:: text
 
     $ starship --reconfigure
-    Please enter the hostname of the server to connect to: [localhost] platform.strawberryfields.ai
+    Please enter the hostname of the server to connect to: [localhost] platform.xanadu.ai
     Please enter the authentication token to use when connecting: [] ElUFm3O6m6q1DXPmpi5g4hWEhYHXFxBc
     Would you like to save these settings to a local cofiguration file in the current directory? [Y/n] y
     Writing configuration file to current working directory...

--- a/doc/introduction/starship.rst
+++ b/doc/introduction/starship.rst
@@ -18,7 +18,7 @@ working directory. A typical file looks like this:
 .. code-block:: toml
 
     [api]
-    hostname = "platform.xanadu.ai"
+    hostname = "platform.strawberryfields.ai"
     authentication_token = "ElUFm3O6m6q1DXPmpi5g4hWEhYHXFxBc"
 
 You can generate this file interactively by using the ``starship`` command as follows, answering the questions in the prompts.
@@ -26,7 +26,7 @@ You can generate this file interactively by using the ``starship`` command as fo
 .. code-block:: text
 
     $ starship --reconfigure
-    Please enter the hostname of the server to connect to: [localhost] platform.xanadu.ai
+    Please enter the hostname of the server to connect to: [localhost] platform.strawberryfields.ai
     Please enter the authentication token to use when connecting: [] ElUFm3O6m6q1DXPmpi5g4hWEhYHXFxBc
     Would you like to save these settings to a local cofiguration file in the current directory? [Y/n] y
     Writing configuration file to current working directory...

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -32,7 +32,7 @@ log.getLogger()
 DEFAULT_CONFIG_SPEC = {
     "api": {
         "authentication_token": (str, ""),
-        "hostname": (str, "localhost"),
+        "hostname": (str, "platform.xanadu.ai"),
         "use_ssl": (bool, True),
         "port": (int, 443),
     }
@@ -102,7 +102,7 @@ def create_config(authentication_token="", **kwargs):
         dict[str, dict[str, Union[str, bool, int]]]: the configuration
             object
     """
-    hostname = kwargs.get("hostname", "localhost")
+    hostname = kwargs.get("hostname", DEFAULT_CONFIG_SPEC["api"]["hostname"][1])
     use_ssl = kwargs.get("use_ssl", DEFAULT_CONFIG_SPEC["api"]["use_ssl"][1])
     port = kwargs.get("port", DEFAULT_CONFIG_SPEC["api"]["port"][1])
 
@@ -263,7 +263,7 @@ def store_account(authentication_token, filename="config.toml", location="user_c
 
         [api]
         authentication_token = "MyToken"
-        hostname = "localhost"
+        hostname = "platform.xanadu.ai"
         use_ssl = true
         port = 443
 

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -32,7 +32,7 @@ log.getLogger()
 DEFAULT_CONFIG_SPEC = {
     "api": {
         "authentication_token": (str, ""),
-        "hostname": (str, "platform.xanadu.ai"),
+        "hostname": (str, "platform.strawberryfields.ai"),
         "use_ssl": (bool, True),
         "port": (int, 443),
     }
@@ -263,7 +263,7 @@ def store_account(authentication_token, filename="config.toml", location="user_c
 
         [api]
         authentication_token = "MyToken"
-        hostname = "platform.xanadu.ai"
+        hostname = "platform.strawberryfields.ai"
         use_ssl = true
         port = 443
 

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -29,7 +29,7 @@ TEST_FILE = """\
 [api]
 # Options for the Strawberry Fields Cloud API
 authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
-hostname = "platform.xanadu.ai"
+hostname = "platform.strawberryfields.ai"
 use_ssl = true
 port = 443
 """
@@ -43,7 +43,7 @@ authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
 EXPECTED_CONFIG = {
     "api": {
         "authentication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
-        "hostname": "platform.xanadu.ai",
+        "hostname": "platform.strawberryfields.ai",
         "use_ssl": True,
         "port": 443,
     }
@@ -303,7 +303,7 @@ class TestKeepValidOptions:
     def test_only_valid_options(self):
         section_config_only_valid = {
             "authentication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
-            "hostname": "platform.xanadu.ai",
+            "hostname": "platform.strawberryfields.ai",
             "use_ssl": True,
             "port": 443,
         }
@@ -398,7 +398,7 @@ class TestUpdateFromEnvironmentalVariables:
         assert conf.parse_environment_variable("some_integer", "123") == 123
 
 
-DEFAULT_KWARGS = {"hostname": "platform.xanadu.ai", "use_ssl": True, "port": 443}
+DEFAULT_KWARGS = {"hostname": "platform.strawberryfields.ai", "use_ssl": True, "port": 443}
 
 
 class MockSaveConfigToFile:

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -29,7 +29,7 @@ TEST_FILE = """\
 [api]
 # Options for the Strawberry Fields Cloud API
 authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
-hostname = "localhost"
+hostname = "platform.xanadu.ai"
 use_ssl = true
 port = 443
 """
@@ -43,7 +43,7 @@ authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
 EXPECTED_CONFIG = {
     "api": {
         "authentication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
-        "hostname": "localhost",
+        "hostname": "platform.xanadu.ai",
         "use_ssl": True,
         "port": 443,
     }
@@ -303,7 +303,7 @@ class TestKeepValidOptions:
     def test_only_valid_options(self):
         section_config_only_valid = {
             "authentication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
-            "hostname": "localhost",
+            "hostname": "platform.xanadu.ai",
             "use_ssl": True,
             "port": 443,
         }
@@ -398,7 +398,7 @@ class TestUpdateFromEnvironmentalVariables:
         assert conf.parse_environment_variable("some_integer", "123") == 123
 
 
-DEFAULT_KWARGS = {"hostname": "localhost", "use_ssl": True, "port": 443}
+DEFAULT_KWARGS = {"hostname": "platform.xanadu.ai", "use_ssl": True, "port": 443}
 
 
 class MockSaveConfigToFile:


### PR DESCRIPTION
**Context:**
Currently `"localhost"` is set as a default hostname in Strawberry Fields. This requires the user to change it each time they want to connect to the Xanadu cloud platform.

**Description of the Change:**
Making `"platform.strawberryfields.ai"` as the default hostname, such that users can simply just run `sf.store_account(AUTH_TOKEN)` when connecting the Xanadu cloud platform.

**Benefits:**
Less configuration is needed.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A