### PR TITLE
Bump version number to 0.13.0rc0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,11 +19,13 @@
   on supported hardware using the new `RemoteEngine`:
 
   ```python
+  import strawberryfields as sf
   from strawberryfields import ops
   from strawberryfields.utils import random_interferometer
 
   # replace AUTHENTICATION_TOKEN with your Xanadu cloud access token
-  eng = sf.RemoteEngine("X8", token="AUTHENTICATION_TOKEN")
+  con = sf.api.Connection(token="AUTH_TOKEN")
+  eng = sf.RemoteEngine("X8", connection=con)
   prog = sf.Program(8)
 
   U = random_interferometer(4)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.13.0rc0 (development release)
+# Release 0.13.0rc0 (release candidate)
 
 <h3>New features since last release</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.13.0-dev (development release)
+# Release 0.13.0rc0 (development release)
 
 <h3>New features since last release</h3>
 
@@ -6,17 +6,24 @@
   [(#101)](https://github.com/XanaduAI/strawberryfields/pull/101)
   [(#148)](https://github.com/XanaduAI/strawberryfields/pull/148)
   [(#294)](https://github.com/XanaduAI/strawberryfields/pull/294)
+  [(#327)](https://github.com/XanaduAI/strawberryfields/pull/327)
+  [(#328)](https://github.com/XanaduAI/strawberryfields/pull/328)
+  [(#329)](https://github.com/XanaduAI/strawberryfields/pull/329)
+  [(#330)](https://github.com/XanaduAI/strawberryfields/pull/330)
+  [(#334)](https://github.com/XanaduAI/strawberryfields/pull/334)
+  [(#336)](https://github.com/XanaduAI/strawberryfields/pull/336)
+  [(#337)](https://github.com/XanaduAI/strawberryfields/pull/337)
+  [(#339)](https://github.com/XanaduAI/strawberryfields/pull/339)
 
   Jobs can now be submitted to the Xanadu cloud platform to be run
   on supported hardware using the new `RemoteEngine`:
 
   ```python
-  from strawberryfields import RemoteEngine
   from strawberryfields import ops
   from strawberryfields.utils import random_interferometer
 
   # replace AUTHENTICATION_TOKEN with your Xanadu cloud access token
-  eng = RemoteEngine("chip2", token="AUTHENTICATION_TOKEN")
+  eng = sf.RemoteEngine("X8", token="AUTHENTICATION_TOKEN")
   prog = sf.Program(8)
 
   U = random_interferometer(4)
@@ -29,13 +36,14 @@
 
       ops.Interferometer(U) | q[:4]
       ops.Interferometer(U) | q[4:]
+      ops.MeasureFock() | q
 
-  result = eng.run(prog)
+  result = eng.run(prog, shots=1000)
   ```
 
   For more details, see the
-  [Xanadu cloud platform](https://strawberryfields.readthedocs.io/en/stable/introduction/remote.html)
-  tutorial.
+  [photonic hardware quickstart](https://strawberryfields.readthedocs.io/en/latest/introduction/photonic_hardware.html)
+  and [tutorial](https://strawberryfields.readthedocs.io/en/latest/tutorials/tutorial_X8.html).
 
 * Significantly speeds up the Fock backend of Strawberry Fields,
   through a variety of changes:
@@ -176,7 +184,7 @@
 This release contains contributions from (in alphabetical order):
 
 Ville Bergholm, Tom Bromley, Jack Ceroni, Theodor Isacsson, Josh Izaac, Nathan Killoran, Shreya P Kumar,
-Nicolás Quesada, Jeremy Swinarton, Antal Száva, Paul Tan, Zeid Zabaneh
+Leonhard Neuhaus, Nicolás Quesada, Jeremy Swinarton, Antal Száva, Paul Tan, Zeid Zabaneh.
 
 
 # Release 0.12.1 (current release)
@@ -211,7 +219,7 @@ Nicolás Quesada, Jeremy Swinarton, Antal Száva, Paul Tan, Zeid Zabaneh
 
 This release contains contributions from (in alphabetical order):
 
-Ville Bergholm, Tom Bromley, Nicolás Quesada, Paul Tan
+Ville Bergholm, Tom Bromley, Nicolás Quesada, Antal Szava, Paul Tan
 
 
 # Release 0.12.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -219,7 +219,7 @@ Leonhard Neuhaus, Nicolás Quesada, Jeremy Swinarton, Antal Száva, Paul Tan, Ze
 
 This release contains contributions from (in alphabetical order):
 
-Ville Bergholm, Tom Bromley, Nicolás Quesada, Antal Szava, Paul Tan
+Ville Bergholm, Tom Bromley, Nicolás Quesada, Paul Tan
 
 
 # Release 0.12.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,9 +12,9 @@ sklearn
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-automodapi
-sphinx-gallery
+sphinx-gallery==0.5.0
 sphinxcontrib-bibtex==0.4.2
 tensorflow-tensorboard>=0.1.8
 tensorflow==1.3
-thewalrus>=0.7
+thewalrus>=0.11
 toml

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.13.0-dev'
+__version__ = '0.13.0rc0'


### PR DESCRIPTION
**Context:** Prepares for the 0.13.0 release candidate 0 release.

**Description of the Change:**

* Bumps version number to 0.13.0rc0

* Updates changelog with recent PRs, and corrects Python example

* Pins `sphinx-gallery` to version 0.5, as 0.6 was recently released, breaking the documentation CSS.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
