### PR TITLE
Add embedding submodule for training GBS distributions

### DIFF
--- a/strawberryfields/apps/__init__.py
+++ b/strawberryfields/apps/__init__.py
@@ -25,6 +25,7 @@ Strawberry Fields application layer.
 	sample
 	similarity
 	subgraph
+	train
 	vibronic
 """
 
@@ -35,4 +36,5 @@ import strawberryfields.apps.points
 import strawberryfields.apps.sample
 import strawberryfields.apps.similarity
 import strawberryfields.apps.subgraph
+import strawberryfields.apps.train
 import strawberryfields.apps.vibronic

--- a/strawberryfields/apps/train/__init__.py
+++ b/strawberryfields/apps/train/__init__.py
@@ -1,0 +1,11 @@
+r"""
+Tools for training variational GBS devices.
+
+.. currentmodule:: strawberryfields.apps.train
+
+.. autosummary::
+    :toctree: api
+
+    embed
+"""
+import strawberryfields.apps.train.embed

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -55,7 +55,6 @@ class ExpFeatures:
         self.m, self.d = np.shape(features)
 
     def __call__(self, params):
-        """Makes an instance of the class callable, so it can be used as a function"""
         return self.weights(params)
 
     def weights(self, params):

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -42,7 +42,7 @@ class ExpFeatures:
     >>> features = np.array([[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]])
     >>> embedding = ExpFeatures(features)
     >>> parameters = np.array([0.1, 0.2, 0.3])
-    >>> embed(parameters)
+    >>> embedding(parameters)
     [0.94176453 0.88692044 0.83527021]
 
     Args:
@@ -67,8 +67,7 @@ class ExpFeatures:
         Returns:
             np.array: weights
         """
-        d = self.d
-        if d != len(params):
+        if self.d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
@@ -84,8 +83,7 @@ class ExpFeatures:
         Returns:
             np.array: Jacobian matrix of weights with respect to parameters
         """
-        d = self.d
-        if d != len(params):
+        if self.d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
@@ -104,9 +102,9 @@ class Exp(ExpFeatures):
     **Example usage:**
 
     >>> dim = 3
-    >>> embed = Exp(dim)
+    >>> embedding = Exp(dim)
     >>> parameters = np.array([0.1, 0.2, 0.3])
-    >>> embed(parameters)
+    >>> embedding(parameters)
     [0.90483742 0.81873075 0.74081822]
 
     Args:

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -1,15 +1,15 @@
 r"""
 Submodule for embedding trainable parameters into the GBS distribution.
 
-Training algorithms for GBS distributions rely on the WAW parametrization, where W is a diagonal 
-matrix of weights and A is a symmetric matrix. Trainable parameters are embedded into the GBS 
+Training algorithms for GBS distributions rely on the WAW parametrization, where W is a diagonal
+matrix of weights and A is a symmetric matrix. Trainable parameters are embedded into the GBS
 distribution by expressing the weights as functions of the parameters.
 
-This submodule contains methods to implement such embeddings. It also provides derivatives 
-of the weights with respect to the trainable parameters. There are two main classes, each 
+This submodule contains methods to implement such embeddings. It also provides derivatives
+of the weights with respect to the trainable parameters. There are two main classes, each
 corresponding to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class
 is a simple embedding where the weights are exponentials of the trainable parameters. The
-:class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that 
+:class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that
 makes use of user-defined feature vectors."""
 
 import numpy as np

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -20,10 +20,10 @@ embedded into the GBS distribution by expressing the weights as functions of the
 
 This submodule contains methods to implement such embeddings. It also provides derivatives
 of the weights with respect to the trainable parameters. There are two main classes, each
-corresponding to a different embedding. The :class:`Exp` class
-is a simple embedding where the weights are exponentials of the trainable parameters. The
-:class:`ExpFeatures` class is a more general embedding that
-makes use of user-defined feature vectors."""
+corresponding to a different embedding. The :class:`Exp` class is a simple embedding where the
+weights are exponentials of the trainable parameters. The :class:`ExpFeatures` class is a more
+general embedding that makes use of user-defined feature vectors, which potentially provide more
+flexibility in training strategies."""
 
 import numpy as np
 
@@ -31,8 +31,8 @@ import numpy as np
 class ExpFeatures:
     r"""Exponential embedding with feature vectors.
 
-    Weights of the W matrix in the WAW parametrization are expressed as exponentials of
-    the inner product between user-specified feature vectors and trainable parameters:
+    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as exponentials
+    of the inner product between user-specified feature vectors and trainable parameters:
     :math:`w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
     the weights with respect to the parameters can be computed straightforwardly as: :math:`
     \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
