### PR TITLE
[WIP] Add ability to configure logging for debugging

### DIFF
--- a/doc/code/sf_cli.rst
+++ b/doc/code/sf_cli.rst
@@ -136,4 +136,4 @@ Code details
 .. automodapi:: strawberryfields.cli
     :no-heading:
     :no-inheritance-diagram:
-    :skip: store_account, create_config, load, RemoteEngine, Connection, ConfigurationError
+    :skip: store_account, DEFAULT_CONFIG, load, RemoteEngine, Connection, ConfigurationError, ping

--- a/doc/code/sf_configuration.rst
+++ b/doc/code/sf_configuration.rst
@@ -67,5 +67,5 @@ Functions
 
 .. automodapi:: strawberryfields.configuration
     :no-heading:
-    :skip: user_config_dir
+    :skip: user_config_dir, store_account, active_configs, reset_config, create_logger
     :no-inheritance-diagram:

--- a/doc/code/sf_configuration.rst
+++ b/doc/code/sf_configuration.rst
@@ -33,8 +33,18 @@ and has the following format:
     use_ssl = true
     port = 443
 
+    [logging]
+    # Options for the logger
+    level = "warning"
+    logfile = "sf.log"
+
 Configuration options
 ---------------------
+
+``[api]``
+^^^^^^^^^
+
+Settings for the Xanadu cloud platform.
 
 **authentication_token (str)** (*required*)
     API token for authentication to the Xanadu cloud platform. This is required
@@ -56,6 +66,29 @@ Configuration options
     The port to be used when connecting to the remote service. Defaults to 443.
 
     *Corresponding environment variable:* ``SF_API_PORT``
+
+``[logging]``
+^^^^^^^^^^^^^
+
+Settings for the Strawberry Fields logger.
+
+**level (str)** (*optional*)
+    Specifies the level of information that should be printed to the standard
+    output. Defaults to ``"info"``, which indicates that all logged details
+    are displayed as output.
+
+    Other options include ``"error"``, ``"warning"``, ``"info"``, ``"debug"``,
+    in decreasing levels of verbosity.
+
+    *Corresponding environment variable:* ``SF_LOGGING_LEVEL``
+
+**logfile (str)** (*optional*)
+    The filepath of an output logfile. This may be a relative or an
+    absolute path. If specified, all logging data is appended to this
+    file during Strawberry Fields execution.
+
+    *Corresponding environment variable:* ``SF_LOGGING_LOGFILE``
+
 
 Functions
 ---------

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
     "ping",
     "store_account",
     "active_configs",
-    "reset_config"
+    "reset_config",
 ]
 
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -24,7 +24,7 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
 from . import apps
 from ._version import __version__
 from .cli import ping
-from .configuration import store_account
+from .configuration import store_account, active_configs, reset_config
 from .engine import Engine, LocalEngine, RemoteEngine
 from .io import load, save
 from .parameters import par_funcs as math
@@ -39,9 +39,10 @@ __all__ = [
     "load",
     "about",
     "cite",
-    "math",
     "ping",
     "store_account",
+    "active_configs",
+    "reset_config"
 ]
 
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -30,7 +30,19 @@ from .io import load, save
 from .parameters import par_funcs as math
 from .program import Program
 
-__all__ = ["Engine", "RemoteEngine", "Program", "version", "save", "load", "about", "cite"]
+__all__ = [
+    "Engine",
+    "RemoteEngine",
+    "Program",
+    "version",
+    "save",
+    "load",
+    "about",
+    "cite",
+    "math",
+    "ping",
+    "store_account",
+]
 
 
 #: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -154,6 +154,8 @@ class Connection:
 
         circuit = bb.serialize()
 
+        self.log.debug("Submitting job\n%s", circuit)
+
         path = "/jobs"
         response = requests.post(self._url(path), headers=self._headers, json={"circuit": circuit})
         if response.status_code == 201:

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -129,6 +129,7 @@ class Job:
         self._status = JobStatus(self._connection.get_job_status(self.id))
         if self._status == JobStatus.COMPLETED:
             self._result = self._connection.get_job_result(self.id)
