### PR TITLE
View/delete existing configurations

### DIFF
--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -76,9 +76,16 @@ class Connection:
         port (int): the port to connect to on the remote host
         use_ssl (bool): whether to use SSL for the connection
     """
+
     # pylint: disable=too-many-instance-attributes
-    def __init__( self, token: str = None, host: str = None, port: int = None,
-            use_ssl: bool = None, verbose: bool = True,):
+    def __init__(
+        self,
+        token: str = None,
+        host: str = None,
+        port: int = None,
+        use_ssl: bool = None,
+        verbose: bool = True,
+    ):
         default_config = load_config()
 
         self._token = token or default_config["api"]["authentication_token"]

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -111,6 +111,23 @@ def create_config(authentication_token=None, **kwargs):
     return config
 
 
+def delete_config(filename="config.toml"):
+    """Delete a configuration file
+
+    Keyword Args:
+        filename (str): the configuration file to delete
+    """
+    file_path = get_config_filepath(filename)
+    if file_path is not None:
+        os.remove(file_path)
+
+
+def reset_config():
+    """Delete all active configuration files"""
+    for config in active_configs():
+        delete_config(config)
+
+
 def get_config_filepath(filename="config.toml"):
     """Get the filepath of the first configuration file found from the defined
     configuration directories (if any).

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -314,8 +314,34 @@ def active_configs(filename="config.toml"):
         filename (str): the name of the configuration files to look for
     """
     active_configs_list = get_available_config_paths(filename)
-    print_active_configs(active_configs_list, filename)
-    print_directories_checked()
+
+    # print the active configurations found based on the filename specified
+    if active_configs_list:
+        active = True
+
+        print(
+            "\nThe following Strawberry Fields configuration files were found "
+            'with the name "{}":\n'.format(filename)
+        )
+
+        for config in active_configs_list:
+            if active:
+                config += " (active)"
+                active = False
+
+            print("* " + config)
+    else:
+        print(
+            "\nNo Strawberry Fields configuration files were found with the "
+            'name "{}".\n'.format(filename)
+        )
+
+    # print the directores that are being checked for a configuration file
+    directories = directories_to_check()
+
+    print("\nThe following directories were checked:\n")
+    for directory in directories:
+        print("* " + directory)
 
 
 def get_available_config_paths(filename="config.toml"):
@@ -337,46 +363,6 @@ def get_available_config_paths(filename="config.toml"):
             active_configs_list.append(filepath)
 
     return active_configs_list
-
-
-def print_active_configs(active_configs_list, filename):
-    """Prints the active configurations found based on the filename specified.
-
-    This function relies on the precedence ordering of directories to mark the
-    active configuration.
-
-    Args:
-        active_configs_list (list[str]): the filepaths for the active configurations
-        filename (str): the name of the configuration file
-    """
-    if active_configs_list:
-        active = True
-
-        print(
-            "\nThe following Strawberry Fields configuration files were found "
-            'with the name "{}":\n'.format(filename)
-        )
-
-        for config in active_configs_list:
-            if active:
-                config += " (active)"
-                active = False
-
-            print("* " + config)
-    else:
-        print(
-            "\nNo Strawberry Fields configuration files were found with the "
-            'name "{}".\n'.format(filename)
-        )
-
-
-def print_directories_checked():
-    """Prints the directores that are being checked for a configuration file."""
-    directories = directories_to_check()
-
-    print("\nThe following directories were checked:\n")
-    for directory in directories:
-        print("* " + directory)
 
 
 def store_account(authentication_token, filename="config.toml", location="user_config", **kwargs):

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -303,8 +303,8 @@ def active_configs(filename="config.toml"):
     Args:
         filename (str): the name of the configuration files to look for
     """
-    active_configs = get_active_configs(filename)
-    print_active_configs(active_configs, filename)
+    active_configs_list = get_active_configs(filename)
+    print_active_configs(active_configs_list, filename)
     print_directories_checked()
 
 def get_active_configs(filename="config.toml"):
