### PR TITLE
Make shots parameter optional for RemoteEngine and Connection

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -168,6 +168,10 @@
   decomposition.
   [(#301)](https://github.com/XanaduAI/strawberryfields/pull/301)
 
+* Updated the relevant methods in `RemoteEngine` and `Connection` to derive `shots`
+  from the Blackbird script or `Program` if not explicitly specified.
+  [(#327)](https://github.com/XanaduAI/strawberryfields/pull/327)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -139,7 +139,8 @@ class Connection:
         Args:
             target (str): the target device
             program (strawberryfields.Program): the quantum circuit
-            shots (int): the number of shots
+            shots (int): The number of shots for which to run the program. If provided,
+                overrides the value stored in the given ``program``.
 
         Returns:
             strawberryfields.api.Job: the created job

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -18,7 +18,7 @@ from datetime import datetime
 import io
 import json
 import logging
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import requests

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -30,6 +30,8 @@ from strawberryfields.program import Program
 from .job import Job, JobStatus
 from .result import Result
 
+# pylint: disable=bad-continuation,protected-access
+
 log = logging.getLogger(__name__)
 
 
@@ -78,7 +80,6 @@ class Connection:
         use_ssl (bool): whether to use SSL for the connection
     """
 
-    # pylint: disable=bad-continuation
     def __init__(
         self,
         token: str = configuration["api"]["authentication_token"],
@@ -132,7 +133,7 @@ class Connection:
         """
         return self._use_ssl
 
-    def create_job(self, target: str, program: Program, shots: int) -> Job:
+    def create_job(self, target: str, program: Program, shots: Optional[int] = None) -> Job:
         """Creates a job with the given circuit.
 
         Args:
@@ -145,10 +146,9 @@ class Connection:
         """
         # Serialize a blackbird circuit for network transmission
         bb = to_blackbird(program)
-        # pylint: disable=protected-access
         bb._target["name"] = target
-        # pylint: disable=protected-access
-        bb._target["options"] = {"shots": shots}
+        if shots is not None:
+            bb._target["options"] = {"shots": shots}
         circuit = bb.serialize()
 
         path = "/jobs"

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -532,7 +532,8 @@ class RemoteEngine:
 
         Args:
             program (strawberryfields.Program): the quantum circuit
-            shots (int): the number of shots for which to run the job
+            shots (Optional[int]): The number of shots for which to run the job. If this
+                argument is not provided, the shots are derived from the given ``program``.
 
         Returns:
             [strawberryfields.api.Result, None]: the job result if successful, and
@@ -563,7 +564,8 @@ class RemoteEngine:
 
         Args:
             program (strawberryfields.Program): the quantum circuit
-            shots (int): the number of shots for which to run the job
+            shots (Optional[int]): The number of shots for which to run the job. If this
+                argument is not provided, the shots are derived from the given ``program``.
 
         Returns:
             strawberryfields.api.Job: the created remote job

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -521,7 +521,7 @@ class RemoteEngine:
         """
         return self._connection
 
-    def run(self, program: Program, shots: int = 1) -> Optional[Result]:
+    def run(self, program: Program, shots: Optional[int] = None) -> Optional[Result]:
         """Runs a blocking job.
 
         In the blocking mode, the engine blocks until the job is completed, failed, or
@@ -555,7 +555,7 @@ class RemoteEngine:
             self._connection.cancel_job(job.id)
             return None
 
-    def run_async(self, program: Program, shots: int = 1) -> Job:
+    def run_async(self, program: Program, shots: Optional[int] = None) -> Job:
         """Runs a non-blocking remote job.
 
         In the non-blocking mode, a ``Job`` object is returned immediately, and the user can


### PR DESCRIPTION
**Context:**

The `run()` and `run_async()` methods on `RemoteEngine` accept an optional shots parameter which defaults to 1. This parameter always overrides the value specified in the Blackbird script or resulting `Program` object, but there should be a way to use the Blackbird/`Program` shots value if the overriding value is not explicitly specified. In particular, the `sf` CLI has no way of specifying the number of shots via its command-line arguments, so programs cannot be run with more than 1 shot.

**Description of the Change:**

The `RemoteEngine.run()`, `RemoteEngine.run_async()`, and `Connection.create_job()` interfaces are modified to make the `shots` parameter default to `None`. When the job is created, the shots value in the `Program` object will be overridden only if the `shots` argument is not `None`.

**Benefits:**

- The number of shots can be correctly derived from a Blackbird script or `Program` object without needing to explicitly pass `shots` to `RemoteEngine` or `Connection`.
- The `sf` CLI can execute remote jobs for more than 1 shot.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**

N/A