### PR TITLE
Rectangular decomposition: Identity fix

### DIFF
--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -233,7 +233,10 @@ def nullTi(m, n, U):
     if nmax != mmax:
         raise ValueError("U must be a square matrix")
 
-    if U[m, n+1] == 0:
+    if (U[m, n+1] == 0 and U[m, n] == 0):
+        thetar = 0
+        phir = 0
+    elif U[m, n+1] == 0:
         thetar = np.pi/2
         phir = 0
     else:
@@ -251,7 +254,10 @@ def nullT(n, m, U):
     if nmax != mmax:
         raise ValueError("U must be a square matrix")
 
-    if U[n-1, m] == 0:
+    if (U[n-1, m] == 0 and U[n, m] == 0):
+        thetar = 0
+        phir = 0
+    elif U[n-1, m] == 0:
         thetar = np.pi/2
         phir = 0
     else:

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -254,7 +254,7 @@ def nullT(n, m, U):
     if nmax != mmax:
         raise ValueError("U must be a square matrix")
 
-    if (U[n-1, m] == 0 and U[n, m] == 0):
+    if U[n, m] == 0:
         thetar = 0
         phir = 0
     elif U[n-1, m] == 0:

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -233,7 +233,7 @@ def nullTi(m, n, U):
     if nmax != mmax:
         raise ValueError("U must be a square matrix")
 
-    if (U[m, n+1] == 0 and U[m, n] == 0):
+    if U[m, n] == 0:
         thetar = 0
         phir = 0
     elif U[m, n+1] == 0:


### PR DESCRIPTION
**Context:**
Currently, the rectangular decomposition is such that the identity matrix is implemented as a series of swaps. While this still gives the correct unitary, it is harder to implement on the hardware.

**Description of the Change:**
With this modification, the identity is decomposed such that there are no unnecessary swaps.

**Benefits:**
Easier to implement on hardware.

**Possible Drawbacks:**


**Related GitHub Issues:**
N/A