### PR TITLE
Remove traces of Python 3.5

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,13 +12,16 @@
 
 <h3>Breaking Changes</h3>
 
+* Removes support for Python 3.5.
+  [(#385)](https://github.com/XanaduAI/strawberryfields/pull/385)
+
 <h3>Bug fixes</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Shreya P. Kumar
+Theodor Isacsson, Shreya P. Kumar
 
 
 # Release 0.14.0 (current release)

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Features
 Installation
 ============
 
-Strawberry Fields requires Python version 3.5, 3.6, 3.7, or 3.8. Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
+Strawberry Fields requires Python version 3.6, 3.7, or 3.8. Installation of Strawberry Fields, as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 

--- a/doc/_static/install.html
+++ b/doc/_static/install.html
@@ -29,7 +29,7 @@
 </head>
 
 <body>
-    
+
 
 <!--Navbar-->
 <nav class="navbar navbar-expand-lg navbar-light white sticky-top">
@@ -98,7 +98,7 @@
 <div class="container my-5 py-5" id="main-column">
     <div class="text-center">
         <h1>Install Strawberry Fields</h1>
-        <p class="lead grey-text w-responsive mx-auto">Strawberry Fields supports Python 3.5 or newer.</p>
+        <p class="lead grey-text w-responsive mx-auto">Strawberry Fields supports Python 3.6 or newer.</p>
         <p class="lead grey-text w-responsive mx-auto mb-5">If you currently do not have Python 3 installed, we recommend <a href="https://www.anaconda.com/download/">Anaconda for Python 3</a>, a distributed version of Python packaged for scientific computation.</p>
     </div>
 

--- a/doc/development/development_guide.rst
+++ b/doc/development/development_guide.rst
@@ -6,15 +6,15 @@ Dependencies
 
 Strawberry Fields requires the following libraries be installed:
 
-* `Python <http://python.org/>`_ >=3.5,<3.7
+* `Python <http://python.org/>`_ >= 3.6
 
 as well as the following Python packages:
 
-* `NumPy <http://numpy.org/>`_  >=1.17.4
-* `SciPy <http://scipy.org/>`_  >=1.0.0
-* `NetworkX <http://networkx.github.io/>`_ >=2.0
-* `Blackbird <https://quantum-blackbird.readthedocs.io>`_ >=0.2.0
-* `The Walrus <https://the-walrus.readthedocs.io>`_ >=0.7.0
+* `NumPy <http://numpy.org/>`_ >= 1.17.4
+* `SciPy <http://scipy.org/>`_ >= 1.0.0
+* `NetworkX <http://networkx.github.io/>`_ >= 2.0
+* `Blackbird <https://quantum-blackbird.readthedocs.io>`_ >= 0.2.0
+* `The Walrus <https://the-walrus.readthedocs.io>`_ >= 0.7.0
 * `toml <https://pypi.org/project/toml/>`_
 * `appdirs <https://pypi.org/project/appdirs/>`_
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
**Context:**
Support for Python 3.5 is deprecated and thus shouldn't be stated anywhere in Strawberry Fields.

**Description of the Change:**
Traces of Python 3.5 is removed from `setup.py`, `README.rst`, the documentation `install.html`, and the development guide.

**Benefits:**
No mentions of Python 3.5 will be left in Strawberry Fields: the readme will display the correct version along with the development guide, and all installation files will be set to ignore this version of Python.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
