### PR TITLE
Fixes bug where negative probabilities can be calculated during Homodyne measurement in the Fock backend

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -185,6 +185,11 @@
   from the Blackbird script or `Program` if not explicitly specified.
   [(#327)](https://github.com/XanaduAI/strawberryfields/pull/327)
 
+* Fixed a bug in homodyne measurements in the Fock backend, where computed
+  probability values could occasionally include small negative values
+  due to floating point precision error.
+  [(#364)](https://github.com/XanaduAI/strawberryfields/pull/364)
+
 * Improves the Takagi decomposition, by making explicit use of the eigendecomposition of real symmetric matrices. [(#352)](https://github.com/XanaduAI/strawberryfields/pull/352)
 
 <h3>Contributors</h3>

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -764,7 +764,7 @@ class Circuit:
             probs = rho_dist.flatten().real
             probs /= np.sum(probs)
 
-            # Due to numerical error, values in the calculated probability distribution
+            # Due to floating point precision error, values in the calculated probability distribution
             # may have a very small negative value of -epsilon. The following sets
             # these small negative values to 0.
             probs[np.abs(probs) < 1e-16] = 0

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -767,7 +767,7 @@ class Circuit:
             # Due to floating point precision error, values in the calculated probability distribution
             # may have a very small negative value of -epsilon. The following sets
             # these small negative values to 0.
-            probs[np.abs(probs) < 1e-16] = 0
+            probs[np.abs(probs) < 1e-10] = 0
 
             sample_hist = np.random.multinomial(1, probs)
             sample_idx = list(sample_hist).index(1)

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -763,6 +763,12 @@ class Circuit:
             # Numpy also does not use the log probabilities
             probs = rho_dist.flatten().real
             probs /= np.sum(probs)
+
+            # Due to numerical error, values in the calculated probability distribution
+            # may have a very small negative value of -epsilon. The following sets
+            # these small negative values to 0.
+            probs[np.abs(probs) < 1e-16] = 0
+
             sample_hist = np.random.multinomial(1, probs)
             sample_idx = list(sample_hist).index(1)
             homodyne_sample = q_tensor[sample_idx]


### PR DESCRIPTION
**Context:**

To calculate homodyne measurements in the Fock backend, a Hermite polynomial probability distribution is computed. However, due to floating point precision error, values in the probability distribution may have a small negative value (e.g., `-2e-20`), causing issues when `np.random.multinomial` is subsequently called.

**Description of the Change:**

Small negative values are set to zero in the probability distribution using NumPy fancy indexing.

**Benefits:** Fixes #354 

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #354