+            self.log.info("Job %s is complete", self.id)
 
     def cancel(self):
         """Cancels an open or queued job.

--- a/strawberryfields/cli/__init__.py
+++ b/strawberryfields/cli/__init__.py
@@ -20,7 +20,7 @@ import argparse
 import sys
 
 from strawberryfields.api import Connection
-from strawberryfields.configuration import ConfigurationError, create_config, store_account
+from strawberryfields.configuration import ConfigurationError, DEFAULT_CONFIG, store_account
 from strawberryfields.engine import RemoteEngine
 from strawberryfields.io import load
 
@@ -162,7 +162,7 @@ def configuration_wizard():
     Returns:
         dict[str, Union[str, bool, int]]: the configuration options
     """
-    default_config = create_config()["api"]
+    default_config = DEFAULT_CONFIG["api"]
 
     # Getting default values that can be used for as messages when getting inputs
     hostname_default = default_config["hostname"]

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -589,6 +589,11 @@ class RemoteEngine:
             # * compiled to a different chip family to the engine target
             #
             # In both cases, recompile the program to match the intended target.
+            self.log.debug(
+                "Compiling program for target %s with compile options %s",
+                self.target,
+                compile_options
+            )
             program = program.compile(self.target, **compile_options)
 
         # update the run options if provided

--- a/strawberryfields/logger.py
+++ b/strawberryfields/logger.py
@@ -49,6 +49,8 @@ https://github.com/pallets/flask/blob/master/src/flask/logging.py
 import logging
 import sys
 
+from strawberryfields.configuration import SESSION_CONFIG
+
 
 def logging_handler_defined(logger):
     """Checks if the logger or any of its ancestors has a handler defined.
@@ -111,27 +113,16 @@ def create_logger(name, level=None):
         # The root logger should pass all log message levels
         # to the handlers.
         logger.setLevel(logging.DEBUG)
-
-        # Import load_config here to avoid a cyclic import
-        # (since the configuration module imports the logger).
-        from strawberryfields.configuration import load_config
-
-        # The load_config function by default logs information.
-        # We need to turn this off here, since the logger has not
-        # been created yet.
-        default_config = load_config(verbose=False)
-        level = level or getattr(logging, default_config["logging"]["level"].upper())
+        level = level or getattr(logging, SESSION_CONFIG["logging"]["level"].upper())
 
         # Attach the standard output logger,
         # with the user defined logging level (defaults to INFO)
         output_handler.setLevel(level)
         logger.addHandler(output_handler)
 
-        if "logfile" in default_config["logging"]:
+        if "logfile" in SESSION_CONFIG["logging"]:
             # Create the file logger
-            file_handler = logging.FileHandler(
-                default_config["logging"]["logfile"], disable_existing_loggers=False
-            )
+            file_handler = logging.FileHandler(SESSION_CONFIG["logging"]["logfile"])
             file_handler.setFormatter(formatter)
 
             # file logger should display all log message levels

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the configuration module"""
+import copy
 import os
 import logging
 import pytest
@@ -142,9 +143,8 @@ class TestLoadConfig:
             f.write(empty_file)
 
         with monkeypatch.context() as m:
-            with pytest.raises(conf.ConfigurationError, match=""):
-                m.setattr(os, "getcwd", lambda: tmpdir)
-                configuration = conf.load_config()
+            m.setattr(os, "getcwd", lambda: tmpdir)
+            configuration = conf.load_config()
 
         assert "does not contain an \"api\" section" in caplog.text
 
@@ -290,32 +290,31 @@ class TestActiveConfigs:
                                    general_message_2 + first_dir_msg + second_dir_msg + third_dir_msg
 
 
-class TestCreateConfigObject:
+class TestGenerateConfigObject:
     """Test the creation of a configuration object"""
 