@@ -315,34 +315,34 @@ def get_active_configs(filename="config.toml"):
     Returns:
         list[str]: the filepaths for the active configurations
     """
-    active_configs = []
+    active_configs_list = []
 
     directories = directories_to_check()
 
     for directory in directories:
         filepath = os.path.join(directory, filename)
         if os.path.exists(filepath):
-            active_configs.append(filepath)
+            active_configs_list.append(filepath)
 
-    return active_configs
+    return active_configs_list
 
-def print_active_configs(active_configs, filename):
+def print_active_configs(active_configs_list, filename):
     """Prints the active configurations found based on the filename specified.
 
     This function relies on the precedence ordering of directories to mark the
     active configuration.
 
     Args:
-        active_configs (list[str]): the filepaths for the active configurations
+        active_configs_list (list[str]): the filepaths for the active configurations
         filename (str): the name of the configuration file
     """
-    if active_configs:
+    if active_configs_list:
         active = True
 
         print("\nThe following Strawberry Fields configuration files were found "
               "with the name \"{}\":\n".format(filename))
 
-        for config in active_configs:
+        for config in active_configs_list:
             if active:
                 config += " (active)"
                 active = False

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -117,7 +117,7 @@ def delete_config(filename="config.toml", directory=None):
     """Delete a configuration file
 
     Keyword Args:
-        filename (str): the configuration file to delete
+        filename (str): the filename of the configuration file to delete
         directory (str): the directory of the configuration file if None, use
             default directory
     """

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -120,8 +120,8 @@ def delete_config(filename="config.toml", directory=None):
 
     Keyword Args:
         filename (str): the filename of the configuration file to delete
-        directory (str): the directory of the configuration file if None, use
-            default directory
+        directory (str): The directory of the configuration file to delete.
+            If ``None``, the currently active configuration file is deleted.
     """
     if directory is None:
         file_path = get_default_config_path(filename)

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -115,7 +115,7 @@ def create_config(authentication_token=None, **kwargs):
 
 def delete_config(filename="config.toml", directory=None):
     """Delete a configuration file.
-    
+
     If called with no arguments, the currently active configuration file is deleted.
 
     Keyword Args:

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -212,7 +212,7 @@ def get_api_section_safely(loaded_config, filepath):
     """Gets the API section from the loaded configuration.
 
     Args:
-        loaded_config (dict): the configuration that was loaded from the toml
+        loaded_config (dict): the configuration that was loaded from the TOML config
             file
         filepath (str): path to the configuration file
 

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -114,7 +114,9 @@ def create_config(authentication_token=None, **kwargs):
 
 
 def delete_config(filename="config.toml", directory=None):
-    """Delete a configuration file
+    """Delete a configuration file.
+    
+    If called with no arguments, the currently active configuration file is deleted.
 
     Keyword Args:
         filename (str): the filename of the configuration file to delete

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -60,11 +60,11 @@ def load_config(filename="config.toml", **kwargs):
     """
     config = create_config()
 
-    filepath = get_default_config_path(filename=filename)
+    filepath = find_config_file(filename=filename)
 
     if filepath is not None:
         loaded_config = load_config_file(filepath)
-        api_config = get_api_section_safely(loaded_config, filepath)
+        api_config = get_api_config(loaded_config, filepath)
 
         valid_api_options = keep_valid_options(api_config)
         config["api"].update(valid_api_options)
@@ -124,7 +124,7 @@ def delete_config(filename="config.toml", directory=None):
             If ``None``, the currently active configuration file is deleted.
     """
     if directory is None:
-        file_path = get_default_config_path(filename)
+        file_path = find_config_file(filename)
     else:
         file_path = os.path.join(directory, filename)
 
@@ -133,11 +133,11 @@ def delete_config(filename="config.toml", directory=None):
 
 def reset_config():
     """Delete all active configuration files"""
-    for config in get_active_configs():
+    for config in get_available_config_paths():
         delete_config(os.path.basename(config), os.path.dirname(config))
 
 
-def get_default_config_path(filename="config.toml"):
+def find_config_file(filename="config.toml"):
     """Get the filepath of the first configuration file found from the defined
     configuration directories (if any).
 
@@ -208,7 +208,7 @@ def load_config_file(filepath):
     return config_from_file
 
 
-def get_api_section_safely(loaded_config, filepath):
+def get_api_config(loaded_config, filepath):
     """Gets the API section from the loaded configuration.
 
     Args:
@@ -228,9 +228,9 @@ def get_api_section_safely(loaded_config, filepath):
     except KeyError:
         log = create_logger(__name__)
         log.error(
-            "The configuration from the %s file does not 'contain an \"api\" section.'", filepath
+            "The configuration from the %s file does not contain an \"api\" section.", filepath
         )
