### PR TITLE
Fixing kwarg assignment bug in engine.py

### DIFF
--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -577,7 +577,7 @@ class RemoteEngine:
         # TODO: this should be provided by the chip API, rather
         # than built-in to Strawberry Fields.
         compile_options = compile_options or {}
-        kwargs = kwargs.update(self._backend_options)
+        kwargs.update(self._backend_options)
 
         if program.target is None or (program.target.split("_")[0] != self.target.split("_")[0]):
             # Program is either:


### PR DESCRIPTION
**Description of the Change:** In #337 the signature of the `RemoteEngine` was updated. In particular, it should accept a `shots` keyword argument. However, there was a bug where `kwargs` was updated, but then *reassigned* to the result of `kwargs.update` (which is `None`). This resulted in the shots not being added to the blackbird scripts which are sent for remote execution. Jobs were summarily rejected.

**Benefits:** This PR fixes the above bug

**Possible Drawbacks:** We need to add a test which would have detected this bug before merging.

**Related GitHub Issues:** PR #337
