### PR TITLE
Fix RemoteEngine.run_async kwargs bug, and add test

### DIFF
--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -147,12 +147,7 @@ class Connection:
         # Serialize a blackbird circuit for network transmission
         bb = to_blackbird(program)
         bb._target["name"] = target
-
-        # update the run options if provided
-        final_run_options = {}
-        final_run_options.update(program.run_options)
-        final_run_options.update(run_options or {})
-        bb._target["options"] = final_run_options
+        bb._target["options"] = run_options
 
         circuit = bb.serialize()
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -588,7 +588,15 @@ class RemoteEngine:
             # In both cases, recompile the program to match the intended target.
             program = program.compile(self.target, **compile_options)
 
-        return self._connection.create_job(self.target, program, kwargs)
+        # update the run options if provided
+        run_options = {}
+        run_options.update(program.run_options)
+        run_options.update(kwargs or {})
+
+        if "shots" not in run_options:
+            raise ValueError("Number of shots must be specified.")
+
+        return self._connection.create_job(self.target, program, run_options)
 
     def __repr__(self):
         return "<{}: target={}, connection={}>".format(

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -577,7 +577,7 @@ class RemoteEngine:
         # TODO: this should be provided by the chip API, rather
         # than built-in to Strawberry Fields.
         compile_options = compile_options or {}
-        kwargs = kwargs.update(self._backend_options)
+        kwargs.update(self._backend_options)
 
         if program.target is None or (program.target.split("_")[0] != self.target.split("_")[0]):
             # Program is either:

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -139,6 +139,10 @@ class TestRemoteEngine:
         with pytest.raises(ValueError, match="Number of shots must be specified"):
             engine.run_async(prog)
 
+
+class TestRemoteEngineIntegration:
+    """Integration tests for the remote engine"""
+
     def test_compilation(self, prog, monkeypatch):
         """Test that the remote engine correctly compiles a program
         for the intended backend"""

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -109,11 +109,11 @@ class TestRemoteEngine:
         for the intended backend"""
         monkeypatch.setattr(Connection, "create_job", lambda *args: args)
 
-        engine = RemoteEngine("X8")
+        engine = RemoteEngine("X8", backend_options={"cutoff_dim": 12})
         _, target, res_prog, run_options = engine.run_async(prog, shots=1234)
 
         assert target == RemoteEngine.DEFAULT_TARGETS["X8"]
-        assert run_options == {"shots": 1234}
+        assert run_options == {"shots": 1234, "cutoff_dim": 12}
 
         # check program is compiled to match the chip template
         expected = prog.compile("X8").circuit

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -109,11 +109,8 @@ class TestRemoteEngine:
         passes all backend and runtime options to the create_job
         method."""
         monkeypatch.setattr(Connection, "create_job", lambda *args: args)
-
         engine = RemoteEngine("X8", backend_options={"cutoff_dim": 12})
-        _, target, res_prog, run_options = engine.run_async(prog, shots=1234)
-
-        assert target == RemoteEngine.DEFAULT_TARGETS["X8"]
+        _, _, _, run_options = engine.run_async(prog, shots=1234)
         assert run_options == {"shots": 1234, "cutoff_dim": 12}
 
     def test_compilation(self, prog, monkeypatch):
@@ -122,7 +119,9 @@ class TestRemoteEngine:
         monkeypatch.setattr(Connection, "create_job", lambda *args: args)
 
         engine = RemoteEngine("X8")
-        _, target, res_prog, run_options = engine.run_async(prog)
+        _, target, res_prog, _ = engine.run_async(prog)
+
+        assert target == RemoteEngine.DEFAULT_TARGETS["X8"]
 
         # check program is compiled to match the chip template
         expected = prog.compile("X8").circuit

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -104,9 +104,10 @@ class TestRemoteEngine:
         engine = RemoteEngine(target)
         assert engine.target == engine.DEFAULT_TARGETS[target]
 
-    def test_compilation(self, prog, monkeypatch):
-        """Test that the remote engine correctly compiles a program
-        for the intended backend"""
+    def test_run_options(self, prog, monkeypatch):
+        """Test that the remote engine run_async method correctly
+        passes all backend and runtime options to the create_job
+        method."""
         monkeypatch.setattr(Connection, "create_job", lambda *args: args)
 
         engine = RemoteEngine("X8", backend_options={"cutoff_dim": 12})
@@ -114,6 +115,14 @@ class TestRemoteEngine:
 
         assert target == RemoteEngine.DEFAULT_TARGETS["X8"]
         assert run_options == {"shots": 1234, "cutoff_dim": 12}
+
+    def test_compilation(self, prog, monkeypatch):
+        """Test that the remote engine correctly compiles a program
+        for the intended backend"""
+        monkeypatch.setattr(Connection, "create_job", lambda *args: args)
+
+        engine = RemoteEngine("X8")
+        _, target, res_prog, run_options = engine.run_async(prog)
 
         # check program is compiled to match the chip template
         expected = prog.compile("X8").circuit

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -19,6 +19,7 @@ import pytest
 
 from strawberryfields.api import Connection, Job, JobStatus, Result
 from strawberryfields.engine import RemoteEngine
+
 from .conftest import mock_return
 
 # pylint: disable=bad-continuation,unused-argument,no-self-use,redefined-outer-name,pointless-statement
@@ -102,3 +103,28 @@ class TestRemoteEngine:
         target = "X8"
         engine = RemoteEngine(target)
         assert engine.target == engine.DEFAULT_TARGETS[target]
+
+    def test_compilation(self, prog, monkeypatch):
+        """Test that the remote engine correctly compiles a program
+        for the intended backend"""
+        monkeypatch.setattr(Connection, "create_job", lambda *args: args)
+
+        engine = RemoteEngine("X8")
+        _, target, res_prog, run_options = engine.run_async(prog, shots=1234)
+
+        assert target == RemoteEngine.DEFAULT_TARGETS["X8"]
+        assert run_options == {"shots": 1234}
+
+        # check program is compiled to match the chip template
+        expected = prog.compile("X8").circuit
+        res = res_prog.circuit
+
+        for cmd1, cmd2 in zip(res, expected):
+            # loop through all commands in res and expected
+
+            # check gates are the same
+            assert type(cmd1.op) is type(cmd2.op)
+            # check modes are the same
+            assert all(i.ind == j.ind for i, j in zip(cmd1.reg, cmd2.reg))
+            # check parameters are the same
+            assert all(p1 == p2 for p1, p2 in zip(cmd1.op.p, cmd2.op.p))


### PR DESCRIPTION
**Context:**

The `RemoteEngine.run_async()` method had the erroneous line
```python
kwargs = kwargs.update(self._backend_options)
```
The `dict.update` method is an in-place method, and returns `None`, resulting in an incorrectly compiled blackbird program.

**Description of the Change:**

* The line above has been modified to remove the assignment.

* A tests has been added to catch this behaviour in future.

* The logic in determining the run options has been moved to `RemoteEngine.run_async`, as it makes more logical sense here than as part of the `Connection` object.

* I noticed that SF was not providing a default value for the number of shots in the remote engine. Local engine has `shots=1` by default, but this is because the `fock` and `tf` backends don't support multishot sampling yet, so isn't as applicable to the remote engine. The `RemoteEngine.run_async` method now raises an error if number of shots is not provided.

**Benefits:**

* Fixes a bug

* More robust remote engine tests

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