-        raise ConfigurationError()
+        raise ConfigurationError
 
 
 def keep_valid_options(sectionconfig):
@@ -307,13 +307,14 @@ def active_configs(filename="config.toml"):
     Args:
         filename (str): the name of the configuration files to look for
     """
-    active_configs_list = get_active_configs(filename)
+    active_configs_list = get_available_config_paths(filename)
     print_active_configs(active_configs_list, filename)
     print_directories_checked()
 
 
-def get_active_configs(filename="config.toml"):
-    """
+def get_available_config_paths(filename="config.toml"):
+    """Get the paths for the configuration files available in Strawberry Fields.
+
     Args:
         filename (str): the name of the configuration files to look for
 

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -79,6 +79,7 @@ def load_config(filename="config.toml", **kwargs):
 
     return config
 
+
 def create_config(authentication_token=None, **kwargs):
     """Create a configuration object that stores configuration related data
     organized into sections.
@@ -224,8 +225,9 @@ def get_api_section_safely(loaded_config, filepath):
         return loaded_config["api"]
     except KeyError:
         log = create_logger(__name__)
-        log.error("The configuration from the %s file does not "\
-                "contain an \"api\" section.", filepath)
+        log.error(
+            "The configuration from the %s file does not 'contain an \"api\" section.'", filepath
+        )
         raise ConfigurationError()
 
 
@@ -307,6 +309,7 @@ def active_configs(filename="config.toml"):
     print_active_configs(active_configs_list, filename)
     print_directories_checked()
 
+
 def get_active_configs(filename="config.toml"):
     """
     Args:
@@ -326,6 +329,7 @@ def get_active_configs(filename="config.toml"):
 
     return active_configs_list
 
+
 def print_active_configs(active_configs_list, filename):
     """Prints the active configurations found based on the filename specified.
 
@@ -339,8 +343,10 @@ def print_active_configs(active_configs_list, filename):
     if active_configs_list:
         active = True
 
-        print("\nThe following Strawberry Fields configuration files were found "
-              "with the name \"{}\":\n".format(filename))
+        print(
+            "\nThe following Strawberry Fields configuration files were found "
+            'with the name "{}":\n'.format(filename)
+        )
 
         for config in active_configs_list:
             if active:
@@ -349,8 +355,11 @@ def print_active_configs(active_configs_list, filename):
 
             print("* " + config)
     else:
-        print("\nNo Strawberry Fields configuration files were found with the "
-              "name \"{}\".\n".format(filename))
+        print(
+            "\nNo Strawberry Fields configuration files were found with the "
+            'name "{}".\n'.format(filename)
+        )
+
 
 def print_directories_checked():
     """Prints the directores that are being checked for a configuration file."""
@@ -359,6 +368,7 @@ def print_directories_checked():
     print("\nThe following directories were checked:\n")
     for directory in directories:
         print("* " + directory)
+
 
 def store_account(authentication_token, filename="config.toml", location="user_config", **kwargs):
     r"""Configure Strawberry Fields for access to the Xanadu cloud platform by

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -112,21 +112,26 @@ def create_config(authentication_token=None, **kwargs):
     return config
 
 
-def delete_config(filename="config.toml"):
+def delete_config(filename="config.toml", directory=None):
     """Delete a configuration file
 
     Keyword Args:
         filename (str): the configuration file to delete
+        directory (str): the directory of the configuration file if None, use
+            default directory
     """
-    file_path = get_default_config_path(filename)
-    if file_path is not None:
-        os.remove(file_path)
+    if directory is None:
+        file_path = get_default_config_path(filename)
+    else:
+        file_path = os.path.join(directory, filename)
+
+    os.remove(file_path)
 
 
 def reset_config():
     """Delete all active configuration files"""
-    for config in active_configs():
-        delete_config(config)
+    for config in get_active_configs():
+        delete_config(os.path.basename(config), os.path.dirname(config))
 
 
 def get_default_config_path(filename="config.toml"):

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -142,6 +142,24 @@ def get_config_filepath(filename="config.toml"):
 
     return None
 
+def active_configs():
+    """Returns the filetpaths for the configuration files that are active. """
+    active_configs = []
+    active = True
+
+    current_dir = os.getcwd()
+    sf_env_config_dir = os.environ.get("SF_CONF", "")
+    sf_user_config_dir = user_config_dir("strawberryfields", "Xanadu")
+
+    directories = [current_dir, sf_env_config_dir, sf_user_config_dir]
+    for directory in directories:
+        filepath = os.path.join(directory, filename)
+        if os.path.exists(filepath):
+            if active:
+                filepath += " (active)"
+            active_configs.append(filepath)
+
+    return active_configs
 
 def load_config_file(filepath):
     """Load a configuration object from a TOML formatted file.

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -227,9 +227,7 @@ def get_api_config(loaded_config, filepath):
         return loaded_config["api"]
     except KeyError:
         log = create_logger(__name__)
