### PR TITLE
Import cli.ping in __init__.py

### DIFF
--- a/doc/introduction/photonic_hardware.rst
+++ b/doc/introduction/photonic_hardware.rst
@@ -55,7 +55,7 @@ Verifying your connection
 To verify that your account credentials correctly authenticate against the cloud
 platform, the :func:`~.ping` function can be used from within Python,
 
->>> sf.cli.ping()
+>>> sf.ping()
 You have successfully authenticated to the platform!
 
 or the ``ping`` flag can be used on the command line:

--- a/doc/tutorials/tutorial_X8.rst
+++ b/doc/tutorials/tutorial_X8.rst
@@ -50,7 +50,7 @@ on.
 To test that your account credentials correctly authenticate against the cloud platform,
 you can use the :func:`~.ping` command,
 
->>> sf.cli.ping()
+>>> sf.ping()
 You have successfully authenticated to the platform!
 
 .. note::

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -23,6 +23,7 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
 """
 from . import apps
 from ._version import __version__
+from .cli import ping
 from .configuration import store_account
 from .engine import Engine, LocalEngine, RemoteEngine
 from .io import load, save


### PR DESCRIPTION
**Context:**
The `cli` module contains a `ping` function to verify the connection to the Xanadu cloud platform. When used in a Python script (and as an option with the command-line interface), an `AttributeError` is raised.

**Description of the Change:**
Imports `cli.ping` in `__init__.py` and adjusts the examples to use `sf.ping()` for brevity.

**Benefits:**
The `ping` function can be used from within a Python script after importing `strawberryfields`:
```python
import strawberryfields as sf
sf.ping()
```

**Possible Drawbacks:**
Shortening the call to `sf.ping()` in the examples is less descriptive when compared to `sf.cli.ping()`.

**Related GitHub Issues:**
#338 