@@ -52,6 +52,7 @@ class ExpFeatures:
     def __init__(self, features):
         """Initializes the class for an input matrix whose rows are feature vectors"""
         self.features = features
+        self.m, self.d = np.shape(features)
 
     def __call__(self, params):
         """Makes the class callable, so it can be used as a function"""
@@ -66,7 +67,7 @@ class ExpFeatures:
         Returns:
             np.array: weights
         """
-        d = np.shape(self.features)[1]
+        d = self.d
         if d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
@@ -83,7 +84,7 @@ class ExpFeatures:
         Returns:
             np.array: Jacobian matrix of weights with respect to parameters
         """
-        m, d = np.shape(self.features)
+        m, d = self.m, self.d
         if d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
@@ -95,9 +96,9 @@ class ExpFeatures:
 class Exp(ExpFeatures):
     r"""Simple exponential embedding.
 
-    Weights of the W matrix in the WAW parametrization are expressed as exponentials of trainable
-    parameters: :math:`w_i = \exp(-\theta_i)`. The Jacobian, which encapsulates the derivatives
-    of the weights with respect to the parameters can be computed straightforwardly as:
+    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as exponentials
+    of trainable parameters: :math:`w_i = \exp(-\theta_i)`. The Jacobian, which encapsulates the
+    derivatives of the weights with respect to the parameters can be computed straightforwardly as:
     :math:`\frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
 
     **Example usage:**
@@ -117,3 +118,9 @@ class Exp(ExpFeatures):
         """The simple exponential mapping is a special case where the matrix of feature vectors
         is the identity"""
         super().__init__(np.eye(dim))
+
+dim = 4
+params = np.zeros(dim)
+exp = Exp(dim)
+g = exp.jacobian(params)
+print(g)

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -31,7 +31,7 @@ import numpy as np
 class ExpFeatures:
     r"""Exponential embedding with feature vectors.
 
-    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as exponentials
+    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as an exponential
     of the inner product between user-specified feature vectors and trainable parameters:
     :math:`w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
     the weights with respect to the parameters can be computed straightforwardly as:
@@ -40,7 +40,7 @@ class ExpFeatures:
     **Example usage:**
 
     >>> features = np.array([[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]])
-    >>> embed = ExpFeatures(features)
+    >>> embedding = ExpFeatures(features)
     >>> parameters = np.array([0.1, 0.2, 0.3])
     >>> embed(parameters)
     [0.94176453 0.88692044 0.83527021]
@@ -96,8 +96,8 @@ class ExpFeatures:
 class Exp(ExpFeatures):
     r"""Simple exponential embedding.
 
-    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as exponentials
-    of trainable parameters: :math:`w_i = \exp(-\theta_i)`. The Jacobian, which encapsulates the
+    Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as an exponential
+    of the trainable parameters: :math:`w_i = \exp(-\theta_i)`. The Jacobian, which encapsulates the
     derivatives of the weights with respect to the parameters can be computed straightforwardly as:
     :math:`\frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
 

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -7,10 +7,10 @@ Training algorithms for GBS distributions rely on the WAW parametrization, where
 matrix of weights and A is a symmetric matrix. Trainable parameters are embedded into the GBS 
 distribution by expressing the weights as functions of the parameters. 
 
-This submodule contains methods to implement these embeddings and provides derivatives of the
-weights with respect to the trainable parameters. There are two main classes each corresponding 
-to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class is a simple 
-embedding where the weights are exponentials of the trainable parameters. The 
+This submodule contains methods to implement such embeddings. It also provides derivatives 
+of the weights with respect to the trainable parameters. There are two main classes, each 
+corresponding to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class 
+is a simple embedding where the weights are exponentials of the trainable parameters. The 
 :class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that 
 makes use of user-defined feature vectors."""
 
@@ -20,8 +20,9 @@ class ExpFeatures:
 
     Weights of the W matrix in the WAW parametrization are expressed as exponentials of
     the inner product between user-specified feature vectors and trainable parameters:
-    `:math: w_i = \exp(-f^{(i)}\cdot\theta)`. Derivatives of the weights with respect to the
-    parameters are straightforward: `:math: \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
+    `:math: w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
+    the weights with respect to the parameters can be computed straightforwardly as: `:math:
+    \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
 
     **Example:**
 
@@ -32,38 +33,36 @@ class ExpFeatures:
     [0.94176453 0.88692044 0.83527021]
 
     Args:
-        features (np.array): Matrix of feature vectors where i-th row is the i-th vector
+        features (np.array): Matrix of feature vectors where the i-th row is the i-th feature vector
     """
 
     def __init__(self, features):
-        """"""
+        """Initializes the class for an input matrix whose rows are feature vectors"""
         self.features = features
 
     def __call__(self, params):
