### PR TITLE
Bump version number for 0.13.0 release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.13.0.rc0 (release candidate)
+# Release 0.13.0 (current release)
 
 <h3>New features since last release</h3>
 
@@ -195,7 +195,7 @@ Ville Bergholm, Tom Bromley, Jack Ceroni, Theodor Isacsson, Josh Izaac, Nathan K
 Leonhard Neuhaus, Nicolás Quesada, Jeremy Swinarton, Antal Száva, Paul Tan, Zeid Zabaneh.
 
 
-# Release 0.12.1 (current release)
+# Release 0.12.1
 
 <h3>New features</h3>
 

--- a/doc/code/sf_cli.rst
+++ b/doc/code/sf_cli.rst
@@ -136,4 +136,4 @@ Code details
 .. automodapi:: strawberryfields.cli
     :no-heading:
     :no-inheritance-diagram:
-    :skip: store_account, create_config, load, RemoteEngine, Connection, ConfigurationError
+    :skip: store_account, create_config, load, RemoteEngine, Connection, ConfigurationError, ping

--- a/doc/code/sf_configuration.rst
+++ b/doc/code/sf_configuration.rst
@@ -36,6 +36,12 @@ and has the following format:
 Configuration options
 ---------------------
 
+``[api]``
+^^^^^^^^^
+
+Settings for the Xanadu cloud platform.
+
+
 **authentication_token (str)** (*required*)
     API token for authentication to the Xanadu cloud platform. This is required
     for submitting remote jobs using :class:`~.RemoteEngine`.
@@ -67,5 +73,5 @@ Functions
 
 .. automodapi:: strawberryfields.configuration
     :no-heading:
-    :skip: user_config_dir
+    :skip: user_config_dir, store_account, active_configs, reset_config, create_logger
     :no-inheritance-diagram:

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -24,7 +24,7 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
 from . import apps
 from ._version import __version__
 from .cli import ping
-from .configuration import store_account, active_configs, reset_config
+from .configuration import store_account, active_configs, reset_config, delete_config
 from .engine import Engine, LocalEngine, RemoteEngine
 from .io import load, save
 from .parameters import par_funcs as math
@@ -43,6 +43,7 @@ __all__ = [
     "store_account",
     "active_configs",
     "reset_config",
+    "delete_config",
 ]
 
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -24,13 +24,26 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
 from . import apps
 from ._version import __version__
 from .cli import ping
-from .configuration import store_account
+from .configuration import store_account, active_configs, reset_config
 from .engine import Engine, LocalEngine, RemoteEngine
 from .io import load, save
 from .parameters import par_funcs as math
 from .program import Program
 
-__all__ = ["Engine", "RemoteEngine", "Program", "version", "save", "load", "about", "cite"]
+__all__ = [
+    "Engine",
+    "RemoteEngine",
+    "Program",
+    "version",
+    "save",
+    "load",
+    "about",
+    "cite",
+    "ping",
+    "store_account",
+    "active_configs",
+    "reset_config",
+]
 
 
 #: float: numerical value of hbar for the frontend (in the implicit units of position * momentum)

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0.rc0"
+__version__ = "0.13.0"

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -227,7 +227,7 @@ class Connection:
             with io.BytesIO() as buf:
                 buf.write(response.content)
                 buf.seek(0)
-                samples = np.load(buf)
+                samples = np.load(buf, allow_pickle=False)
             return Result(samples, is_stateful=False)
         raise RequestFailedError(
             "Failed to get job result: {}".format(self._format_error_message(response))


### PR DESCRIPTION
**Description of the Change:**

* Bump version number to v0.13.0 for release

* Fix documentation build errors, by skipping functions that are being imported in multiple places

* Fix small backdoor for older versions of NumPy, by enforcing `allow_pickle=False` when loading sampled data.

**Benefits:** n/a
 
**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
