### PR TITLE
Fix a json-issue in the cancel_job method of sf.api.connection.Connection

### DIFF
--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -16,7 +16,6 @@ This module provides an interface to a remote program execution backend.
 """
 from datetime import datetime
 import io
-import json
 import logging
 from typing import List, Optional
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -154,7 +154,7 @@ class Connection:
 
         path = "/jobs"
         response = requests.post(
-            self._url(path), headers=self._headers, data=json.dumps({"circuit": circuit}),
+            self._url(path), headers=self._headers, json={"circuit": circuit},
         )
         if response.status_code == 201:
             if self._verbose:
@@ -244,7 +244,7 @@ class Connection:
         """
         path = "/jobs/{}".format(job_id)
         response = requests.patch(
-            self._url(path), headers=self._headers, data={"status": JobStatus.CANCELLED.value},
+            self._url(path), headers=self._headers, json={"status": JobStatus.CANCELLED.value},
         )
         if response.status_code == 204:
             if self._verbose:

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -189,7 +189,7 @@ class TestConnection:
         # A custom `mock_return` that checks for expected arguments
         def _mock_return(return_value):
             def function(*args, **kwargs):
-                assert kwargs.get("data") == {"status": "cancelled"}
+                assert kwargs.get("json") == {"status": "cancelled"}
                 return return_value
 
             return function


### PR DESCRIPTION
**Context:**
Remote engine job cancellation.

**Description of the Change:**
Fixed a bug that prevented jobs from being cancelled when cancelling a running job.

**Benefits:**
Jobs can be cancelled now.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.