-        log.error(
-            "The configuration from the %s file does not contain an \"api\" section.", filepath
-        )
+        log.error('The configuration from the %s file does not contain an "api" section.', filepath)
         raise ConfigurationError
 
 

--- a/strawberryfields/configuration.py
+++ b/strawberryfields/configuration.py
@@ -131,9 +131,17 @@ def delete_config(filename="config.toml", directory=None):
     os.remove(file_path)
 
 
-def reset_config():
-    """Delete all active configuration files"""
-    for config in get_available_config_paths():
+def reset_config(filename="config.toml"):
+    """Delete all active configuration files
+
+    .. warning::
+        This will delete all configuration files with the specified filename
+        (default ``config.toml``) found in the configuration directories.
+
+    Keyword Args:
+        filename (str): the filename of the configuration files to reset
+    """
+    for config in get_available_config_paths(filename):
         delete_config(os.path.basename(config), os.path.dirname(config))
 
 

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -280,7 +280,7 @@ class TestConnectionIntegration:
             assert os.path.exists(file1)
 
             assert a.token == "DummyToken"
-            assert a.host == "DummyToken"
+            assert a.host == "DummyHost"
             assert a.port == 1234
             assert a.use_ssl == False
             conf.delete_config(directory=path1)

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -16,17 +16,37 @@ Unit tests for strawberryfields.api.connection
 """
 from datetime import datetime
 import io
+import os
 
 import numpy as np
 import pytest
 import requests
 
 from strawberryfields.api import Connection, JobStatus, RequestFailedError
+from strawberryfields import configuration as conf
 from .conftest import mock_return
 
 # pylint: disable=no-self-use,unused-argument
 
 pytestmark = pytest.mark.api
+
+TEST_CONFIG_FILE_1 = """\
+[api]
+# Options for the Strawberry Fields Cloud API
+authentication_token = "DummyToken"
+hostname = "DummyHost"
+use_ssl = false
+port = 1234
+"""
+
+TEST_CONFIG_FILE_2 = """\
+[api]
+# Options for the Strawberry Fields Cloud API
+authentication_token = "071cdcce-9241-4965-93af-4a4dbc739135"
+hostname = "platform.strawberryfields.ai"
+use_ssl = true
+port = 443
+"""
 
 
 class MockResponse:
@@ -217,3 +237,58 @@ class TestConnection:
         monkeypatch.setattr(requests, "get", mock_return(MockResponse(500, {})))
 
         assert not connection.ping()
+
+class TestConnectionIntegration:
+    """Integration tests for using instances of the Connection."""
+
+    def test_configuration_deleted_integration(self, monkeypatch, tmpdir):
+        """Check that once two Connection instances indeed differ in their
+        configuration if the configuration is being deleted in the meantime.
+
+        The logic of the test goes as follows:
+        1. Two temporary paths and files are being created
+        2. The directories to be checked are mocked out to the temporary paths
+        3. A connection object is created, using the configuration from the
+        first config
+        4. The first configuration is deleted, leaving the second config as
+        default
+        5. Another connection object is created, using the configuration from the
+        second config
+        6. Checks for the configuration for each Connection instances
+        """
+        test_file_name = "config.toml"
+
+        # Creating the two temporary paths and files
+        path1 = tmpdir.mkdir("sub1")
+        path2 = tmpdir.mkdir("sub2")
+
+        file1 = path1.join(test_file_name)
+        file2 = path2.join(test_file_name)
+
+        with open(file1, "w") as f:
+            f.write(TEST_CONFIG_FILE_1)
+
+        with open(file2, "w") as f:
+            f.write(TEST_CONFIG_FILE_2)
+
+        with monkeypatch.context() as m:
+            m.setattr(os, "getcwd", lambda: path1)
+            m.delenv("SF_CONF", raising=False)
+            m.setattr(conf, "user_config_dir", lambda *args: path2)
+
+            a = Connection()
+            assert os.path.exists(file1)
+
+            assert a.token == "DummyToken"
+            assert a.host == "DummyToken"
+            assert a.port == 1234
+            assert a.use_ssl == False
+            conf.delete_config(directory=path1)
+
+            assert not os.path.exists(file1)
+
+            b = Connection()
+            assert b.token == "071cdcce-9241-4965-93af-4a4dbc739135"
+            assert b.host == "platform.strawberryfields.ai"
+            assert b.port == 443
+            assert b.use_ssl == True

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -199,7 +199,7 @@ class TestCreateConfigObject:
 
 
 class TestGetConfigFilepath:
-    """Tests for the get_config_filepath function."""
+    """Tests for the get_default_config_path function."""
 
     def test_current_directory(self, tmpdir, monkeypatch):
         """Test that the default configuration file is loaded from the current