-    def test_empty_config_object(self):
-        """Test that an empty configuration object can be created."""
-        config = conf.create_config(authentication_token="", hostname="", use_ssl="", port="")
-
-        assert all(value == "" for value in config["api"].values())
+    def test_type_validation(self):
+        """Test that passing an incorrect type raises an exception"""
+        with pytest.raises(conf.ConfigurationError, match="Expected type"):
+            config = conf._generate_config(
+                conf.DEFAULT_CONFIG_SPEC, api={"use_ssl":""}
+            )
 
     def test_config_object_with_authentication_token(self):
         """Test that passing only the authentication token creates the expected
         configuration object."""
-        assert (
-            conf.create_config(authentication_token="071cdcce-9241-4965-93af-4a4dbc739135")
-            == EXPECTED_CONFIG
+        config = conf._generate_config(
+            conf.DEFAULT_CONFIG_SPEC, api={"authentication_token":"071cdcce-9241-4965-93af-4a4dbc739135",}
         )
+        assert config == EXPECTED_CONFIG
 
     def test_config_object_every_keyword_argument(self):
         """Test that passing every keyword argument creates the expected
         configuration object."""
-        assert (
-            conf.create_config(
-                authentication_token="SomeAuth", hostname="SomeHost", use_ssl=False, port=56
-            )
-            == OTHER_EXPECTED_CONFIG
+        config = conf._generate_config(
+            conf.DEFAULT_CONFIG_SPEC, api={"authentication_token":"SomeAuth", "hostname":"SomeHost", "use_ssl":False, "port":56}
         )
+        assert config == OTHER_EXPECTED_CONFIG
 
 class TestRemoveConfigFile:
     """Test the removal of configuration files"""
@@ -475,61 +474,6 @@ class TestGetConfigFilepath:
         assert config_filepath is None
 
 
-class TestLoadConfigFile:
-    """Tests the load_config_file function."""
-
-    def test_load_config_file(self, monkeypatch, tmpdir):
-        """Tests that configuration is loaded correctly from a TOML file."""
-        filename = tmpdir.join("test_config.toml")
-
-        with open(filename, "w") as f:
-            f.write(TEST_FILE)
-
-        loaded_config = conf.load_config_file(filepath=filename)
-
-        assert loaded_config == EXPECTED_CONFIG
-
-    def test_loading_absolute_path(self, monkeypatch, tmpdir):
-        """Test that the default configuration file can be loaded
-        via an absolute path."""
-        filename = tmpdir.join("test_config.toml")
-
-        with open(filename, "w") as f:
-            f.write(TEST_FILE)
-
-        with monkeypatch.context() as m:
-            m.setenv("SF_CONF", "")
-            loaded_config = conf.load_config_file(filepath=filename)
-
-        assert loaded_config == EXPECTED_CONFIG
-
-
-class TestKeepValidOptions:
-    def test_only_invalid_options(self):
-        section_config_with_invalid_options = {"NotValid1": 1, "NotValid2": 2, "NotValid3": 3}
-        assert conf.keep_valid_options(section_config_with_invalid_options) == {}
-
-    def test_valid_and_invalid_options(self):
-        section_config_with_invalid_options = {
-            "authentication_token": "MyToken",
-            "NotValid1": 1,
-            "NotValid2": 2,
-            "NotValid3": 3,
-        }
-        assert conf.keep_valid_options(section_config_with_invalid_options) == {
-            "authentication_token": "MyToken"
-        }
-
-    def test_only_valid_options(self):
-        section_config_only_valid = {
-            "authentication_token": "071cdcce-9241-4965-93af-4a4dbc739135",
-            "hostname": "platform.strawberryfields.ai",
-            "use_ssl": True,
-            "port": 443,
-        }
-        assert conf.keep_valid_options(section_config_only_valid) == EXPECTED_CONFIG["api"]
-
-
 value_mapping = [
     ("SF_API_AUTHENTICATION_TOKEN", "SomeAuth"),
     ("SF_API_HOSTNAME", "SomeHost"),
@@ -558,7 +502,7 @@ class TestUpdateFromEnvironmentalVariables:
             for env_var, value in value_mapping:
                 m.setenv(env_var, value)
 
-            config = conf.create_config()
+            config = copy.deepcopy(conf.DEFAULT_CONFIG)
             for v, parsed_value in zip(config["api"].values(), parsed_values_mapping.values()):
                 assert v != parsed_value
 
@@ -581,7 +525,7 @@ class TestUpdateFromEnvironmentalVariables:
         with monkeypatch.context() as m:
             m.setenv(env_var, value)
 
-            config = conf.create_config()
+            config = copy.deepcopy(conf.DEFAULT_CONFIG)
             for v, parsed_value in zip(config["api"].values(), parsed_values_mapping.values()):
                 assert v != parsed_value
 
@@ -598,24 +542,24 @@ class TestUpdateFromEnvironmentalVariables:
         """Tests that boolean values can be parsed correctly from environment
         variables."""
         monkeypatch.setattr(conf, "DEFAULT_CONFIG_SPEC", {"api": {"some_boolean": (bool, True)}})
-        assert conf.parse_environment_variable("some_boolean", "true") is True
-        assert conf.parse_environment_variable("some_boolean", "True") is True
-        assert conf.parse_environment_variable("some_boolean", "TRUE") is True
-        assert conf.parse_environment_variable("some_boolean", "1") is True
-        assert conf.parse_environment_variable("some_boolean", 1) is True
+        assert conf._parse_environment_variable("api", "some_boolean", "true") is True
+        assert conf._parse_environment_variable("api", "some_boolean", "True") is True
+        assert conf._parse_environment_variable("api", "some_boolean", "TRUE") is True
+        assert conf._parse_environment_variable("api", "some_boolean", "1") is True
+        assert conf._parse_environment_variable("api", "some_boolean", 1) is True
 
-        assert conf.parse_environment_variable("some_boolean", "false") is False
-        assert conf.parse_environment_variable("some_boolean", "False") is False
-        assert conf.parse_environment_variable("some_boolean", "FALSE") is False
-        assert conf.parse_environment_variable("some_boolean", "0") is False
-        assert conf.parse_environment_variable("some_boolean", 0) is False
+        assert conf._parse_environment_variable("api", "some_boolean", "false") is False
+        assert conf._parse_environment_variable("api", "some_boolean", "False") is False
+        assert conf._parse_environment_variable("api", "some_boolean", "FALSE") is False
+        assert conf._parse_environment_variable("api", "some_boolean", "0") is False
+        assert conf._parse_environment_variable("api", "some_boolean", 0) is False
 
     def test_parse_environment_variable_integer(self, monkeypatch):
         """Tests that integer values can be parsed correctly from environment
         variables."""
 
         monkeypatch.setattr(conf, "DEFAULT_CONFIG_SPEC", {"api": {"some_integer": (int, 123)}})
-        assert conf.parse_environment_variable("some_integer", "123") == 123
+        assert conf._parse_environment_variable("api", "some_integer", "123") == 123
 
 
 DEFAULT_KWARGS = {"hostname": "platform.strawberryfields.ai", "use_ssl": True, "port": 443}
@@ -656,8 +600,7 @@ class TestStoreAccount:
         with monkeypatch.context() as m:
             m.setattr(os, "getcwd", lambda: tmpdir)
             m.setattr(conf, "user_config_dir", lambda *args: "NotTheCorrectDir")
-            m.setattr(conf, "create_config", mock_create_config)
-            m.setattr(conf, "save_config_to_file", lambda a, b: mock_save_config_file.update(a, b))
+            m.setattr("toml.dump", lambda a, b: mock_save_config_file.update(a, b.name))
             conf.store_account(
                 authentication_token, filename="config.toml", location="local", **DEFAULT_KWARGS
             )
@@ -676,8 +619,7 @@ class TestStoreAccount:
         with monkeypatch.context() as m:
             m.setattr(os, "getcwd", lambda: "NotTheCorrectDir")
             m.setattr(conf, "user_config_dir", lambda *args: tmpdir)
-            m.setattr(conf, "create_config", mock_create_config)
-            m.setattr(conf, "save_config_to_file", lambda a, b: mock_save_config_file.update(a, b))
+            m.setattr("toml.dump", lambda a, b: mock_save_config_file.update(a, b.name))
             conf.store_account(
                 authentication_token,
                 filename="config.toml",
@@ -800,32 +742,3 @@ class TestStoreAccountIntegration:
         filepath = os.path.join(recursive_dir, "config.toml")
         result = toml.load(filepath)
         assert result == EXPECTED_CONFIG
-
-
-class TestSaveConfigToFile:
-    """Tests for the store_account function."""
-
-    def test_correct(self, tmpdir):
-        """Test saving a configuration file."""
-        filepath = str(tmpdir.join("config.toml"))
-
-        conf.save_config_to_file(OTHER_EXPECTED_CONFIG, filepath)
-
-        result = toml.load(filepath)
-        assert result == OTHER_EXPECTED_CONFIG
-
-    def test_file_already_existed(self, tmpdir):
-        """Test saving a configuration file even if the file already
-        existed."""
-        filepath = str(tmpdir.join("config.toml"))
-
-        with open(filepath, "w") as f:
-            f.write(TEST_FILE)
-
-        result_for_existing_file = toml.load(filepath)
-        assert result_for_existing_file == EXPECTED_CONFIG
-
-        conf.save_config_to_file(OTHER_EXPECTED_CONFIG, filepath)
-
-        result_for_new_file = toml.load(filepath)
-        assert result_for_new_file == OTHER_EXPECTED_CONFIG

--- a/tests/frontend/test_configuration.py
+++ b/tests/frontend/test_configuration.py
@@ -47,7 +47,8 @@ EXPECTED_CONFIG = {
         "hostname": "platform.strawberryfields.ai",
         "use_ssl": True,
         "port": 443,
-    }
+    },
+    'logging': {'level': 'info'}
 }
 
 OTHER_EXPECTED_CONFIG = {
@@ -56,7 +57,8 @@ OTHER_EXPECTED_CONFIG = {
         "hostname": "SomeHost",
         "use_ssl": False,
         "port": 56,
-    }
+    },
+    'logging': {'level': 'info'}
 }
 
 environment_variables = [
@@ -92,9 +94,12 @@ class TestLoadConfig:
             m.setenv("SF_API_PORT", "42")
 
             m.setattr(os, "getcwd", lambda: tmpdir)
-            configuration = conf.load_config(
-                authentication_token="SomeAuth", hostname="SomeHost", use_ssl=False, port=56
-            )
+            configuration = conf.load_config(api={
+                "authentication_token": "SomeAuth",
+                "hostname": "SomeHost",
+                "use_ssl": False,
+                "port": 56
+            })
 
         assert configuration == OTHER_EXPECTED_CONFIG
 

--- a/tests/frontend/test_logger.py
+++ b/tests/frontend/test_logger.py
@@ -52,7 +52,7 @@ import strawberryfields.api.job as job
 import strawberryfields.api.connection as connection
 import strawberryfields.engine as engine
 
-from strawberryfields.logger import logging_handler_defined, default_handler, create_logger
+from strawberryfields.logger import logging_handler_defined, output_handler, create_logger
 
 modules_contain_logging = [job, connection, engine]
 
@@ -114,7 +114,7 @@ class TestLogger:
         logger = create_logger(module.__name__)
         assert logger.level == logging.INFO
         assert logging_handler_defined(logger)
-        assert logger.handlers[0] == default_handler
+        assert logger.handlers[0] == output_handler
 
 class TestLoggerIntegration:
     """Tests that the SF logger integrates well with user defined logging

--- a/tests/frontend/test_sf_cli.py
+++ b/tests/frontend/test_sf_cli.py
@@ -15,6 +15,7 @@ r"""
 Unit tests for the Strawberry Fields command line interface.
 """
 # pylint: disable=no-self-use,unused-argument
+import copy
 import os
 import functools
 import argparse
@@ -160,7 +161,7 @@ class TestConfigure:
         configuration takes place using the configuration_wizard function."""
         with monkeypatch.context() as m:
             mock_store_account = MockStoreAccount()
-            m.setattr(cli, "configuration_wizard", lambda: cli.create_config()["api"])
+            m.setattr(cli, "configuration_wizard", lambda: cli.DEFAULT_CONFIG["api"])
             m.setattr(cli, "store_account", mock_store_account.store_account)
 
             args = MockArgs()
@@ -190,7 +191,7 @@ class TestConfigure:
         the configuration_wizard function."""
         with monkeypatch.context() as m:
             mock_store_account = MockStoreAccount()
-            m.setattr(cli, "configuration_wizard", lambda: cli.create_config()["api"])
+            m.setattr(cli, "configuration_wizard", lambda: cli.DEFAULT_CONFIG["api"])
             m.setattr(cli, "store_account", mock_store_account.store_account)
 
             args = MockArgs()
@@ -278,7 +279,7 @@ class TestConfigureEverything:
         correctly, once the authentication token is passed."""
         with monkeypatch.context() as m:
             auth_prompt = "Please enter the authentication token"
-            default_config = cli.create_config()["api"]
+            default_config = copy.deepcopy(cli.DEFAULT_CONFIG["api"])
             default_auth = "SomeAuth"
             default_config['authentication_token'] = default_auth
 
@@ -291,7 +292,7 @@ class TestConfigureEverything:
         with monkeypatch.context() as m:
 
             auth_prompt = "Please enter the authentication token"
-            default_config = cli.create_config()["api"]
+            default_config = copy.deepcopy(cli.DEFAULT_CONFIG["api"])
             default_auth = "SomeAuth"
             default_config['authentication_token'] = default_auth
 


### PR DESCRIPTION
**Context:**

When debugging configuration and API access, it's useful to be able to output debugging logging information to a file. This can then be shared when requesting help.

Currently, Strawberry Fields performs logging of internal state and warning, but requires the user have knowledge of the Python logging module in order to modify the logging level/output the log information to a file.

**Description of the Change:**

* Adds a new section to the configuration pertaining to logging:

  ```toml
  [logging]
  # default logger output on the terminal
  level = "info"
  # optional logfile output
  logfile = "sf.log"
  ```

  By changing the `level` option, the user can specify the types of log messages that are displayed in the terminal when using the default SF logger. For instance, by setting `level = "debug"`, more detailed information is output during execution.

  By setting the `logfile` option, the user can specify a logfile that is appended to during SF execution. Currently, the logfile contains all logged messages, of level DEBUG and up.

  <details>
    <summary>Click here to see an example logfile created when submitting a remote program.  </summary>

  ```console
  2020-04-12 21:12:26,640 - DEBUG - Configuration file /home/josh/.config/strawberryfields/config.toml loaded
  2020-04-12 21:12:26,641 - DEBUG - Loaded configuration: {'api': {'authentication_token': 'm8Tox***********************************', 'hostname': 'platform.strawberryfields.ai', 'use_ssl': True, 'port': 443}, 'logging': {'level': 'debug'}}
  2020-04-12 21:12:26,641 - DEBUG - Compiling program for target X8_01 with compile options {}
  2020-04-12 21:12:26,964 - DEBUG - Submitting job
  name test
  version 1.0
  target X8_01 (shots=10)

  S2gate(0, 0) | [2, 6]
  S2gate(1, 0.0) | [1, 5]
  S2gate(0.0, 0.0) | [3, 7]
  S2gate(1.0, 0.0) | [0, 4]
  MZgate(5.3074357926500895, 1.5739876247864792) | [0, 1]
  MZgate(4.279290161703878, 4.202979995136468) | [2, 3]
  MZgate(5.824121814032434, 5.033017799971674) | [1, 2]
  MZgate(5.198882953351497, 3.715902833866422) | [0, 1]
  MZgate(4.712954779003035, 3.107023958221405) | [2, 3]
  MZgate(4.83853796968657, 5.988756943006127) | [1, 2]
  Rgate(0.6651640322699326) | 0
  Rgate(0.06106261020227405) | 1
  Rgate(2.94378117796741) | 2
  Rgate(1.820738947340938) | 3
  MZgate(5.3074357926500895, 1.5739876247864792) | [4, 5]
  MZgate(4.279290161703878, 4.202979995136468) | [6, 7]
  MZgate(5.824121814032434, 5.033017799971674) | [5, 6]
  MZgate(5.198882953351497, 3.715902833866422) | [4, 5]
  MZgate(4.712954779003035, 3.107023958221405) | [6, 7]
  MZgate(4.83853796968657, 5.988756943006127) | [5, 6]
  Rgate(0.6651640322699326) | 4
  Rgate(0.06106261020227405) | 5
  Rgate(2.94378117796741) | 6
  Rgate(1.820738947340938) | 7
  MeasureFock() | [0, 1, 2, 3, 4, 5, 6, 7]

  2020-04-12 21:12:27,608 - INFO - Job d101fc18-289f-442b-a899-3d5a6d40fffc was successfully submitted.
  ```
  </details>

  *Note: these options only affect the built-in SF logger handlers. If the user creates their own custom logging handler, this overrides the SF built-in handlers.*

* Adds a DEBUG log message on job submission, logging the submitted blackbird script.

* Adds a DEBUG log message on `RemoteEngine.run_async()`, providing details on program compilation if it occurs.

* Adds an INFO log message if the job is complete after a refresh

* Adds a `sf.configuration.SESSION_CONFIG` global variable that stores the configuration of Strawberry Fields as first import. This is used to configure the logger --- the configuration of the logger should not change after this.

* `load_config()` now logs debugging information, including the loaded configuration. Note that loaded API tokens are automatically masked.

* Minor refactor of the `sf.configuration` module:

  - The logging section has been added to `DEFAULT_CONFIG_SPEC`.

  - Some existing functions had hardcoded dependence on the `"api"` section of the configuration file. This has been removed; now no functions, except for `store_account()`, depend on the structure of the `"api"` section. As a result, `create_config` has been replaced with `_generate_config`, which automatically generates a default configuration object given a configuration spec.

  - `find_config_file` seemed to duplicate the logic in `get_available_config_paths`, so now depends on the former.

  - `get_api_section` was currently used only in `load_config`. Since `load_config` is now agnostic of the configuration structure, this function is redundant.

  - `keep_valid_options` was removed; in testing, it tended to lead to bad user experience to filter out unknown options. Typos (e.g., `prot` instead of `port`) would be pruned from the loaded configuration, making debugging difficult.

* Since there is now more than just an `api` section in the configuration, `store_account` now loads the existing configuration, modifies it as requested, and then re-writes it to disk. This avoids non-API configuration from being overwritten.

**Benefits:**

* Provides an interface for easy logging configuration for the user.

**Possible Drawbacks:**

* Currently, `create_logger` requires a loaded configuration to configure the logger. However, `load_config` creates a logger in order to log details about finding/loading the configuration! This leads to a circular dependency. Currently, this is avoided by passing `logging=False` to `load_config` on first load, to turn off any logging (since the logger has not been created yet). However, this is ugly, and bad form. If something goes wrong with the users logging configuration, it won't be logged!

* We could consider having a function `sf.configure_logger()` in order to configure the logging section of the config file within SF, similar to how `sf.store_account()` configures the API section. E.g.:

  ```python
  >>> sf.configure_logger(level="debug", logfile="sf.log")
   ```

  However, since the logger is configured on import, these settings would not take affect until the next SF import. 

**Related GitHub Issues:** n/a
