### PR TITLE
Remove accidental xfail commit from the demo branch

### DIFF
--- a/tests/frontend/test_circuitspecs_gaussianunitary.py
+++ b/tests/frontend/test_circuitspecs_gaussianunitary.py
@@ -117,7 +117,6 @@ def test_modes_subset(depth):
     assert indices == sorted(list(indices))
 
 
-@pytest.mark.xfail
 def test_non_primitive_gates():
     """Tests that the compiler is able to compile a number of non-primitive Gaussian gates"""
 


### PR DESCRIPTION
**Description of the Change:**

The test `tests/frontend/test_circuitspecs_gaussianunitary.py::test_non_primitive_gates` was accidentally marked `xfail` on a commit during the `demo` branch development. This PR reverts that change.

**Benefits:** additional test will run

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