@@ -213,7 +213,7 @@ class TestGetConfigFilepath:
 
         with monkeypatch.context() as m:
             m.setattr(os, "getcwd", lambda: tmpdir)
-            config_filepath = conf.get_config_filepath(filename=filename)
+            config_filepath = conf.get_default_config_path(filename=filename)
 
         assert config_filepath == tmpdir.join(filename)
 
@@ -239,7 +239,7 @@ class TestGetConfigFilepath:
             m.setenv("SF_CONF", str(tmpdir))
             m.setattr(conf, "user_config_dir", lambda *args: "NotTheFileName")
 
-            config_filepath = conf.get_config_filepath(filename="config.toml")
+            config_filepath = conf.get_default_config_path(filename="config.toml")
 
         assert config_filepath == tmpdir.join("config.toml")
 
@@ -266,12 +266,12 @@ class TestGetConfigFilepath:
                 lambda x, *args: tmpdir if x == "strawberryfields" else "NoConfigFileHere",
             )
 
-            config_filepath = conf.get_config_filepath(filename="config.toml")
+            config_filepath = conf.get_default_config_path(filename="config.toml")
 
         assert config_filepath == tmpdir.join("config.toml")
 
     def test_no_config_file_found_returns_none(self, monkeypatch, tmpdir):
-        """Test that the get_config_filepath returns None if the
+        """Test that the get_default_config_path returns None if the
         configuration file is nowhere to be found.
 
         This is a test case for when there is no configuration file:
@@ -288,7 +288,7 @@ class TestGetConfigFilepath:
             m.setenv("SF_CONF", "NoConfigFileHere")
             m.setattr(conf, "user_config_dir", lambda *args: "NoConfigFileHere")
 
-            config_filepath = conf.get_config_filepath(filename="config.toml")
+            config_filepath = conf.get_default_config_path(filename="config.toml")
 
         assert config_filepath is None
 

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -197,6 +197,68 @@ class TestCreateConfigObject:
             == OTHER_EXPECTED_CONFIG
         )
 
