### PR TITLE
Unify RemoteEngine.run() and LocalEngine.run() signatures, and allow for default chip specs for each device family.

### DIFF
--- a/doc/algorithms/gaussian_boson_sampling.rst
+++ b/doc/algorithms/gaussian_boson_sampling.rst
@@ -89,7 +89,7 @@ If we wish to simulate Fock measurements, we can additionally include
     MeasureFock() | q
 
 after the beamsplitter array. After constructing the circuit and running the engine, the values of the Fock state measurements will be available within the :attr:`samples` attribute of the :class:`~.Result` object returned by the engine.
-In order to sample from this distribution :math:`N` times, a :code:`shots` parameter can be included in :code:`run_options` during engine execution, i.e., :func:`eng.run(gbs, run_options={"shots": N})` (only supported for Gaussian backend).
+In order to sample from this distribution :math:`N` times, the keyword argument :code:`shots` can be included during engine execution, i.e., :func:`eng.run(gbs, shots=N)` (only supported for Gaussian backend).
 
 Alternatively, you may omit the measurements, and extract the resulting Fock state probabilities directly via the state methods :meth:`~.BaseFockState.all_fock_probs` (supported by Fock backends) or :meth:`~.BaseState.fock_prob` (supported by all backends).
 

--- a/doc/gallery/gate_synthesis/GateSynthesis.ipynb
+++ b/doc/gallery/gate_synthesis/GateSynthesis.ipynb
@@ -237,7 +237,7 @@
     "        layer(k, q[0])\n",
     "\n",
     "# Run engine\n",
-    "state = eng.run(prog, run_options={\"eval\": False}).state\n",
+    "state = eng.run(prog, eval=False}).state\n",
     "ket = state.ket()"
    ]
   },

--- a/doc/gallery/minimizing_correlations/minimizing_correlations.ipynb
+++ b/doc/gallery/minimizing_correlations/minimizing_correlations.ipynb
@@ -332,7 +332,7 @@
     "    Ket(in_state) | q\n",
     "    BSgate(np.pi/4, 0) | q\n",
     "    \n",
-    "result = eng.run(prog, run_options={\"eval\": False, \"modes\": [1]})\n",
+    "result = eng.run(prog, eval=False, modes=[1])\n",
     "state = result.state"
    ]
   },

--- a/doc/gallery/state_learner/StateLearning.ipynb
+++ b/doc/gallery/state_learner/StateLearning.ipynb
@@ -208,7 +208,7 @@
     "        layer(k, q[0])\n",
     "\n",
     "# Run engine\n",
-    "state = eng.run(prog, run_options={\"eval\": False}).state\n",
+    "state = eng.run(prog, eval=False).state\n",
     "ket = state.ket()"
    ]
   },

--- a/doc/tutorials/tutorial_machine_learning.rst
+++ b/doc/tutorials/tutorial_machine_learning.rst
@@ -70,7 +70,7 @@ To properly evaluate measurement results, we must therefore do a little more wor
     sess.run(tf.global_variables_initializer())
     feed_dict = {phi: 0.0}
 
-    results = eng.run(prog, run_options={"session": sess, "feed_dict": feed_dict})
+    results = eng.run(prog, **{"session": sess, "feed_dict": feed_dict})
 
 This code will execute without error, and both the output results and the register :code:`q` will contain numeric values based on the given value for the angle phi. We can select measurement results at other angles by supplying different values for :code:`phi` in :code:`feed_dict`.
 
@@ -81,7 +81,7 @@ Symbolic computation
 
 Supplying a :code:`Session` and :code:`feed_dict` to :code:`eng.run()` is okay for checking one or two numerical values.
 However, each call of :code:`eng.run()` will create additional redundant nodes in the underlying Tensorflow computational graph.
-A better method is to make the single call :code:`eng.run(prog, run_options={"eval": False})`. This will carry out the computation symbolically but not numerically.
+A better method is to make the single call :code:`eng.run(prog, eval=False)`. This will carry out the computation symbolically but not numerically.
 The results returned by the engine will instead contain *unevaluted Tensors*. These Tensors can be evaluated numerically by running the :code:`tf.Session` and supplying the desired values for any placeholders:
 
 .. code-block:: python
@@ -93,7 +93,7 @@ The results returned by the engine will instead contain *unevaluted Tensors*. Th
         MeasureHomodyne(phi) | q[0]
 
     eng = sf.Engine(backend="tf", backend_options={"cutoff_dim": 7})
-    results = eng.run(prog, run_options={"eval": False})
+    results = eng.run(prog, eval=False)
 
     state_density_matrix = results.state.dm()
     homodyne_meas = results.samples[0]
@@ -141,7 +141,7 @@ It is common in machine learning to process data in *batches*. Strawberry Fields
     with prog.context as q:
         Dgate(tf.Variable([0.1] * batch_size)) | q[0]
 
-    result = eng.run(prog, run_options={"eval": False})
+    result = eng.run(prog, eval=False)
 
 .. note:: The batch size should be static, i.e., not changing over the course of a computation.
 

