### PR TITLE
Add error details for failed remote job

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 <h3>Improvements</h3>
 
+* Add details to the error message for failed remote jobs.
+  [(#370)](https://github.com/XanaduAI/strawberryfields/pull/370)
+
 <h3>Bug fixes</h3>
 
 <h3>Contributors</h3>

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -193,6 +193,7 @@ class Connection:
                 id_=response.json()["id"],
                 status=JobStatus(response.json()["status"]),
                 connection=self,
+                meta=response.json()["meta"],
             )
         raise RequestFailedError(
             "Failed to get job: {}".format(self._format_error_message(response))

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -73,7 +73,7 @@ class Job:
         status (strawberryfields.api.JobStatus): the job status
         connection (strawberryfields.api.Connection): the connection over which the
             job is managed
-        meta (dict[str, str]): auxiliary information related to job execution
+        meta (dict[str, str]): metadata related to job execution
     """
 
     def __init__(self, id_: str, status: JobStatus, connection, meta: dict = None):
@@ -123,7 +123,7 @@ class Job:
 
     @property
     def meta(self) -> dict:
-        """Returns a dictionary of auxiliary information on job execution, such as error
+        """Returns a dictionary of metadata on job execution, such as error
         details.
 
         Returns:
@@ -132,7 +132,7 @@ class Job:
         return self._meta
 
     def refresh(self):
-        """Refreshes the status and meta information of an open or queued job,
+        """Refreshes the status and metadata of an open or queued job,
         along with the job result if the job is newly completed.
         """
         if self._status.is_final:
@@ -140,7 +140,7 @@ class Job:
             return
         job_info = self._connection.get_job(self.id)
         self._status = JobStatus(job_info.status)
-        self._meta = JobStatus(job_info.meta)
+        self._meta = job_info.meta
         if self._status == JobStatus.COMPLETED:
             self._result = self._connection.get_job_result(self.id)
 

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -81,7 +81,7 @@ class Job:
         self._status = status
         self._connection = connection
         self._result = None
-        self._meta = meta if meta is not None else {}
+        self._meta = meta or {}
 
         self.log = create_logger(__name__)
 

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -141,6 +141,7 @@ class Job:
         job_info = self._connection.get_job(self.id)
         self._status = JobStatus(job_info.status)
         self._meta = job_info.meta
+        self.log.debug("Job {} metadata: {}".format(self.id, job_info.meta))
         if self._status == JobStatus.COMPLETED:
             self._result = self._connection.get_job_result(self.id)
 

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -73,14 +73,15 @@ class Job:
         status (strawberryfields.api.JobStatus): the job status
         connection (strawberryfields.api.Connection): the connection over which the
             job is managed
+        meta (dict[str, str]): auxiliary information related to job execution
     """
 
-    def __init__(self, id_: str, status: JobStatus, connection):
+    def __init__(self, id_: str, status: JobStatus, meta: dict, connection):
         self._id = id_
         self._status = status
+        self._meta = meta
         self._connection = connection
         self._result = None
-        self._meta = None
 
         self.log = create_logger(__name__)
 
@@ -122,7 +123,8 @@ class Job:
 
     @property
     def meta(self) -> dict:
-        """Returns a dictionary of meta information on job execution.
+        """Returns a dictionary of auxiliary information on job execution, such as error
+        details.
 
         Returns:
             dict[str, str]
@@ -130,7 +132,7 @@ class Job:
         return self._meta
 
     def refresh(self):
-        """Refreshes the status of an open or queued job,
+        """Refreshes the status and meta information of an open or queued job,
         along with the job result if the job is newly completed.
         """
         if self._status.is_final:

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -141,7 +141,7 @@ class Job:
         job_info = self._connection.get_job(self.id)
         self._status = JobStatus(job_info.status)
         self._meta = job_info.meta
-        self.log.debug("Job {} metadata: {}".format(self.id, job_info.meta))
+        self.log.debug("Job %s metadata: %s", self.id, job_info.meta)
         if self._status == JobStatus.COMPLETED:
             self._result = self._connection.get_job_result(self.id)
 

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -76,12 +76,12 @@ class Job:
         meta (dict[str, str]): auxiliary information related to job execution
     """
 
-    def __init__(self, id_: str, status: JobStatus, meta: dict, connection):
+    def __init__(self, id_: str, status: JobStatus, connection, meta: dict = None):
         self._id = id_
         self._status = status
-        self._meta = meta
         self._connection = connection
         self._result = None
+        self._meta = meta if meta is not None else {}
 
         self.log = create_logger(__name__)
 

--- a/strawberryfields/api/job.py
+++ b/strawberryfields/api/job.py
@@ -80,6 +80,7 @@ class Job:
         self._status = status
         self._connection = connection
         self._result = None
+        self._meta = None
 
         self.log = create_logger(__name__)
 
@@ -119,6 +120,15 @@ class Job:
             )
         return self._result
 
+    @property
+    def meta(self) -> dict:
+        """Returns a dictionary of meta information on job execution.
+
+        Returns:
+            dict[str, str]
+        """
+        return self._meta
+
     def refresh(self):
         """Refreshes the status of an open or queued job,
         along with the job result if the job is newly completed.
@@ -126,7 +136,9 @@ class Job:
         if self._status.is_final:
             self.log.warning("A %s job cannot be refreshed", self._status.value)
             return
-        self._status = JobStatus(self._connection.get_job_status(self.id))
+        job_info = self._connection.get_job(self.id)
+        self._status = JobStatus(job_info.status)
+        self._meta = JobStatus(job_info.meta)
         if self._status == JobStatus.COMPLETED:
             self._result = self._connection.get_job_result(self.id)
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -547,8 +547,8 @@ class RemoteEngine:
 
                 if job.status == "failed":
                     message = (
-                        "The remote job %s failed due to an internal "
-                        "server error. Please try again. %s" % (job.id, job.meta)
+                        "The remote job {} failed due to an internal "
+                        "server error. Please try again. {}".format(job.id, job.meta)
                     )
                     self.log.error(message)
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -548,7 +548,7 @@ class RemoteEngine:
                 if job.status == "failed":
                     message = (
                         "The remote job %s failed due to an internal "
-                        "server error. Please try again. (%s)" % (job.id, job.meta)
+                        "server error. Please try again. %s" % (job.id, job.meta)
                     )
                     self.log.error(message)
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -548,7 +548,7 @@ class RemoteEngine:
                 if job.status == "failed":
                     message = (
                         "The remote job %s failed due to an internal "
-                        "server error. Please try again." % job.id
+                        "server error. Please try again. (%s)" % (job.id, job.meta)
                     )
                     self.log.error(message)
 

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -132,16 +132,19 @@ class TestConnection:
 
     def test_get_job(self, connection, monkeypatch):
         """Tests a successful job request."""
-        id_, status = "123", JobStatus.COMPLETED
+        id_, status, meta = "123", JobStatus.COMPLETED, {"abc": "def"}
 
         monkeypatch.setattr(
-            requests, "get", mock_return(MockResponse(200, {"id": id_, "status": status.value})),
+            requests,
+            "get",
+            mock_return(MockResponse(200, {"id": id_, "status": status.value, "meta": meta})),
         )
 
         job = connection.get_job(id_)
 
         assert job.id == id_
         assert job.status == status.value
+        assert job.meta == meta
 
     def test_get_job_error(self, connection, monkeypatch):
         """Tests a failed job request."""
@@ -155,7 +158,9 @@ class TestConnection:
         id_, status = "123", JobStatus.COMPLETED
 
         monkeypatch.setattr(
-            requests, "get", mock_return(MockResponse(200, {"id": id_, "status": status.value})),
+            requests,
+            "get",
+            mock_return(MockResponse(200, {"id": id_, "status": status.value, "meta": {}})),
         )
 
         assert connection.get_job_status(id_) == status.value
@@ -237,6 +242,7 @@ class TestConnection:
         monkeypatch.setattr(requests, "get", mock_return(MockResponse(500, {})))
 
         assert not connection.ping()
+
 
 class TestConnectionIntegration:
     """Integration tests for using instances of the Connection."""

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -45,7 +45,7 @@ class MockServer:
             if self.request_count >= self.REQUESTS_BEFORE_COMPLETED
             else JobStatus.QUEUED
         )
-        return Job(id_="123", status=status, connection=None)
+        return Job(id_="123", status=status, connection=None, meta={"foo": "bar"})
 
 
 @pytest.fixture
@@ -91,6 +91,7 @@ class TestRemoteEngine:
             job.refresh()
 
         assert job.status == JobStatus.COMPLETED.value
+        assert job.meta == {"foo": "bar"}
         assert np.array_equal(job.result.samples, np.array([[1, 2], [3, 4]]))
 
         with pytest.raises(

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -35,16 +35,17 @@ class MockServer:
     def __init__(self):
         self.request_count = 0
 
-    def get_job_status(self, _id):
+    def get_job(self, _id):
         """Returns a 'queued' job status until the number of requests exceeds a defined
         threshold, beyond which a 'complete' job status is returned.
         """
         self.request_count += 1
-        return (
+        status = (
             JobStatus.COMPLETED
             if self.request_count >= self.REQUESTS_BEFORE_COMPLETED
             else JobStatus.QUEUED
         )
+        return Job(id_="123", status=status, connection=None)
 
 
 @pytest.fixture
@@ -56,7 +57,7 @@ def job_to_complete(connection, monkeypatch):
         mock_return(Job(id_="123", status=JobStatus.OPEN, connection=connection)),
     )
     server = MockServer()
-    monkeypatch.setattr(Connection, "get_job_status", server.get_job_status)
+    monkeypatch.setattr(Connection, "get_job", server.get_job)
     monkeypatch.setattr(
         Connection,
         "get_job_result",


### PR DESCRIPTION
**Context:**

Currently, a failed remote job produces a generic error message that is difficult to diagnose. The job info response from the remote platform contains a `meta` field that is currently unused, but has some information that may be useful, e.g.,

```python
{
    'error_code': 'hardware-message-error',
    'error_detail': 'The job failed because the message received from the hardware could not be understood.'
}
```

**Description of the Change:**

- Add a `meta` property to the `Job` class. In the event of job failure, this dictionary will contain an `error-code` and `error-detail`.
- Refresh the `meta` attribute (along with `status`) when `Job.refresh()` is called.
- Add the contents of `meta` to the error message for a failed job.

Example:
- Previous error message: `"The remote job 928ee53e-677a-48c0-8ba5-a0566ba3e295 failed due to an internal server error. Please try again."`
- New error message: `"The remote job 928ee53e-677a-48c0-8ba5-a0566ba3e295 failed due to an internal server error. Please try again. {'error_code': 'hardware-message-error', 'error_detail': 'The job failed because the message received from the hardware could not be understood.'}"`

**Benefits:**

The added context in a copy-pastable error message is likely to make it easier to diagnose and debug job failures.

**Possible Drawbacks:**

The new error message is slightly verbose.

**Related GitHub Issues:**

N/A