+class TestRemoveConfigFile:
+    """Test the removal of configuration files"""
+
+    def test_remove_default_config(self, monkeypatch, tmpdir):
+        """Test removing the default config file; i.e. called without arguments"""
+        filename = tmpdir.join("config.toml")
+        empty_file = ""
+
+        with open(filename, "w") as f:
+            f.write(empty_file)
+
+        with monkeypatch.context() as m:
+            m.setattr(conf, "get_default_config_path", lambda *args: filename)
+
+            assert os.path.exists(filename)
+
+            conf.delete_config()
+
+            assert not os.path.exists(filename)
+
+    def test_remove_config_in_subdirectory(self, tmpdir):
+        """Test removing a config file in a subdirectory"""
+        subdir = tmpdir.join("subdir")
+        filename = subdir.join("new_config.toml")
+        empty_file = ""
+
+        os.mkdir(subdir)
+        with open(filename, "w") as f:
+            f.write(empty_file)
+
+        assert os.path.exists(filename)
+
+        conf.delete_config(filename, directory=subdir)
+
+        assert not os.path.exists(filename)
+
+    def test_reset_config(self, monkeypatch, tmpdir):
+        """Test resetting the configuration by removing current configuration files"""
+        subdir = tmpdir.join("subdir")
+        filename_1 = tmpdir.join("config.toml")
+        filename_2 = subdir.join("config.toml")
+        active_configs = [filename_1, filename_2]
+
+        empty_file = ""
+
+        with open(filename_1, "w") as f:
+            f.write(empty_file)
+
+        os.mkdir(subdir)
+        with open(filename_2, "w") as f:
+            f.write(empty_file)
+
+        with monkeypatch.context() as m:
+            m.setattr(conf, "get_active_configs", lambda *args: active_configs)
+
+            assert os.path.exists(filename_1)
+            assert os.path.exists(filename_2)
+
+            conf.reset_config()
+
+            assert not os.path.exists(filename_1)
+            assert not os.path.exists(filename_2)
 
 class TestGetConfigFilepath:
     """Tests for the get_default_config_path function."""

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -214,65 +214,81 @@ class TestActiveConfigs:
             active_configs = conf.get_available_config_paths(**kwargs)
             assert active_configs == [file1, file2, file3]
 
-    def test_print_active_configs_single_config(self, capsys):
+    def test_print_active_configs_single_config(self, capsys, monkeypatch):
         """Checks that the correct message is outputted when a single
         configuration file was found."""
         active_configs = ["first_path"]
-        conf.print_active_configs(active_configs, test_file_name)
-
-        captured = capsys.readouterr()
-
-        general_message = "\nThe following Strawberry Fields configuration files were found "\
-                          "with the name \"{}\":\n".format(test_file_name)
-        single_config = "\n* " + active_configs[0] + " (active)\n"
-
-        assert general_message + single_config == captured.out
-
-    def test_print_active_configs_multiple_configs(self, capsys):
-        """Checks that the correct message is outputted for a single
-        configuration file found."""
-        active_configs = ["first_path", "second_path", "third_path"]
-        conf.print_active_configs(active_configs, test_file_name)
-
-        captured = capsys.readouterr()
-
-        general_message = "\nThe following Strawberry Fields configuration files were found "\
-                          "with the name \"{}\":\n".format(test_file_name)
-        first_config = "\n* " + active_configs[0] + " (active)\n"
-        second_config = "* " + active_configs[1] + "\n"
-        third_config = "* " + active_configs[2] + "\n"
-
-        assert general_message + first_config + second_config + third_config == captured.out
-
-    def test_print_active_configs_no_configs(self, capsys):
-        """Checks that the correct message is outputted if no configuration
-        files were found."""
-        conf.print_active_configs([], test_file_name)
-
-        captured = capsys.readouterr()
-
-        general_message = "\nNo Strawberry Fields configuration files were found with the "\
-                          "name \"{}\".\n\n".format(test_file_name)
-
-        assert captured.out == general_message
-
-    def test_print_directories_checked(self, monkeypatch, capsys):
-        """Checks that the correct directories are outputted by
-        print_directories_checked."""
         temp_dirs = ["first_path", "second_path", "third_path"]
-
         with monkeypatch.context() as m:
-            m.setattr(conf, "directories_to_check", lambda : temp_dirs)
-            conf.print_directories_checked()
+            m.setattr(conf, "directories_to_check", lambda: temp_dirs)
+            m.setattr(conf, "get_available_config_paths", lambda *args: active_configs)
+            conf.active_configs(test_file_name)
 
             captured = capsys.readouterr()
-            general_message = "\nThe following directories were checked:\n\n"
+
+            general_message_1 = "\nThe following Strawberry Fields configuration files were found "\
+                            "with the name \"{}\":\n".format(test_file_name)
+            single_config = "\n* " + active_configs[0] + " (active)\n"
+
+            general_message_2 = "\nThe following directories were checked:\n\n"
 
             first_dir_msg = "* " + temp_dirs[0] + "\n"
             second_dir_msg = "* " + temp_dirs[1] + "\n"
             third_dir_msg = "* " + temp_dirs[2] + "\n"
 