-        """Makes the class callable so it can be used as a function"""
+        """Makes the class callable, so it can be used as a function"""
         return self.weights(params)
 
     def weights(self, params):
         r"""Computes weights as a function of input parameters.
-
         Args:
             params (np.array): trainable parameters
-
         Returns:
             np.array: weights
         """
         m, d = np.shape(self.features)
         if d != len(params):
             raise ValueError(
+                "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
         return np.exp(-self.features @ params)
 
-    def grad(self, params):
-        r"""Computes the Jacobian matrix of weights with respect to input parameters.
-
+    def jacobian(self, params):
+        r"""Computes the Jacobian matrix of weights with respect to input parameters :math:`J_{
+        ij} = \frac{\partial w_i}{\partial \theta_j}`.
         Args:
             params (np.array): trainable parameters
-
         Returns:
             np.array: Jacobian matrix of weights with respect to parameters
         """
@@ -84,12 +83,14 @@ class Exp(ExpFeatures):
     r"""Simple exponential embedding.
 
     Weights of the W matrix in the WAW parametrization are expressed as exponentials of trainable
-    parameters: `:math: w_i = \exp(-\theta_i)`. Derivatives of the weights with respect to the
-    parameters are straightforward: `:math: \frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
+    parameters: `:math: w_i = \exp(-\theta_i)`. D The Jacobian, which encapsulates the derivatives
+    of the weights with respect to the parameters can be computed straightforwardly as:
+    `:math: \frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
 
     **Example:**
 
-    >>> embed = Exp(3)
+    >>> dim = 3
+    >>> embed = Exp(dim)
     >>> params = np.array([0.1, 0.2, 0.3])
     >>> embed(params)
     [0.90483742 0.81873075 0.74081822]

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -3,7 +3,7 @@ Submodule for embedding trainable parameters into the GBS distribution.
 
 Training algorithms for GBS distributions rely on the WAW parametrization, where W is a diagonal 
 matrix of weights and A is a symmetric matrix. Trainable parameters are embedded into the GBS 
-distribution by expressing the weights as functions of the parameters. 
+distribution by expressing the weights as functions of the parameters.
 
 This submodule contains methods to implement such embeddings. It also provides derivatives 
 of the weights with respect to the trainable parameters. There are two main classes, each 
@@ -51,7 +51,7 @@ class ExpFeatures:
         Returns:
             np.array: weights
         """
-        m, d = np.shape(self.features)
+        d = np.shape(self.features)[1]
         if d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
@@ -104,3 +104,7 @@ class Exp(ExpFeatures):
         """The simple exponential mapping is a special case where the matrix of feature vectors
         is the identity"""
         super().__init__(np.eye(dim))
+
+x = np.ones((4, 5))
+
+print(np.shape(x)[1])

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -20,7 +20,7 @@ class ExpFeatures:
 
     Weights of the W matrix in the WAW parametrization are expressed as exponentials of
     the inner product between user-specified feature vectors and trainable parameters:
-    `:math: w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
+    :math:`w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
     the weights with respect to the parameters can be computed straightforwardly as: `:math:
     \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
 

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 r"""
 Submodule for embedding trainable parameters into the GBS distribution.
 
@@ -9,10 +7,12 @@ distribution by expressing the weights as functions of the parameters.
 
 This submodule contains methods to implement such embeddings. It also provides derivatives 
 of the weights with respect to the trainable parameters. There are two main classes, each 
-corresponding to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class 
-is a simple embedding where the weights are exponentials of the trainable parameters. The 
+corresponding to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class
+is a simple embedding where the weights are exponentials of the trainable parameters. The
 :class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that 
 makes use of user-defined feature vectors."""
+
+import numpy as np
 
 
 class ExpFeatures:

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -1,3 +1,16 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 r"""
 Submodule for embedding trainable parameters into the GBS distribution.
 
@@ -21,10 +34,10 @@ class ExpFeatures:
     Weights of the W matrix in the WAW parametrization are expressed as exponentials of
     the inner product between user-specified feature vectors and trainable parameters:
     :math:`w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
-    the weights with respect to the parameters can be computed straightforwardly as: `:math:
+    the weights with respect to the parameters can be computed straightforwardly as: :math:`
     \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
 
-    **Example:**
+    **Example usage:**
 
     >>> features = np.array([[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]])
     >>> embed = ExpFeatures(features)
@@ -46,8 +59,10 @@ class ExpFeatures:
 
     def weights(self, params):
         r"""Computes weights as a function of input parameters.
+        
         Args:
             params (np.array): trainable parameters
+            
         Returns:
             np.array: weights
         """
@@ -61,8 +76,10 @@ class ExpFeatures:
     def jacobian(self, params):
         r"""Computes the Jacobian matrix of weights with respect to input parameters :math:`J_{
         ij} = \frac{\partial w_i}{\partial \theta_j}`.
+
         Args:
             params (np.array): trainable parameters
+
         Returns:
             np.array: Jacobian matrix of weights with respect to parameters
         """
@@ -72,22 +89,18 @@ class ExpFeatures:
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
         w = self.weights(params)
-        dw = np.zeros((m, d))
-        for i in range(m):
-            for k in range(d):
-                dw[i, k] = -1 * self.features[i, k] * w[i]
-        return dw
+        return - self.features * w[:, np.newaxis]
 
 
 class Exp(ExpFeatures):
     r"""Simple exponential embedding.
 
     Weights of the W matrix in the WAW parametrization are expressed as exponentials of trainable
-    parameters: `:math: w_i = \exp(-\theta_i)`. D The Jacobian, which encapsulates the derivatives
+    parameters: :math:`w_i = \exp(-\theta_i)`. The Jacobian, which encapsulates the derivatives
     of the weights with respect to the parameters can be computed straightforwardly as:
-    `:math: \frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
+    :math:`\frac{d w_i}{d\theta_k} = -w_i\delta_{i,k}`.
 
-    **Example:**
+    **Example usage:**
 
     >>> dim = 3
     >>> embed = Exp(dim)
@@ -97,7 +110,7 @@ class Exp(ExpFeatures):
 
     Args:
         dim (int): Dimension of the vector of parameters, which is equal to the number of modes
-        in the GBS distribution
+            in the GBS distribution
     """
 
     def __init__(self, dim):

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -60,10 +60,10 @@ class ExpFeatures:
 
     def weights(self, params):
         r"""Computes weights as a function of input parameters.
-        
+
         Args:
             params (np.array): trainable parameters
-            
+
         Returns:
             np.array: weights
         """

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -55,7 +55,6 @@ class ExpFeatures:
         m, d = np.shape(self.features)
         if d != len(params):
             raise ValueError(
-                "Dimension of parameter vector must be equal to dimension of feature " "vectors"
             )
         return np.exp(-self.features @ params)
 
@@ -71,7 +70,7 @@ class ExpFeatures:
         m, d = np.shape(self.features)
         if d != len(params):
             raise ValueError(
-                "Dimension of parameter vector must be equal to dimension of feature " "vectors"
+                "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
         w = self.weights(params)
         dw = np.zeros((m, d))

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -34,8 +34,8 @@ class ExpFeatures:
     Weights of the :math:`W` matrix in the :math:`WAW` parametrization are expressed as exponentials
     of the inner product between user-specified feature vectors and trainable parameters:
     :math:`w_i = \exp(-f^{(i)}\cdot\theta)`. The Jacobian, which encapsulates the derivatives of
-    the weights with respect to the parameters can be computed straightforwardly as: :math:`
-    \frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
+    the weights with respect to the parameters can be computed straightforwardly as:
+    :math:`\frac{d w_i}{d\theta_k} = -f^{(i)}_k w_i`.
 
     **Example usage:**
 
@@ -55,7 +55,7 @@ class ExpFeatures:
         self.m, self.d = np.shape(features)
 
     def __call__(self, params):
-        """Makes the class callable, so it can be used as a function"""
+        """Makes an instance of the class callable, so it can be used as a function"""
         return self.weights(params)
 
     def weights(self, params):

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -1,0 +1,44 @@
+r"""
+Submodule for embedding trainable GBS parameters.
+
+Training algorithms that rely on the WAW parametrization, where W is a diagonal matrix of weights
+and A is a symmetric matrix, proceed by updating the weights using gradient descent. This process
+is facilitated when trainable parameters are embedded in the weights, i.e., when the weights
+are functions of the parameters. This ensures that the updated weights lead to valid matrices and
+provides additional flexibility in training strategies.
+
+This submodule contains methods to implement these embeddings and provides derivatives of the
+weights with respect to the trainable parameters."""
+
+
+class Exp:
+
+    def weights(self, params):
+        return np.exp(-params)
+
+    def derivative(self, params):
+        return -1*self.weights(params)
+
+
+class ExpFeatures(features):
+
+    def __init__(self):
+        self.features = features
+
+    def weights(self, params):
+        m, d = np.shape(params)
+        for i in range(m):
+            w[i] = np.exp(-np.dot(self.features[i], params[i]))
+        return w
+
+    def derivative(self, params):
+        m, d = np.shape(params)
+        w = self.weights(self, params)
+        dw = np.zeros(m, d)
+        for i in range(m):
+            for j in range(d):
+                dw[i, j] = -self.features[i, j]*w[i]
+        return dw
+
+
+

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -7,7 +7,7 @@ embedded into the GBS distribution by expressing the weights as functions of the
 
 This submodule contains methods to implement such embeddings. It also provides derivatives
 of the weights with respect to the trainable parameters. There are two main classes, each
-corresponding to a different embedding. The :class:`~strawberryfields.apps.train.embed.Exp` class
+corresponding to a different embedding. The :class:`Exp` class
 is a simple embedding where the weights are exponentials of the trainable parameters. The
 :class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that
 makes use of user-defined feature vectors."""

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -9,7 +9,7 @@ This submodule contains methods to implement such embeddings. It also provides d
 of the weights with respect to the trainable parameters. There are two main classes, each
 corresponding to a different embedding. The :class:`Exp` class
 is a simple embedding where the weights are exponentials of the trainable parameters. The
-:class:`~strawberryfields.apps.train.embed.ExpFeatures` class is a more general embedding that
+:class:`ExpFeatures` class is a more general embedding that
 makes use of user-defined feature vectors."""
 
 import numpy as np

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -104,7 +104,3 @@ class Exp(ExpFeatures):
         """The simple exponential mapping is a special case where the matrix of feature vectors
         is the identity"""
         super().__init__(np.eye(dim))
-
-x = np.ones((4, 5))
-
-print(np.shape(x)[1])

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -54,8 +54,9 @@ class ExpFeatures:
         """
         m, d = np.shape(self.features)
         if d != len(params):
-            raise ValueError("Dimension of parameter vector must be equal to dimension of feature "
-                             "vectors")
+            raise ValueError(
+                "Dimension of parameter vector must be equal to dimension of feature " "vectors"
+            )
         return np.exp(-self.features @ params)
 
     def grad(self, params):
@@ -69,13 +70,14 @@ class ExpFeatures:
         """
         m, d = np.shape(self.features)
         if d != len(params):
-            raise ValueError("Dimension of parameter vector must be equal to dimension of feature "
-                             "vectors")
+            raise ValueError(
+                "Dimension of parameter vector must be equal to dimension of feature " "vectors"
+            )
         w = self.weights(params)
         dw = np.zeros((m, d))
         for i in range(m):
             for k in range(d):
-                dw[i, k] = -1*self.features[i, k]*w[i]
+                dw[i, k] = -1 * self.features[i, k] * w[i]
         return dw
 
 
@@ -102,5 +104,3 @@ class Exp(ExpFeatures):
         """The simple exponential mapping is a special case where the matrix of feature vectors
         is the identity"""
         super().__init__(np.eye(dim))
-
-

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -15,7 +15,7 @@ r"""
 Submodule for embedding trainable parameters into the GBS distribution.
 
 Training algorithms for GBS distributions rely on the :math:`WAW` parametrization, where :math:`W`
-is a diagonal matrix of weights and :math:`A` is a symmetric matrix. Trainable parameters are 
+is a diagonal matrix of weights and :math:`A` is a symmetric matrix. Trainable parameters are
 embedded into the GBS distribution by expressing the weights as functions of the parameters.
 
 This submodule contains methods to implement such embeddings. It also provides derivatives
@@ -41,8 +41,8 @@ class ExpFeatures:
 
     >>> features = np.array([[0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]])
     >>> embed = ExpFeatures(features)
-    >>> params = np.array([0.1, 0.2, 0.3])
-    >>> embed(params)
+    >>> parameters = np.array([0.1, 0.2, 0.3])
+    >>> embed(parameters)
     [0.94176453 0.88692044 0.83527021]
 
     Args:
@@ -84,13 +84,13 @@ class ExpFeatures:
         Returns:
             np.array: Jacobian matrix of weights with respect to parameters
         """
-        m, d = self.m, self.d
+        d = self.d
         if d != len(params):
             raise ValueError(
                 "Dimension of parameter vector must be equal to dimension of feature vectors"
             )
         w = self.weights(params)
-        return - self.features * w[:, np.newaxis]
+        return -self.features * w[:, np.newaxis]
 
 
 class Exp(ExpFeatures):
@@ -105,8 +105,8 @@ class Exp(ExpFeatures):
 
     >>> dim = 3
     >>> embed = Exp(dim)
-    >>> params = np.array([0.1, 0.2, 0.3])
-    >>> embed(params)
+    >>> parameters = np.array([0.1, 0.2, 0.3])
+    >>> embed(parameters)
     [0.90483742 0.81873075 0.74081822]
 
     Args:
@@ -118,9 +118,3 @@ class Exp(ExpFeatures):
         """The simple exponential mapping is a special case where the matrix of feature vectors
         is the identity"""
         super().__init__(np.eye(dim))
-
-dim = 4
-params = np.zeros(dim)
-exp = Exp(dim)
-g = exp.jacobian(params)
-print(g)

--- a/strawberryfields/apps/train/embed.py
+++ b/strawberryfields/apps/train/embed.py
@@ -1,9 +1,9 @@
 r"""
 Submodule for embedding trainable parameters into the GBS distribution.
 
-Training algorithms for GBS distributions rely on the WAW parametrization, where W is a diagonal
-matrix of weights and A is a symmetric matrix. Trainable parameters are embedded into the GBS
-distribution by expressing the weights as functions of the parameters.
+Training algorithms for GBS distributions rely on the :math:`WAW` parametrization, where :math:`W`
+is a diagonal matrix of weights and :math:`A` is a symmetric matrix. Trainable parameters are 
+embedded into the GBS distribution by expressing the weights as functions of the parameters.
 
 This submodule contains methods to implement such embeddings. It also provides derivatives
 of the weights with respect to the trainable parameters. There are two main classes, each

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -146,7 +146,7 @@ class TestJacobianExp:
         params = np.zeros(dim)
         exp = embed.Exp(dim)
         g = exp.jacobian(params)
-        assert np.allclose(-1*np.eye(dim), g)
+        assert np.allclose(-1 * np.eye(dim), g)
 
     def test_jacobian_predefined(self, dim):
         """Tests that the jacobian is computed correctly for pre-defined features and parameters"""

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -68,6 +68,17 @@ class TestExpFeatures:
             expf = embed.ExpFeatures(features)
             expf(np.zeros(dim))
 
+    @pytest.mark.parametrize("m", range(2, 5))
+    def test_exp_features_integration(self, dim, m):
+        """Test that ``strawberryfields.apps.train.embed.ExpFeatures`` outputs weights and jacobian
+        of the correct shape"""
+        features = np.ones((m, dim))
+        expf = embed.ExpFeatures(features)
+        features = np.ones(dim)
+
+        assert expf(features).shape == (m,)
+        assert expf.jacobian(features).shape == (m, dim)
+
     def test_zero_params(self, dim):
         """Tests that weights are equal to one when parameters are zero"""
         features = np.ones((dim, dim))
@@ -156,3 +167,12 @@ class TestJacobianExp:
         exp = embed.Exp(dim)
         g = exp.jacobian(ps[k])
         assert np.allclose(g, jacobian[k])
+
+    def test_jacobian_identity(self, dim):
+        """Tests that the jacobian is computed correctly compared to a general calculation using an
+        identity matrix of feature vectors"""
+        k = dim - 2
+        features = np.eye(dim)
+        expf = embed.ExpFeatures(features)
+        exp = embed.Exp(dim)
+        assert np.allclose(expf.jacobian(ps[k]), exp.jacobian(ps[k]))

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -24,7 +24,7 @@ feats = [
     [[0.1, 0.2, 0.3], [0.3, 0.1, 0.2], [0.2, 0.3, 0.1]],
     [[0.1, 0.2, 0.3, 0.4], [0.4, 0.1, 0.2, 0.3], [0.3, 0.4, 0.1, 0.2], [0.2, 0.3, 0.4, 0.1]],
 ]
-feats = [np.array(f) for f in feats]
+feats = np.array([np.array(f) for f in feats])
 
 ps = [[1.0, 2.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]]
 ps = np.array([np.array(p) for p in ps])
@@ -78,7 +78,7 @@ class TestExpFeatures:
         k = dim - 2
         features = feats[k]
         expf = embed.ExpFeatures(features)
-        assert (expf(ps[k]) - weights_f[k]).all() == 0
+        assert np.allclose(expf(ps[k]), weights_f[k])
 
 
 @pytest.mark.parametrize("dim", range(2, 5))
@@ -94,12 +94,13 @@ class TestJacobianExpFeatures:
             expf(np.zeros(dim))
 
     def test_jacobian_zero_params(self, dim):
-        """Tests that the jacobian is equal to negative identity when parameters are zero"""
+        """Tests that the jacobian is equal to a matrix with -1 in all entries when parameters are
+        zero"""
         features = np.ones((dim, dim))
         params = np.zeros(dim)
         expf = embed.ExpFeatures(features)
         g = expf.jacobian(params)
-        assert (-np.ones((dim, dim)) - g).all() == 0
+        assert np.allclose(-np.ones((dim, dim)), g)
 
     def test_jacobian_predefined(self, dim):
         """Tests that the jacobian is computed correctly for pre-defined features and parameters"""
@@ -107,7 +108,7 @@ class TestJacobianExpFeatures:
         features = feats[k]
         expf = embed.ExpFeatures(features)
         g = expf.jacobian(ps[k])
-        assert (g - jacobian_f[k]).all() == 0
+        assert np.allclose(g, jacobian_f[k])
 
 
 @pytest.mark.parametrize("dim", range(2, 5))
@@ -118,13 +119,13 @@ class TestExp:
         """Tests that weights are equal to one when parameters are zero"""
         exp = embed.Exp(dim)
         params = np.zeros(dim)
-        assert (exp(params) - np.ones(dim)).all() == 0
+        assert np.allclose(exp(params), np.ones(dim))
 
     def test_predefined(self, dim):
         """Tests that weights are computed correctly for pre-defined features and parameters"""
         k = dim - 2
         exp = embed.Exp(dim)
-        assert (exp(ps[k]) - weights[k]).all() == 0
+        assert np.allclose(exp(ps[k]), weights[k])
 
     def test_identity(self, dim):
         """Tests that weights are computed correctly compared to a general calculation using an
@@ -133,7 +134,7 @@ class TestExp:
         features = np.eye(dim)
         expf = embed.ExpFeatures(features)
         exp = embed.Exp(dim)
-        assert (expf(ps[k]) - exp(ps[k])).all() == 0
+        assert np.allclose(expf(ps[k]), exp(ps[k]))
 
 
 @pytest.mark.parametrize("dim", range(2, 5))
@@ -145,11 +146,11 @@ class TestJacobianExp:
         params = np.zeros(dim)
         exp = embed.Exp(dim)
         g = exp.jacobian(params)
-        assert (-np.ones((dim, dim)) - g).all() == 0
+        assert np.allclose(-1*np.eye(dim), g)
 
     def test_jacobian_predefined(self, dim):
         """Tests that the jacobian is computed correctly for pre-defined features and parameters"""
         k = dim - 2
         exp = embed.Exp(dim)
         g = exp.jacobian(ps[k])
-        assert (g - jacobian[k]).all() == 0
+        assert np.allclose(g, jacobian[k])

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -19,6 +19,8 @@ import numpy as np
 import pytest
 from strawberryfields.apps.train import embed
 
+pytestmark = pytest.mark.apps
+
 feats = [
     [[0.1, 0.2], [0.2, 0.1]],
     [[0.1, 0.2, 0.3], [0.3, 0.1, 0.2], [0.2, 0.3, 0.1]],

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -69,15 +69,15 @@ class TestExpFeatures:
             expf(np.zeros(dim))
 
     @pytest.mark.parametrize("m", range(2, 5))
-    def test_exp_features_integration(self, dim, m):
-        """Test that ``strawberryfields.apps.train.embed.ExpFeatures`` outputs weights and jacobian
-        of the correct shape"""
+    def test_exp_features_shape(self, dim, m):
+        """Tests that the weights and jacobian have the correct shape for a range of different 
+        sizes for the input features matrix"""
         features = np.ones((m, dim))
         expf = embed.ExpFeatures(features)
-        features = np.ones(dim)
+        params = np.ones(dim)
 
-        assert expf(features).shape == (m,)
-        assert expf.jacobian(features).shape == (m, dim)
+        assert expf(params).shape == (m,)
+        assert expf.jacobian(params).shape == (m, dim)
 
     def test_zero_params(self, dim):
         """Tests that weights are equal to one when parameters are zero"""

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2020 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-Unit tests for strawberryfields.apps.clique
+Unit tests for strawberryfields.apps.train.embed
 """
 # pylint: disable=no-self-use,unused-argument
 import numpy as np
@@ -24,7 +24,7 @@ feats = [
     [[0.1, 0.2, 0.3], [0.3, 0.1, 0.2], [0.2, 0.3, 0.1]],
     [[0.1, 0.2, 0.3, 0.4], [0.4, 0.1, 0.2, 0.3], [0.3, 0.4, 0.1, 0.2], [0.2, 0.3, 0.4, 0.1]],
 ]
-feats = np.array([np.array(f) for f in feats])
+feats = [np.array(f) for f in feats]
 
 ps = [[1.0, 2.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]]
 ps = np.array([np.array(p) for p in ps])
@@ -56,7 +56,7 @@ for i in range(3):
 
 @pytest.mark.parametrize("dim", range(2, 5))
 class TestExpFeatures:
-    """Tests for the callable class ``strawberryfields.apps.train.embed.ExpFeatures``"""
+    """Tests for the class ``strawberryfields.apps.train.embed.ExpFeatures``"""
 
     def test_invalid_dim(self, dim):
         """Tests that a warning is issued if the feature vectors do not have the correct
@@ -71,7 +71,7 @@ class TestExpFeatures:
         features = np.ones((dim, dim))
         expf = embed.ExpFeatures(features)
         params = np.zeros(dim)
-        assert (expf(params) - np.ones(dim)).all() == 0
+        assert np.allclose(expf(params), np.ones(dim))
 
     def test_predefined(self, dim):
         """Tests that weights are computed correctly for pre-defined features and parameters"""

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -52,8 +52,8 @@ jacobian = np.array([np.zeros((d, d)) for d in range(2, 5)])
 for i in range(3):
     jacobian[i] = -np.diag(weights[i])
     for j in range(i + 2):
-        for k in range(i + 2):
-            jacobian_f[i][j, k] = -feats[i][j, k] * weights_f[i][j]
+        for m in range(i + 2):
+            jacobian_f[i][j, m] = -feats[i][j, m] * weights_f[i][j]
 
 
 @pytest.mark.parametrize("dim", range(2, 5))

--- a/tests/apps/test_embed.py
+++ b/tests/apps/test_embed.py
@@ -1,0 +1,95 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Unit tests for strawberryfields.apps.clique
+"""
+# pylint: disable=no-self-use,unused-argument
+import functools
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from strawberryfields.apps.train import embed
+
+pytestmark = pytest.mark.apps
+
+feats = [[[0.1, 0.2], [0.2, 0.1]], [[0.1, 0.2, 0.3], [0.3, 0.1, 0.2], [0.2, 0.3, 0.1]],
+         [[0.1, 0.2, 0.3, 0.4], [0.4, 0.1, 0.2, 0.3], [0.3, 0.4, 0.1, 0.2], [0.2, 0.3, 0.4, 0.1]]]
+feats = np.array([np.array(f) for f in feats])
+
+ps = [[1.0, 2.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]]
+ps = np.array([np.array(p) for p in ps])
+
+weights_f = np.array([np.exp(-feats[i] @ ps[i]) for i in range(3)])
+weights = np.array([np.exp(-ps[i]) for i in range(3)])
+
+
+@pytest.mark.parametrize("dim", range(2, 5))
+class TestExpFeatures:
+    """Tests for the class ``strawberryfields.apps.train.embed.ExpFeatures``"""
+
+    def test_zero_params(self, dim):
+        """Tests that weights are equal to one when parameters are zero"""
+        features = np.ones((dim, dim))
+        expf = embed.ExpFeatures(features)
+        params = np.zeros(dim)
+        assert (expf(params) - np.ones(dim)).all() == 0
+
+    def test_inf_params(self, dim):
+        """Tests that weights are equal to zero when parameters are infinity"""
+        features = np.ones((dim, dim))
+        expf = embed.ExpFeatures(features)
+        params = np.array([float("Inf") for _ in range(dim)])
+        assert (expf(params) - np.zeros(dim)).all() == 0
+
+    def test_predefined(self, dim):
+        """Tests that weights are computed correctly for pre-defined features and parameters"""
+        k = dim - 2
+        features = feats[k]
+        expf = embed.ExpFeatures(features)
+        assert (expf(ps[k]) - weights_f[k]).all() == 0
+
+
+@pytest.mark.parametrize("dim", range(2, 5))
+class TestExp:
+    """Tests for the class ``strawberryfields.apps.train.embed.Exp``"""
+
+    def test_zero_params(self, dim):
+        """Tests that weights are equal to one when parameters are zero"""
+        exp = embed.Exp(dim)
+        params = np.zeros(dim)
+        assert (exp(params) - np.ones(dim)).all() == 0
+
+    def test_inf_params(self, dim):
+        """Tests that weights are equal to zero when parameters are infinity"""
+        exp = embed.Exp(dim)
+        params = np.array([float("Inf") for _ in range(dim)])
+        assert (exp(params) - np.zeros(dim)).all() == 0
+
+    def test_predefined(self, dim):
+        """Tests that weights are computed correctly for pre-defined features and parameters"""
+        k = dim - 2
+        exp = embed.Exp(dim)
+        assert (exp(ps[k]) - weights[k]).all() == 0
+
+    def test_identity(self, dim):
+        """Tests that weights are computed correctly compared to a general calculation using an
+        identity matrix of feature vectors"""
+        k = dim - 2
+        features = np.eye(dim)
+        expf = embed.ExpFeatures(features)
+        exp = embed.Exp(dim)
+        assert (expf(ps[k]) - exp(ps[k])).all() == 0
+


### PR DESCRIPTION
This PR adds a submodule for embedding trainable parameters for GBS distributions. It is part of a new `train` module in the apps layer dedicated to training and optimizing GBS distributions. 

The core functionality is the ability to express GBS parameters (weights) as a function of trainable parameters. This includes calculating derivatives of weights with respect to the parameters, which will be required for gradient-based optimization