### PR TITLE
Fix printing of results object when it contains no state

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -191,7 +191,7 @@
   [(#364)](https://github.com/XanaduAI/strawberryfields/pull/364)
 
 * Fixed a bug that caused an exception when printing results with no state.
-  [(#368)](https://github.com/XanaduAI/strawberryfields/pull/368)
+  [(#367)](https://github.com/XanaduAI/strawberryfields/pull/367)
 
 * Improves the Takagi decomposition, by making explicit use of the eigendecomposition of real symmetric matrices. [(#352)](https://github.com/XanaduAI/strawberryfields/pull/352)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -190,6 +190,9 @@
   due to floating point precision error.
   [(#364)](https://github.com/XanaduAI/strawberryfields/pull/364)
 
+* Fixed a bug that caused an exception when printing results with no state.
+  [(#368)](https://github.com/XanaduAI/strawberryfields/pull/368)
+
 * Improves the Takagi decomposition, by making explicit use of the eigendecomposition of real symmetric matrices. [(#352)](https://github.com/XanaduAI/strawberryfields/pull/352)
 
 <h3>Contributors</h3>

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -230,7 +230,7 @@ class Connection:
 
                 samples = np.load(buf, allow_pickle=False)
 
-                if samples.dtype.type is np.int8:
+                if np.issubdtype(samples.dtype, np.integer):
                     # Samples represent photon numbers.
                     # Convert to int64, to avoid unexpected behaviour
                     # when users postprocess these samples.

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -227,7 +227,15 @@ class Connection:
             with io.BytesIO() as buf:
                 buf.write(response.content)
                 buf.seek(0)
-                samples = np.load(buf, allow_pickle=False).astype(np.int64)
+
+                samples = np.load(buf, allow_pickle=False)
+
+                if samples.dtype.type is np.int8:
+                    # Samples represent photon numbers.
+                    # Convert to int64, to avoid unexpected behaviour
+                    # when users postprocess these samples.
+                    samples = samples.astype(np.float64)
+
             return Result(samples, is_stateful=False)
         raise RequestFailedError(
             "Failed to get job result: {}".format(self._format_error_message(response))

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -227,7 +227,7 @@ class Connection:
             with io.BytesIO() as buf:
                 buf.write(response.content)
                 buf.seek(0)
-                samples = np.load(buf, allow_pickle=False)
+                samples = np.load(buf, allow_pickle=False).astype(np.int64)
             return Result(samples, is_stateful=False)
         raise RequestFailedError(
             "Failed to get job result: {}".format(self._format_error_message(response))

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -234,7 +234,7 @@ class Connection:
                     # Samples represent photon numbers.
                     # Convert to int64, to avoid unexpected behaviour
                     # when users postprocess these samples.
-                    samples = samples.astype(np.float64)
+                    samples = samples.astype(np.int64)
 
             return Result(samples, is_stateful=False)
         raise RequestFailedError(

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -109,6 +109,7 @@ class Result:
 
     def __str__(self):
         """String representation."""
-        return "Result: {} subsystems, state: {}\n samples: {}".format(
-            len(self.samples), self.state, self.samples
+        shots, modes = self.samples.shape
+        return "<Result: num_modes={}, shots={}, contains state={}>".format(
+            modes, shots, self._is_stateful
         )

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -107,7 +107,7 @@ class Result:
             raise AttributeError("The state is undefined for a stateless computation.")
         return self._state
 
-    def __str__(self):
+    def __repr__(self):
         """String representation."""
         shots, modes = self.samples.shape
         return "<Result: num_modes={}, shots={}, contains state={}>".format(

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -14,6 +14,7 @@
 """
 Unit tests for strawberryfields.api.result
 """
+import numpy as np
 import pytest
 
 from strawberryfields.api import Result
@@ -29,9 +30,27 @@ class TestResult:
     def test_stateless_result_raises_on_state_access(self):
         """Tests that `result.state` raises an error for a stateless result.
         """
-        result = Result([[1, 2], [3, 4]], is_stateful=False)
+        result = Result(np.array([[1, 2], [3, 4]]), is_stateful=False)
 
         with pytest.raises(
             AttributeError, match="The state is undefined for a stateless computation."
         ):
             result.state
+
+    def test_stateless_print(self, capfd):
+        """Test that printing a result object with no state provides the correct output."""
+        result = Result(np.array([[1, 2], [3, 4], [5, 6]]), is_stateful=False)
+        print(result)
+        out, err = capfd.readouterr()
+        assert "modes=2" in out
+        assert "shots=3" in out
+        assert "contains state=False" in out
+
+    def test_state_print(self, capfd):
+        """Test that printing a result object with a state provides the correct output."""
+        result = Result(np.array([[1, 2], [3, 4], [5, 6]]), is_stateful=True)
+        print(result)
+        out, err = capfd.readouterr()
+        assert "modes=2" in out
+        assert "shots=3" in out
+        assert "contains state=True" in out


### PR DESCRIPTION
**Context:** The `Results.__str__()` method attempted to print out the contained state and samples, even if the backend didn't return a state.

**Description of the Change:** Removes the printing of contained data from the class string representation.

```python
>>> results
<Result: num_modes=3, shots=1, contains state=True>
>>> results.state
<FockState: num_modes=3, cutoff=5, pure=True, hbar=2>
>>>  results.samples
array([[0, None, -0.1783017830178295]], dtype=object)
```

**Benefits:** No longer errors if the backend does not return a state object. Provides metadata about the results object, rather than the underlying state and sample data, which is a better separation of logic.

**Possible Drawbacks:** We should add more metadata to the results object, including:

- The program used to generate the result
- The backend and backend options used
- If remote, details about the submitted remote job.

However, this is significantly more work.

**Related GitHub Issues:** Fixes #356 