-            assert general_message + first_dir_msg + second_dir_msg + third_dir_msg == captured.out
+            assert captured.out == general_message_1 + single_config +\
+                                   general_message_2 + first_dir_msg + second_dir_msg + third_dir_msg
+
+    def test_print_active_configs_multiple_configs(self, capsys, monkeypatch):
+        """Checks that the correct message is outputted for a single
+        configuration file found."""
+        active_configs = ["first_path", "second_path", "third_path"]
+        temp_dirs = ["first_path", "second_path", "third_path"]
+        with monkeypatch.context() as m:
+            m.setattr(conf, "directories_to_check", lambda: temp_dirs)
+            m.setattr(conf, "get_available_config_paths", lambda *args: active_configs)
+            conf.active_configs(test_file_name)
+
+            captured = capsys.readouterr()
+
+            general_message_1 = "\nThe following Strawberry Fields configuration files were found "\
+                            "with the name \"{}\":\n".format(test_file_name)
+            first_config = "\n* " + active_configs[0] + " (active)\n"
+            second_config = "* " + active_configs[1] + "\n"
+            third_config = "* " + active_configs[2] + "\n"
+
+            general_message_2 = "\nThe following directories were checked:\n\n"
+
+            first_dir_msg = "* " + temp_dirs[0] + "\n"
+            second_dir_msg = "* " + temp_dirs[1] + "\n"
+            third_dir_msg = "* " + temp_dirs[2] + "\n"
+
+            assert captured.out == general_message_1 + first_config + second_config + third_config +\
+                                   general_message_2 + first_dir_msg + second_dir_msg + third_dir_msg
+
+    def test_print_active_configs_no_configs(self, capsys, monkeypatch):
+        """Checks that the correct message is outputted if no configuration
+        files were found."""
+        temp_dirs = ["first_path", "second_path", "third_path"]
+        with monkeypatch.context() as m:
+            m.setattr(conf, "directories_to_check", lambda: temp_dirs)
+            m.setattr(conf, "get_available_config_paths", lambda *args: [])
+            conf.active_configs(test_file_name)
+
+            captured = capsys.readouterr()
+
+            general_message_1 = "\nNo Strawberry Fields configuration files were found with the "\
+                            "name \"{}\".\n\n".format(test_file_name)
+
+            general_message_2 = "\nThe following directories were checked:\n\n"
+
+            first_dir_msg = "* " + temp_dirs[0] + "\n"
+            second_dir_msg = "* " + temp_dirs[1] + "\n"
+            third_dir_msg = "* " + temp_dirs[2] + "\n"
+
+            assert captured.out == general_message_1 +\
+                                   general_message_2 + first_dir_msg + second_dir_msg + third_dir_msg
+
 
 class TestCreateConfigObject:
     """Test the creation of a configuration object"""

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -178,8 +178,8 @@ class TestActiveConfigs:
     """Test the active_configs function and its auxiliary functions."""
 
     @pytest.mark.parametrize("kwargs", test_kwargs)
-    def test_get_active_configs_mock_directories(self, monkeypatch, kwargs):
-        """Test that the get_active_configs correctly uses the output of the
+    def test_get_available_config_paths_mock_directories(self, monkeypatch, kwargs):
+        """Test that the get_available_config_paths correctly uses the output of the
         directories_to_check function."""
         test_directory = "test_directory_path"
         test_file_name = kwargs["filename"] if kwargs else default_file_name
@@ -187,12 +187,12 @@ class TestActiveConfigs:
         with monkeypatch.context() as m:
             m.setattr(conf, "directories_to_check", lambda: [test_directory])
             m.setattr(os.path, "exists", lambda *args: True)
-            active_configs = conf.get_active_configs(**kwargs)
+            active_configs = conf.get_available_config_paths(**kwargs)
             assert active_configs == [os.path.join(test_directory, test_file_name)]
 
     @pytest.mark.parametrize("kwargs", test_kwargs)
-    def test_get_active_configs_integration(self, monkeypatch, tmpdir, kwargs):
-        """Tests that the get_active_configs function integrates well with
+    def test_get_available_config_paths_integration(self, monkeypatch, tmpdir, kwargs):
+        """Tests that the get_available_config_paths function integrates well with
         parts of the directories_to_check function."""
         test_file_name = kwargs["filename"] if kwargs else default_file_name
 
@@ -211,7 +211,7 @@ class TestActiveConfigs:
             m.setenv("SF_CONF", str(path2))
             m.setattr(conf, "user_config_dir", lambda *args: path3)
             m.setattr(os.path, "exists", lambda arg: arg in temporary_files)
