### PR TITLE
Make clean-docs remove build files in doc/code/api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ docs:
 .PHONY : clean-docs
 clean-docs:
 	make -C doc clean
+	rm -rf doc/code/api
 
 test: test-frontend test-gaussian test-fock test-tf batch-test-tf test-apps test-api
 


### PR DESCRIPTION
Make clean-docs remove build files in doc/code/api. If this isn't done, there can be warnings when building docs due to old function/class stubs made by `automodapi`.