--- a/doc/tutorials/tutorial_teleportation.rst
+++ b/doc/tutorials/tutorial_teleportation.rst
@@ -170,7 +170,7 @@ We can now execute our quantum program ``prog`` on the engine via the :func:`Eng
 
 .. code-block:: python3
 
-    result = eng.run(prog, run_options={"shots":1, "modes":None}, compile_options={})
+    result = eng.run(prog, shots=1, modes=None, compile_options={})
 
 The :meth:`eng.run <strawberryfields.LocalEngine.run>` method accepts the arguments:
 

--- a/examples/GaussianBosonSampling.ipynb
+++ b/examples/GaussianBosonSampling.ipynb
@@ -232,7 +232,7 @@
     "    Interferometer(U) | q\n",
     "    MeasureFock() | q\n",
     "    \n",
-    "results = eng.run(gbs, run_options={\"shots\":10})\n",
+    "results = eng.run(gbs, shots=10)\n",
     "state = results.state\n",
     "\n",
     "# Note: Running this cell will generate a warning. This is just the Gaussian backend of Strawberryfields telling us \n",

--- a/examples/gaussian_cloning.py
+++ b/examples/gaussian_cloning.py
@@ -31,7 +31,7 @@ with gaussian_cloning.context as q:
     # end circuit
 
 # run the engine
-results = eng.run(gaussian_cloning, run_options={"modes": [0, 3]})
+results = eng.run(gaussian_cloning, modes=[0, 3])
 
 # return the cloning fidelity
 fidelity = sqrt(results.state.fidelity_coherent([0.7+1.2j, 0.7+1.2j]))
@@ -45,7 +45,7 @@ a = np.empty([reps], dtype=np.complex128)
 
 for i in range(reps):
     eng.reset()
-    results = eng.run(gaussian_cloning, run_options={"modes": [0]})
+    results = eng.run(gaussian_cloning, modes=[0])
     f[i] = results.state.fidelity_coherent([0.7+1.2j])
     a[i] = results.state.displacement()
 

--- a/examples/optimization.py
+++ b/examples/optimization.py
@@ -16,7 +16,7 @@ tf_phi = tf.Variable(0.1)
 alpha, phi = circuit.params('alpha', 'phi')
 with circuit.context as q:
     Dgate(alpha, phi) | q[0]
-results = eng.run(circuit, args={'alpha': tf_alpha, 'phi': tf_phi}, run_options={"eval": False})
+results = eng.run(circuit, args={'alpha': tf_alpha, 'phi': tf_phi}, eval=False})
 
 # loss is probability for the coherent state |alpha=1>
 prob = results.state.fidelity_coherent([1.0])

--- a/examples/quantum_neural_network.py
+++ b/examples/quantum_neural_network.py
@@ -96,7 +96,7 @@ with qnn.context as q:
         layer(q)
 
 # starting the engine
-results = eng.run(qnn, run_options={"eval": False})
+results = eng.run(qnn, eval=False)
 ket = results.state.ket()
 
 # defining cost function

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -18,7 +18,7 @@ from datetime import datetime
 import io
 import json
 import logging
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import requests

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -133,14 +133,14 @@ class Connection:
         """
         return self._use_ssl
 
-    def create_job(self, target: str, program: Program, shots: Optional[int] = None) -> Job:
+    def create_job(self, target: str, program: Program, run_options: dict = None) -> Job:
         """Creates a job with the given circuit.
 
         Args:
             target (str): the target device
             program (strawberryfields.Program): the quantum circuit
-            shots (int): The number of shots for which to run the program. If provided,
-                overrides the value stored in the given ``program``.
+            run_options (Dict[str, Any]): Runtime arguments for the program execution.
+                If provided, overrides the value stored in the given ``program``.
 
         Returns:
             strawberryfields.api.Job: the created job
@@ -148,8 +148,13 @@ class Connection:
         # Serialize a blackbird circuit for network transmission
         bb = to_blackbird(program)
         bb._target["name"] = target
-        if shots is not None:
-            bb._target["options"] = {"shots": shots}
+
+        # update the run options if provided
+        final_run_options = {}
+        final_run_options.update(program.run_options)
+        final_run_options.update(run_options or {})
+        bb._target["options"] = final_run_options
+
         circuit = bb.serialize()
 
         path = "/jobs"

--- a/strawberryfields/apps/sample.py
+++ b/strawberryfields/apps/sample.py
@@ -167,8 +167,7 @@ def sample(
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning, message="Cannot simulate non-")
-        s = eng.run(p, run_options={"shots": n_samples}).samples
-
+        s = eng.run(p, shots=n_samples).samples
     return s.tolist()
 
 
@@ -365,7 +364,7 @@ def vibronic(
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning, message="Cannot simulate non-")
 
-        s = eng.run(gbs, run_options={"shots": n_samples}).samples
+        s = eng.run(gbs, shots=n_samples).samples
 
     s = np.array(s).tolist()  # convert all generated samples to list
 

--- a/strawberryfields/circuitspecs/X12.py
+++ b/strawberryfields/circuitspecs/X12.py
@@ -29,7 +29,7 @@ from .gbs import GBSSpecs
 
 # Supporting multiple string formatting, such that the target can be replaced
 # first followed by squeezing amplitude and phase values
-DEFAULT_CIRCUIT = textwrap.dedent(
+X12_CIRCUIT = textwrap.dedent(
     """\
     name template_6x2_X12
     version 1.0
@@ -113,7 +113,7 @@ class X12Specs(CircuitSpecs):
     remote = True
     local = True
     interactive = False
-    circuit = DEFAULT_CIRCUIT.format(target=short_name)
+    circuit = X12_CIRCUIT.format(target=short_name)
 
     sq_amplitude = 1.0
 
@@ -122,6 +122,8 @@ class X12Specs(CircuitSpecs):
         "Interferometer": {"mesh": "rectangular_symmetric", "drop_identity": False},
         "BipartiteGraphEmbed": {"mesh": "rectangular_symmetric", "drop_identity": False},
     }
+
+    circuit = X12_CIRCUIT.format(target=short_name)
 
     def compile(self, seq, registers):
         """Try to arrange a quantum circuit into a form suitable for X12.
@@ -275,11 +277,11 @@ class X12_01(X12Specs):
     """Circuit specifications for the first X12 chip."""
 
     short_name = "X12_01"
-    circuit = DEFAULT_CIRCUIT.format(target=short_name)
+    circuit = X12_CIRCUIT.format(target=short_name)
 
 
 class X12_02(X12Specs):
     """Circuit specifications for the second X12 chip."""
 
     short_name = "X12_02"
-    circuit = DEFAULT_CIRCUIT.format(target=short_name)
+    circuit = X12_CIRCUIT.format(target=short_name)

--- a/strawberryfields/circuitspecs/X12.py
+++ b/strawberryfields/circuitspecs/X12.py
@@ -123,8 +123,6 @@ class X12Specs(CircuitSpecs):
         "BipartiteGraphEmbed": {"mesh": "rectangular_symmetric", "drop_identity": False},
     }
 
-    circuit = X12_CIRCUIT.format(target=short_name)
-
     def compile(self, seq, registers):
         """Try to arrange a quantum circuit into a form suitable for X12.
 

--- a/strawberryfields/circuitspecs/X8.py
+++ b/strawberryfields/circuitspecs/X8.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Circuit class specification for the X8 class of circuits."""
-import abc
 import textwrap
 
 import numpy as np
@@ -28,8 +27,58 @@ from .circuit_specs import CircuitSpecs
 from .gbs import GBSSpecs
 
 
-class X8Specs(CircuitSpecs, abc.ABC):
+# Supporting multiple string formatting, such that the target can be replaced
+# first followed by squeezing amplitude and phase values
+X8_CIRCUIT = textwrap.dedent(
+    """\
+    name template_4x2_X8
+    version 1.0
+    target {target} (shots=1)
+
+    # for n spatial degrees, first n signal modes, then n idler modes, all phases zero
+    S2gate({{squeezing_amplitude_0}}, 0.0) | [0, 4]
+    S2gate({{squeezing_amplitude_1}}, 0.0) | [1, 5]
+    S2gate({{squeezing_amplitude_2}}, 0.0) | [2, 6]
+    S2gate({{squeezing_amplitude_3}}, 0.0) | [3, 7]
+
+    # standard 4x4 interferometer for the signal modes (the lower ones in frequency)
+    # even phase indices correspond to internal Mach-Zehnder interferometer phases
+    # odd phase indices correspond to external Mach-Zehnder interferometer phases
+    MZgate({{phase_0}}, {{phase_1}}) | [0, 1]
+    MZgate({{phase_2}}, {{phase_3}}) | [2, 3]
+    MZgate({{phase_4}}, {{phase_5}}) | [1, 2]
+    MZgate({{phase_6}}, {{phase_7}}) | [0, 1]
+    MZgate({{phase_8}}, {{phase_9}}) | [2, 3]
+    MZgate({{phase_10}}, {{phase_11}}) | [1, 2]
+
+    # duplicate the interferometer for the idler modes (the higher ones in frequency)
+    MZgate({{phase_0}}, {{phase_1}}) | [4, 5]
+    MZgate({{phase_2}}, {{phase_3}}) | [6, 7]
+    MZgate({{phase_4}}, {{phase_5}}) | [5, 6]
+    MZgate({{phase_6}}, {{phase_7}}) | [4, 5]
+    MZgate({{phase_8}}, {{phase_9}}) | [6, 7]
+    MZgate({{phase_10}}, {{phase_11}}) | [5, 6]
+
+    # add final dummy phases to allow mapping any unitary to this template (these do not
+    # affect the photon number measurement)
+    Rgate({{final_phase_0}}) | [0]
+    Rgate({{final_phase_1}}) | [1]
+    Rgate({{final_phase_2}}) | [2]
+    Rgate({{final_phase_3}}) | [3]
+    Rgate({{final_phase_4}}) | [4]
+    Rgate({{final_phase_5}}) | [5]
+    Rgate({{final_phase_6}}) | [6]
+    Rgate({{final_phase_7}}) | [7]
+
+    # measurement in Fock basis
+    MeasureFock() | [0, 1, 2, 3, 4, 5, 6, 7]
+    """
+)
+
+
+class X8Specs(CircuitSpecs):
     """Circuit specifications for the X8 class of circuits."""
+    short_name = "X8"
     modes = 8
     remote = True
     local = True
@@ -42,6 +91,8 @@ class X8Specs(CircuitSpecs, abc.ABC):
         "Interferometer": {"mesh": "rectangular_symmetric", "drop_identity": False},
         "BipartiteGraphEmbed": {"mesh": "rectangular_symmetric", "drop_identity": False}
     }
+
+    circuit = X8_CIRCUIT.format(target=short_name)
 
     def compile(self, seq, registers):
         """Try to arrange a quantum circuit into a form suitable for X8.
@@ -191,51 +242,5 @@ class X8Specs(CircuitSpecs, abc.ABC):
 
 class X8_01(X8Specs):
     """Circuit specifications for the X8_01 class of circuits."""
-
     short_name = "X8_01"
-
-    circuit = textwrap.dedent(
-        """\
-        name template_4x2_X8
-        version 1.0
-        target X8_01 (shots=1)
-
-        # for n spatial degrees, first n signal modes, then n idler modes, all phases zero
-        S2gate({squeezing_amplitude_0}, 0.0) | [0, 4]
-        S2gate({squeezing_amplitude_1}, 0.0) | [1, 5]
-        S2gate({squeezing_amplitude_2}, 0.0) | [2, 6]
-        S2gate({squeezing_amplitude_3}, 0.0) | [3, 7]
-
-        # standard 4x4 interferometer for the signal modes (the lower ones in frequency)
-        # even phase indices correspond to internal Mach-Zehnder interferometer phases
-        # odd phase indices correspond to external Mach-Zehnder interferometer phases
-        MZgate({phase_0}, {phase_1}) | [0, 1]
-        MZgate({phase_2}, {phase_3}) | [2, 3]
-        MZgate({phase_4}, {phase_5}) | [1, 2]
-        MZgate({phase_6}, {phase_7}) | [0, 1]
-        MZgate({phase_8}, {phase_9}) | [2, 3]
-        MZgate({phase_10}, {phase_11}) | [1, 2]
-
-        # duplicate the interferometer for the idler modes (the higher ones in frequency)
-        MZgate({phase_0}, {phase_1}) | [4, 5]
-        MZgate({phase_2}, {phase_3}) | [6, 7]
-        MZgate({phase_4}, {phase_5}) | [5, 6]
-        MZgate({phase_6}, {phase_7}) | [4, 5]
-        MZgate({phase_8}, {phase_9}) | [6, 7]
-        MZgate({phase_10}, {phase_11}) | [5, 6]
-
-        # add final dummy phases to allow mapping any unitary to this template (these do not
-        # affect the photon number measurement)
-        Rgate({final_phase_0}) | [0]
-        Rgate({final_phase_1}) | [1]
-        Rgate({final_phase_2}) | [2]
-        Rgate({final_phase_3}) | [3]
-        Rgate({final_phase_4}) | [4]
-        Rgate({final_phase_5}) | [5]
-        Rgate({final_phase_6}) | [6]
-        Rgate({final_phase_7}) | [7]
-
-        # measurement in Fock basis
-        MeasureFock() | [0, 1, 2, 3, 4, 5, 6, 7]
-        """
-    )
+    circuit = X8_CIRCUIT.format(target=short_name)

--- a/strawberryfields/circuitspecs/__init__.py
+++ b/strawberryfields/circuitspecs/__init__.py
@@ -48,6 +48,11 @@ from .gaussian_unitary import GaussianUnitary
 specs = (X8_01, X12_01, X12_02, FockSpecs, GaussianSpecs, GBSSpecs, TFSpecs, GaussianUnitary)
 
 circuit_db = {c.short_name: c for c in specs}
-"""dict[str, ~strawberryfields.circuitspecs.CircuitSpecs]: Map from circuit family short name to the corresponding class."""
+"""dict[str, ~strawberryfields.circuitspecs.CircuitSpecs]: Map from circuit
+family short name to the corresponding class."""
+
+# update the circuit database with default values for each chip series
+circuit_db["X8"] = X8_01
+circuit_db["X12"] = X12_01
 
 __all__ = ["circuit_db", "CircuitSpecs"] + [i.__name__ for i in specs]

--- a/strawberryfields/circuitspecs/__init__.py
+++ b/strawberryfields/circuitspecs/__init__.py
@@ -37,22 +37,18 @@ corresponding CircuitSpecs instance with the same short name, used to validate P
 executed on that backend.
 """
 from .circuit_specs import CircuitSpecs
-from .X8 import X8_01
-from .X12 import X12_01, X12_02
+from .X8 import X8Specs, X8_01
+from .X12 import X12Specs, X12_01, X12_02
 from .fock import FockSpecs
 from .gaussian import GaussianSpecs
 from .gbs import GBSSpecs
 from .tensorflow import TFSpecs
 from .gaussian_unitary import GaussianUnitary
 
-specs = (X8_01, X12_01, X12_02, FockSpecs, GaussianSpecs, GBSSpecs, TFSpecs, GaussianUnitary)
+specs = (X8Specs, X8_01, X12Specs, X12_01, X12_02, FockSpecs, GaussianSpecs, GBSSpecs, TFSpecs, GaussianUnitary)
 
 circuit_db = {c.short_name: c for c in specs}
 """dict[str, ~strawberryfields.circuitspecs.CircuitSpecs]: Map from circuit
 family short name to the corresponding class."""
-
-# update the circuit database with default values for each chip series
-circuit_db["X8"] = X8_01
-circuit_db["X12"] = X12_01
 
 __all__ = ["circuit_db", "CircuitSpecs"] + [i.__name__ for i in specs]

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -481,6 +481,7 @@ class RemoteEngine:
         target (str): the target device
         connection (strawberryfields.api.Connection): a connection to the remote job
             execution platform
+        backend_options (Dict[str, Any]): keyword arguments for the backend
     """
 
     POLLING_INTERVAL_SECONDS = 1

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -45,8 +45,6 @@ class BaseEngine(abc.ABC):
         backend_options (Dict[str, Any]): keyword arguments for the backend
     """
 
-    REMOTE = False
-
     def __init__(self, backend, backend_options=None):
         if backend_options is None:
             backend_options = {}
@@ -280,15 +278,12 @@ class BaseEngine(abc.ABC):
                 p = p.compile(target, **compile_options)
             p.lock()
 
-            if self.REMOTE:
-                self.samples = self._run_program(p, **kwargs)
-            else:
-                self._run_program(p, **kwargs)
-                shots = kwargs.get("shots", 1)
-                self.samples = [
-                    _broadcast_nones(p.reg_refs[k].val, shots) for k in sorted(p.reg_refs)
-                ]
-                self.run_progs.append(p)
+            self._run_program(p, **kwargs)
+            shots = kwargs.get("shots", 1)
+            self.samples = [
+                _broadcast_nones(p.reg_refs[k].val, shots) for k in sorted(p.reg_refs)
+            ]
+            self.run_progs.append(p)
 
             prev = p
 
@@ -369,20 +364,16 @@ class LocalEngine(BaseEngine):
                 ) from None
         return applied
 
-    def run(self, program, *, args=None, compile_options=None, run_options=None):
+    def run(self, program, *, args=None, compile_options=None, **run_options):
         """Execute quantum programs by sending them to the backend.
 
         Args:
             program (Program, Sequence[Program]): quantum programs to run
             args (dict[str, Any]): values for the free parameters in the program(s) (if any)
             compile_options (None, Dict[str, Any]): keyword arguments for :meth:`.Program.compile`
-            run_options (None, Dict[str, Any]): keyword arguments that are needed by the backend during execution
-                e.g., in :meth:`Operation.apply` or :meth:`.BaseBackend.state`
 
         Returns:
             Result: results of the computation
-
-        ``run_options`` can contain the following:
 
         Keyword Args:
             shots (int): number of times the program measurement evaluation is repeated
@@ -494,14 +485,16 @@ class RemoteEngine:
 
     POLLING_INTERVAL_SECONDS = 1
     VALID_TARGETS = ("X8_01", "X12_01", "X12_02")
+    DEFAULT_TARGETS = {"X8": "X8_01", "X12": "X12_01"}
 
-    def __init__(self, target: str, connection: Connection = Connection()):
+    def __init__(self, target: str, connection: Connection = Connection(), backend_options: dict = None):
         if target not in self.VALID_TARGETS:
             raise ValueError(
                 "Invalid engine target: {} (valid targets: {})".format(target, self.VALID_TARGETS)
             )
         self._target = target
         self._connection = connection
+        self._backend_options = backend_options or {}
 
     @property
     def target(self) -> str:
@@ -521,7 +514,7 @@ class RemoteEngine:
         """
         return self._connection
 
-    def run(self, program: Program, shots: Optional[int] = None) -> Optional[Result]:
+    def run(self, program: Program, *, compile_options=None, **run_options) -> Optional[Result]:
         """Runs a blocking job.
 
         In the blocking mode, the engine blocks until the job is completed, failed, or
@@ -532,6 +525,8 @@ class RemoteEngine:
 
         Args:
             program (strawberryfields.Program): the quantum circuit
+
+        Keyword Args:
             shots (Optional[int]): The number of shots for which to run the job. If this
                 argument is not provided, the shots are derived from the given ``program``.
 
@@ -539,7 +534,7 @@ class RemoteEngine:
             [strawberryfields.api.Result, None]: the job result if successful, and
                 ``None`` otherwise
         """
-        job = self.run_async(program, shots)
+        job = self.run_async(program, compile_options=compile_options, **run_options)
         try:
             while True:
                 job.refresh()
@@ -556,7 +551,7 @@ class RemoteEngine:
             self._connection.cancel_job(job.id)
             return None
 
-    def run_async(self, program: Program, shots: Optional[int] = None) -> Job:
+    def run_async(self, program: Program, *, compile_options=None, **run_options) -> Job:
         """Runs a non-blocking remote job.
 
         In the non-blocking mode, a ``Job`` object is returned immediately, and the user can
@@ -564,13 +559,32 @@ class RemoteEngine:
 
         Args:
             program (strawberryfields.Program): the quantum circuit
+            compile_options (None, Dict[str, Any]): keyword arguments for :meth:`.Program.compile`
+
+        Keyword Args:
             shots (Optional[int]): The number of shots for which to run the job. If this
                 argument is not provided, the shots are derived from the given ``program``.
 
         Returns:
             strawberryfields.api.Job: the created remote job
         """
-        return self._connection.create_job(self.target, program, shots)
+        # get the specific chip to submit the program to
+        # TODO: this should be provided by the chip API, rather
+        # than built-in to Strawberry Fields.
+        target = self.DEFAULT_TARGETS.get(self.target, self.target)
+        compile_options = compile_options or {}
+        run_options = run_options.update(self._backend_options)
+
+        if program.target is None or (program.target.split("_")[0] != target.split("_")[0]):
+            # Program is either:
+            #
+            # * uncompiled (program.target is None)
+            # * compiled to a different chip family to the engine target
+            #
+            # In both cases, recompile the program to match the intended target.
+            program = program.compile(target, **compile_options)
+
+        return self._connection.create_job(target, program, run_options)
 
     def __repr__(self):
         return "<{}: target={}, connection={}>".format(

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -49,7 +49,10 @@ def to_blackbird(prog, version="1.0"):
 
         # set the run options
         if prog.run_options:
-            bb._target["options"] = prog.run_options
+            bb._target["options"].update(prog.run_options)
+
+        if prog.backend_options:
+            bb._target["options"].update(prog.backend_options)
 
     # fill in the quantum circuit
     for cmd in prog.circuit:

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -500,7 +500,7 @@ class Program:
         # create the compiled Program
         compiled = self._linked_copy()
         compiled.circuit = seq
-        compiled._target = target
+        compiled._target = db.short_name
 
         # get run options of compiled program
         # for the moment, shots is the only supported run option.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,9 +25,11 @@ from strawberryfields.api import Connection
 @pytest.fixture
 def prog():
     """Program fixture."""
-    program = Program(2)
+    program = Program(8)
     with program.context as q:
-        ops.Dgate(0.5) | q[0]
+        ops.Rgate(0.5) | q[0]
+        ops.Rgate(0.5) | q[4]
+        ops.MeasureFock() | q
     return program
 
 

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -71,7 +71,7 @@ class TestConnection:
             requests, "post", mock_return(MockResponse(201, {"id": id_, "status": status})),
         )
 
-        job = connection.create_job("X8_01", prog, 1)
+        job = connection.create_job("X8_01", prog, {"shots": 1})
 
         assert job.id == id_
         assert job.status == status.value
@@ -81,7 +81,7 @@ class TestConnection:
         monkeypatch.setattr(requests, "post", mock_return(MockResponse(400, {})))
 
         with pytest.raises(RequestFailedError, match="Failed to create job"):
-            connection.create_job("X8_01", prog, 1)
+            connection.create_job("X8_01", prog, {"shots": 1})
 
     @pytest.mark.xfail(reason="method not yet implemented")
     def test_get_all_jobs(self, connection, monkeypatch):

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -95,3 +95,10 @@ class TestRemoteEngine:
             AttributeError, match="The state is undefined for a stateless computation."
         ):
             job.result.state
+
+    def test_device_class_target(self):
+        """Test that the remote engine correctly instantiates itself
+        when provided with a non-specific target"""
+        target = "X8"
+        engine = RemoteEngine(target)
+        assert engine.target == engine.DEFAULT_TARGETS[target]

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -180,7 +180,7 @@ class TestMultipleShotsErrors:
         with pytest.raises(
             NotImplementedError, match="Batching cannot be used together with multiple shots."
         ):
-            meng.run(prog, run_options={"shots": 2})
+            meng.run(prog, **{"shots": 2})
 
     @pytest.mark.parametrize("meng", engines)
     def test_postselection_error(self, meng):
@@ -192,7 +192,7 @@ class TestMultipleShotsErrors:
         with pytest.raises(
             NotImplementedError, match="Post-selection cannot be used together with multiple shots."
         ):
-            meng.run(prog, run_options={"shots": 2})
+            meng.run(prog, **{"shots": 2})
 
     @pytest.mark.parametrize("meng", engines)
     def test_feedforward_error(self, meng):
@@ -206,4 +206,4 @@ class TestMultipleShotsErrors:
             NotImplementedError,
             match="Feed-forwarding of measurements cannot be used together with multiple shots.",
         ):
-            meng.run(prog, run_options={"shots": 2})
+            meng.run(prog, **{"shots": 2})

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -595,7 +595,7 @@ class TestEngineIntegration:
 
         with monkeypatch.context() as m:
             m.setattr("strawberryfields.engine.BaseEngine._run", dummy_run)
-            results = eng.run(prog, run_options={"shots": 1000})
+            results = eng.run(prog, shots=1000)
 
         assert results.run_options == {"shots": 1000}
 

--- a/tests/integration/test_algorithms.py
+++ b/tests/integration/test_algorithms.py
@@ -241,7 +241,7 @@ class TestGaussianCloning:
             Coherent(a) | q[0]
             self.gaussian_cloning_circuit(q)
 
-        state = eng.run(prog, run_options={'modes': [0, 3]}).state
+        state = eng.run(prog, **{'modes': [0, 3]}).state
         coh = np.array([state.is_coherent(i) for i in range(2)])
         disp = state.displacement()
 
@@ -264,7 +264,7 @@ class TestGaussianCloning:
         a_list = np.empty([shots], dtype=np.complex128)
 
         for i in range(shots):
-            state = eng.run(prog, run_options={'modes': [0]}).state
+            state = eng.run(prog, **{'modes': [0]}).state
             eng.reset()
             f_list[i] = state.fidelity_coherent([0.7 + 1.2j])
             a_list[i] = state.displacement()

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -103,7 +103,7 @@ class TestProperExecution:
     def test_no_return_state(self, setup_eng):
         """Engine returns no state object when none is requested."""
         eng, prog = setup_eng(2)
-        res = eng.run(prog, run_options={"modes": []})
+        res = eng.run(prog, modes=[])
         assert res.state is None
 
     def test_return_state(self, setup_eng):
@@ -118,7 +118,7 @@ class TestProperExecution:
         with prog.context as q:
             ops.MeasureX | q[0]
 
-        res = eng.run(prog, run_options=None)
+        res = eng.run(prog)
         # one entry for each mode
         assert len(res.samples[0]) == 2
         # the same samples can also be found in the regrefs
@@ -289,7 +289,7 @@ class TestProperExecution:
         eng, p1 = setup_eng(3)
         with p1.context as q:
             ops.MeasureFock() | q
-        samples = eng.run(p1, run_options={"shots": shots}).samples.astype(int)
+        samples = eng.run(p1, shots=shots).samples.astype(int)
         assert samples.shape == (shots, 3)
         assert all(samples[:, 0] == expected)
         assert all(samples[:, 1] == expected)
@@ -299,7 +299,7 @@ class TestProperExecution:
         eng, p2 = setup_eng(3)
         with p2.context as q:
             ops.MeasureFock() | (q[0], q[2])
-        samples = eng.run(p2, run_options={"shots": shots}).samples
+        samples = eng.run(p2, shots=shots).samples
         assert samples.shape == (shots, 3)
         assert all(samples[:, 0].astype(int) == expected)
         assert all(s is None for s in samples[:, 1])
@@ -309,7 +309,7 @@ class TestProperExecution:
         eng, p3 = setup_eng(3)
         with p3.context as q:
             ops.MeasureFock() | q[0]
-        samples = eng.run(p3, run_options={"shots": shots}).samples
+        samples = eng.run(p3, shots=shots).samples
         assert samples.shape == (shots, 3)
         assert all(samples[:, 0].astype(int) == expected)
         assert all(s is None for s in samples[:, 1])
@@ -328,4 +328,4 @@ class TestProperExecution:
         with pytest.raises(NotImplementedError,
                             match=r"""(Measure|MeasureFock) has not been implemented in {} """
                             """for the arguments {{'shots': {}}}""".format(backend_name, shots)):
-            eng.run(p1, run_options={"shots": shots}).samples
+            eng.run(p1, shots=shots).samples

--- a/tests/integration/test_measurement_integration.py
+++ b/tests/integration/test_measurement_integration.py
@@ -142,6 +142,6 @@ class TestPostselection:
             ops.Coherent(alpha) | q[0]
             ops.MeasureFock() | q[0]
         state = eng.run(prog).state
-        samples = np.array(eng.run(prog, run_options={"shots": shots})).flatten()
+        samples = np.array(eng.run(prog, shots=shots)).flatten()
 
         assert not np.all(samples == np.zeros_like(samples, dtype=int))

--- a/tests/integration/test_ops_integration.py
+++ b/tests/integration/test_ops_integration.py
@@ -221,7 +221,7 @@ class TestKetDensityMatrixIntegration:
         ket0 = ket0 / np.linalg.norm(ket0)
         with prog.context as q:
             ops.Ket(ket0) | q[0]
-        state = eng.run(prog, run_options={'modes': [0]}).state
+        state = eng.run(prog, **{'modes': [0]}).state
         assert np.allclose(state.dm(), np.outer(ket0, ket0.conj()), atol=tol, rtol=0)
 
         eng.reset()
@@ -230,7 +230,7 @@ class TestKetDensityMatrixIntegration:
         state1 = BaseFockState(ket0, 1, True, cutoff)
         with prog.context as q:
             ops.Ket(state1) | q[0]
-        state2 = eng.run(prog, run_options={'modes': [0]}).state
+        state2 = eng.run(prog, **{'modes': [0]}).state
         assert np.allclose(state1.dm(), state2.dm(), atol=tol, rtol=0)
 
     def test_ket_two_mode(self, setup_eng, hbar, cutoff, tol):
@@ -279,7 +279,7 @@ class TestKetDensityMatrixIntegration:
         rho = np.outer(ket, ket.conj())
         with prog.context as q:
             ops.DensityMatrix(rho) | q[0]
-        state = eng.run(prog, run_options={'modes': [0]}).state
+        state = eng.run(prog, **{'modes': [0]}).state
         assert np.allclose(state.dm(), rho, atol=tol, rtol=0)
 
         eng.reset()
@@ -288,7 +288,7 @@ class TestKetDensityMatrixIntegration:
         state1 = BaseFockState(rho, 1, False, cutoff)
         with prog.context as q:
             ops.DensityMatrix(state1) | q[0]
-        state2 = eng.run(prog, run_options={'modes': [0]}).state
+        state2 = eng.run(prog, **{'modes': [0]}).state
         assert np.allclose(state1.dm(), state2.dm(), atol=tol, rtol=0)
 
     def test_dm_two_mode(self, setup_eng, hbar, cutoff, tol):

--- a/tests/integration/test_tf_symbolic.py
+++ b/tests/integration/test_tf_symbolic.py
@@ -73,7 +73,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         state_data = state.data
 
         assert isinstance(state_data, tf.Tensor)
@@ -87,7 +87,7 @@ class TestOneModeSymbolic:
             Dgate(0.5) | q
             MeasureX | q
 
-        eng.run(prog, run_options=evalf)
+        eng.run(prog, **evalf)
         val = q[0].val
         assert isinstance(val, tf.Tensor)
 
@@ -109,7 +109,7 @@ class TestOneModeSymbolic:
             Dgate(x, y) | q
 
         # use TF to evaluate symbolic parameter expressions
-        state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, run_options=tf_params).state
+        state = eng.run(prog, args={'a': tf_a, 'phi': tf_phi}, **tf_params).state
 
         if state.is_pure:
             k = state.ket()
@@ -137,7 +137,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         ket = state.ket()
         assert isinstance(ket, tf.Tensor)
 
@@ -180,7 +180,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         dm = state.dm()
         assert isinstance(dm, tf.Tensor)
 
@@ -222,7 +222,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         tr = state.trace()
         assert isinstance(tr, tf.Tensor)
 
@@ -261,7 +261,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         rho = state.reduced_dm([0])
         assert isinstance(rho, tf.Tensor)
 
@@ -297,7 +297,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         fidel_vac = state.fidelity_vacuum()
         assert isinstance(fidel_vac, tf.Tensor)
 
@@ -332,7 +332,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(0.5) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         is_vac = state.is_vacuum()
         assert isinstance(is_vac, tf.Tensor)
 
@@ -367,7 +367,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(ALPHA) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         fidel_coh = state.fidelity_coherent([ALPHA])
         assert isinstance(fidel_coh, tf.Tensor)
 
@@ -406,7 +406,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(ALPHA) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         fidel = state.fidelity(coherent_state(ALPHA, cutoff), 0)
         assert isinstance(fidel, tf.Tensor)
 
@@ -445,7 +445,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(ALPHA) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         e, v = state.quad_expectation(0, 0)
         assert isinstance(e, tf.Tensor)
         assert isinstance(v, tf.Tensor)
@@ -489,7 +489,7 @@ class TestOneModeSymbolic:
         with prog.context as q:
             Dgate(ALPHA) | q
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         nbar, var = state.mean_photon(0)
         assert isinstance(nbar, tf.Tensor)
         assert isinstance(var, tf.Tensor)
@@ -538,7 +538,7 @@ class TestTwoModeSymbolic:
             Dgate(ALPHA) | q[0]
             Dgate(-ALPHA) | q[1]
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         probs = state.all_fock_probs()
         assert isinstance(probs, tf.Tensor)
 
@@ -586,7 +586,7 @@ class TestTwoModeSymbolic:
             Dgate(ALPHA) | q[0]
             Dgate(-ALPHA) | q[1]
 
-        state = eng.run(prog, run_options=evalf).state
+        state = eng.run(prog, **evalf).state
         prob = state.fock_prob([cutoff // 2, cutoff // 2])
         assert isinstance(prob, tf.Tensor)
 


### PR DESCRIPTION
**Context:**

Currently in Strawberry Fields:

* The user must initialize an engine or a compile a program with a specific chip target, e.g., `X8_01`, `X12_01`, etc. However, there should be a way for the user to initialize an engine or compile a program for a chip _family_ (e.g., `eng.run("X8")`, `prog.compile("X8")`), with the Remote engine delegating the job to a specified default for each family.

* `LocalEngine.run()` and `RemoteEngine.run()` have inconsistent signatures:

  ```python3
  LocalEngine.run(self, program, *, args=None, compile_options=None, run_options=None)
  RemoteEngine.run(self, program: Program, shots: Optional[int] = None)
  ```

While these appear as two separate issues, they are quite interconnected. Since `eng.run()` internally calls the `prog.compile()` method, both engines must keep track and pass on any `run_options` that the user specifies so that they can be taken into account during compilation/execution.

**Description of the Change:**

* The base `X8Spec` and `X12Spec` specifications are now included in the Strawberry Fields circuit spec database, with short names `X8` and `X12` respectively. Programs that are compiled against these specs, e.g., `prog.compile("X8")` have `prog.target == "X8"`.

* The `RemoteEngine` can now be instantiated with targets `"X8"` and `"X12"`.

* The `RemoteEngine` has a class attribute
  ```python
  DEFAULT_TARGETS = {"X8": "X8_01", "X12": "X12_01"}
  ```
  which specifies the default chip to target for each device family. Hardcoding this is a temporary fix, and will be removed once the chip API is online.

* For now, since only chip family compilation is available (i.e., there is no chip specific compilation), compiling against either `"X8"` and `"X8_01"` makes no difference. Therefore, `eng=RemoteEngine("X8")` will only recompile a program if `program.target[:2] != "X8"`.

* Old references to `REMOTE` in the `BaseEngine` have been removed, since `RemoteEngine` no longer inherits from `BaseEngine`.

* `RemoteEngine.run()` and `LocalEngine.run()` signatures have both been standardized to the following:

  ```python
  run(run(self, program, *, args=None, compile_options=None, **run_options)
  ```

  This is a compromise that aims to balance a nicer, more consistent UI against internal behaviour. In particular:

  - The `run_options={}` dictionary argument from the LocalEngine has been changed to `**run_options`. This allows for the syntax `eng.run(prog, shots=100)`, which is cleaner and more intutive than `eng.run(prog, run_options={"shots": 100})`.

  - `compile_options={}` dictionary argument has been added to the RemoteEngine, as well as compilation (previously the remote engine was not validating/compiling programs).

* `RunEngine.__init__()` now takes a `backend_options={}` argument, allowing backend options to be set. This is not needed currently, but will be needed for remote simulators (e.g., passing cutoff dimension).

* The `Connection.create_job()` method has been updated to send _all_ run and backend options, rather than just `shots` (useful for future compatibility with remote simulators).

**Benefits:** see above.

**Possible Drawbacks:**

* Currently, compiling a program against `"X8"` and `"X8_01"` makes no difference. However, in the future, compiling against `"X8"` will compile to match the (static) family architecture, while `X8_01` will compile to match (dynamic) specific hardware constraints of chip 01 from the API service.

* Hardcoding of the default chip specs is temporary, and will be removed once a chip API is online.

**Related GitHub Issues:**

- Fixes #335 
- Will allow implementation of suggested changes from #334 