-            active_configs = conf.get_active_configs(**kwargs)
+            active_configs = conf.get_available_config_paths(**kwargs)
             assert active_configs == [file1, file2, file3]
 
     def test_print_active_configs_single_config(self, capsys):
@@ -313,7 +313,7 @@ class TestRemoveConfigFile:
             f.write(empty_file)
 
         with monkeypatch.context() as m:
-            m.setattr(conf, "get_default_config_path", lambda *args: filename)
+            m.setattr(conf, "find_config_file", lambda *args: filename)
 
             assert os.path.exists(filename)
 
@@ -354,7 +354,7 @@ class TestRemoveConfigFile:
             f.write(empty_file)
 
         with monkeypatch.context() as m:
-            m.setattr(conf, "get_active_configs", lambda *args: active_configs)
+            m.setattr(conf, "get_available_config_paths", lambda *args: active_configs)
 
             assert os.path.exists(filename_1)
             assert os.path.exists(filename_2)
@@ -365,7 +365,7 @@ class TestRemoveConfigFile:
             assert not os.path.exists(filename_2)
 
 class TestGetConfigFilepath:
-    """Tests for the get_default_config_path function."""
+    """Tests for the find_config_file function."""
 
     def test_current_directory(self, tmpdir, monkeypatch):
         """Test that the default configuration file is loaded from the current
@@ -379,7 +379,7 @@ class TestGetConfigFilepath:
 
         with monkeypatch.context() as m:
             m.setattr(os, "getcwd", lambda: tmpdir)
-            config_filepath = conf.get_default_config_path(filename=filename)
+            config_filepath = conf.find_config_file(filename=filename)
 
         assert config_filepath == tmpdir.join(filename)
 
@@ -405,7 +405,7 @@ class TestGetConfigFilepath:
             m.setenv("SF_CONF", str(tmpdir))
             m.setattr(conf, "user_config_dir", lambda *args: "NotTheFileName")
 
-            config_filepath = conf.get_default_config_path(filename="config.toml")
+            config_filepath = conf.find_config_file(filename="config.toml")
 
         assert config_filepath == tmpdir.join("config.toml")
 
@@ -432,12 +432,12 @@ class TestGetConfigFilepath:
                 lambda x, *args: tmpdir if x == "strawberryfields" else "NoConfigFileHere",
             )
 
-            config_filepath = conf.get_default_config_path(filename="config.toml")
+            config_filepath = conf.find_config_file(filename="config.toml")
 
         assert config_filepath == tmpdir.join("config.toml")
 
     def test_no_config_file_found_returns_none(self, monkeypatch, tmpdir):
-        """Test that the get_default_config_path returns None if the
+        """Test that the find_config_file returns None if the
         configuration file is nowhere to be found.
 
         This is a test case for when there is no configuration file:
@@ -454,7 +454,7 @@ class TestGetConfigFilepath:
             m.setenv("SF_CONF", "NoConfigFileHere")
             m.setattr(conf, "user_config_dir", lambda *args: "NoConfigFileHere")
 
-            config_filepath = conf.get_default_config_path(filename="config.toml")
+            config_filepath = conf.find_config_file(filename="config.toml")
 
         assert config_filepath is None
 


### PR DESCRIPTION
**Context:**
There is currently no simple way of viewing what configuration file a user is using, and where this is located on the user's computer. The ability to view active configuration files as well as to be able to delete specific configuration files and to reset all configurations to default, would be very nice; particularly when it comes to debugging and issue-solving for the user.

**Description of the Change:**
The following main functions are added to `configuration.py`:

- `active_configurations()`: prints the current configuration files, marking the active configuration path with `(active)`.

- `delete_config(filename="config.toml", directory=None)`: removes a configuration file with name `filename` in `directory`. If no arguments are passed it removes the config file with name `config.toml` in the default directory.

- `reset_config()`: removes all configuration files in directories potentially containing SF configuration files.

Furthermore, the `Connection` class now directly calls `load_config()` in `configuration.py` instead of simply loading a module attribute called `configuration` (instantiated at import), letting a new config file be loaded automatically when creating a `Connection` object after removing or resetting the config file(s).

**Benefits:**
The configuration file(s) can now be deleted and completely reset to default if needed, and it's now possible to view what configurations files are active as well as their location.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A