### PR TITLE
Add more details to Connection error message

### DIFF
--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -157,9 +157,7 @@ class Connection:
         circuit = bb.serialize()
 
         path = "/jobs"
-        response = requests.post(
-            self._url(path), headers=self._headers, json={"circuit": circuit},
-        )
+        response = requests.post(self._url(path), headers=self._headers, json={"circuit": circuit},)
         if response.status_code == 201:
             if self._verbose:
                 log.info("The job was successfully submitted.")
@@ -274,8 +272,11 @@ class Connection:
     @staticmethod
     def _format_error_message(response: requests.Response) -> str:
         body = response.json()
-        return "{} ({}): {}".format(
-            body.get("status_code", ""), body.get("code", ""), body.get("detail", "")
+        return "{} ({}): {} ({})".format(
+            body.get("status_code", ""),
+            body.get("code", ""),
+            body.get("detail", ""),
+            body.get("meta", ""),
         )
 
     def __repr__(self):


### PR DESCRIPTION
**Context:**

The error message produced by an unsuccessful request made by the `Connection` class is somewhat opaque and lacks context for effectively diagnosing and/or debugging the problem.

**Description of the Change:**

Extends the error message produced by failed `Connection` API requests with the contents of the `meta` field (if present) in the error response body.

**Example:**

Before:

```
  File ".../strawberryfields/api/connection.py", line 170, in create_job
    "Failed to create job: {}".format(self._format_error_message(response))
strawberryfields.api.connection.RequestFailedError: Failed to create job:  (validation-error): The server cannot process the request because it is invalid. Please check the request parameters and try again.
```

After:

```
  File ".../strawberryfields/api/connection.py", line 170, in create_job
    "Failed to create job: {}".format(self._format_error_message(response))
strawberryfields.api.connection.RequestFailedError: Failed to create job:  (validation-error): The server cannot process the request because it is invalid. Please check the request parameters and try again. ({'circuit': ["The program must specify a 'shots' parameter."]})
```

**Benefits:**

Easier to diagnose and debug remote job execution failures.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**

N/A
