### PR TITLE
Adds the Parity Operator for States in the Gaussian Backend (WIP)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,8 @@
   [(#389)](https://github.com/XanaduAI/strawberryfields/pull/389)
 
 * Adds `parity_expectation` method as an instance of `diagonal_expectation` for
-  the `BaseFockState` class, which returns the expectation value of the parity operator,
+  the `BaseFockState` class, and its own function for `BaseGaussianState`. 
+  This returns the expectation value of the parity operator,
   defined as (-1)^N.
   [(#389)](https://github.com/XanaduAI/strawberryfields/pull/389) 
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 <h3>New features since last release</h3>
 
-* Adds `diaongal_expectation` method for the `BaseFockState` class, which returns
+* Adds `diagonal_expectation` method for the `BaseFockState` class, which returns
   the expectation value of any operator that is diagonal in the number basis.
   [(#389)](https://github.com/XanaduAI/strawberryfields/pull/389)
 
-* Adds `parity_expectation` method as an instance of `diaongal_expectation` for 
-  the `BaseFockState` class, which returns the expectation value of the parity operator, 
+* Adds `parity_expectation` method as an instance of `diagonal_expectation` for 
+  the `BaseFockState` class, and its own function for `BaseGaussianState`, 
+  which returns the expectation value of the parity operator, 
   defined as (-1)^N.
   [(#389)](https://github.com/XanaduAI/strawberryfields/pull/389) 
 
@@ -25,13 +26,16 @@
 
 <h3>Breaking Changes</h3>
 
+* Removes support for Python 3.5.
+  [(#385)](https://github.com/XanaduAI/strawberryfields/pull/385)
+
 <h3>Bug fixes</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Jack Ceroni, Shreya P. Kumar
+Jack Ceroni, Theodor Isacsson, Shreya P. Kumar
 
 
 # Release 0.14.0 (current release)

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1257,8 +1257,8 @@ class BaseGaussianState(BaseState):
         if len(modes) != len(set(modes)):
             raise ValueError("There can be no duplicates in the modes specified.")
 
-        mu = self._mu
-        cov = self._cov
+        mu = self.means()
+        cov = self.cov()
         num = np.exp(-(0.5) * (mu @ (np.linalg.inv(cov) @ mu)))
         parity = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1259,8 +1259,8 @@ class BaseGaussianState(BaseState):
 
         mu = self._mu
         cov = self._cov
-        new = mu @ (np.linalg.inv(cov) @ mu)
-        num = np.exp(-(0.5) * new)
+        number = mu @ (np.linalg.inv(cov) @ mu)
+        num = np.exp(-(0.5) * number)
         new_num = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 
         return new_num

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1259,8 +1259,8 @@ class BaseGaussianState(BaseState):
 
         mu = self._mu
         cov = self._cov
-        number = mu @ (np.linalg.inv(cov) @ mu)
-        num = np.exp(-(0.5) * number)
+        
+        num = np.exp(-(0.5) * (mu @ (np.linalg.inv(cov) @ mu)) )
         parity = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 
         return parity

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1263,7 +1263,7 @@ class BaseGaussianState(BaseState):
         num = np.exp(-(0.5) * number)
         new_num = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 
-        return new_num
+        return parity
 
     @abc.abstractmethod
     def reduced_dm(self, modes, **kwargs):

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -25,9 +25,11 @@ from scipy.linalg import block_diag
 from scipy.stats import multivariate_normal
 from scipy.special import factorial
 from scipy.integrate import simps
+
 from thewalrus.quantum import photon_number_mean, photon_number_covar
 
 import strawberryfields as sf
+
 from .shared_ops import rotation_matrix as _R
 from .shared_ops import changebasis
 
@@ -1249,6 +1251,19 @@ class BaseGaussianState(BaseState):
         raise ValueError(
             "The number_expectation method only supports one or two modes for Gaussian states."
         )
+
+    def parity_expectation(self, modes):
+        """Calculates the expectation value of a product of parity operators acting on given modes"""
+        if len(modes) != len(set(modes)):
+            raise ValueError("There can be no duplicates in the modes specified.")
+
+        mu = self._mu
+        cov = self._cov
+        new = mu @ (np.linalg.inv(cov) @ mu)
+        num = np.exp(-(0.5) * new)
+        new_num = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
+
+        return new_num
 
     @abc.abstractmethod
     def reduced_dm(self, modes, **kwargs):

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -367,7 +367,7 @@ class BaseState(abc.ABC):
         .. warning:: This method only supports at most two modes in the Gaussian backend.
         """
         raise NotImplementedError
-        
+
     def parity_expectation(self, modes):
         """Calculates the expectation value of a product of parity operators acting on given modes"""
         raise NotImplementedError

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1259,8 +1259,7 @@ class BaseGaussianState(BaseState):
 
         mu = self._mu
         cov = self._cov
-        
-        num = np.exp(-(0.5) * (mu @ (np.linalg.inv(cov) @ mu)) )
+        num = np.exp(-(0.5) * (mu @ (np.linalg.inv(cov) @ mu)))
         parity = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 
         return parity

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -367,6 +367,10 @@ class BaseState(abc.ABC):
         .. warning:: This method only supports at most two modes in the Gaussian backend.
         """
         raise NotImplementedError
+        
+    def parity_expectation(self, modes):
+        """Calculates the expectation value of a product of parity operators acting on given modes"""
+        raise NotImplementedError
 
     def p_quad_values(self, mode, xvec, pvec):
 
@@ -923,7 +927,6 @@ class BaseFockState(BaseState):
         return self.diagonal_expectation(modes, values)
 
     def parity_expectation(self, modes):
-        """Calculates the expectation value of a product of parity operators acting on given modes"""
         cutoff = self._cutoff
         values = (-1) ** np.arange(cutoff)
         return self.diagonal_expectation(modes, values)
@@ -1253,7 +1256,6 @@ class BaseGaussianState(BaseState):
         )
 
     def parity_expectation(self, modes):
-        """Calculates the expectation value of a product of parity operators acting on given modes"""
         if len(modes) != len(set(modes)):
             raise ValueError("There can be no duplicates in the modes specified.")
 

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1261,7 +1261,7 @@ class BaseGaussianState(BaseState):
         cov = self._cov
         number = mu @ (np.linalg.inv(cov) @ mu)
         num = np.exp(-(0.5) * number)
-        new_num = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
+        parity = ((self.hbar / 2) ** len(modes)) * num / (np.sqrt(np.linalg.det(cov)))
 
         return parity
 

--- a/tests/backend/test_states.py
+++ b/tests/backend/test_states.py
@@ -408,6 +408,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_parity_fock(self, setup_backend, tol, batch_size):
+        """Tests the parity operator for an even superposition of the first two number states"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(2)
@@ -423,6 +424,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_two_mode_fock(self, setup_backend, tol, batch_size):
+        """Tests the product of parity operators for two number states"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(2)
@@ -437,6 +439,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_coherent(self, setup_backend, tol, batch_size):
+        """Tests the parity operator for a coherent state"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(1)
@@ -451,6 +454,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_squeezed(self, setup_backend, tol, batch_size):
+        """Tests the parity operator for a squeezed state"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(1)
@@ -464,6 +468,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_two_mode_squeezed(self, setup_backend, tol, batch_size):
+        """Tests the parity operator for a two-mode squeezed state"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(2)
@@ -480,6 +485,7 @@ class TestParityExpectation:
 
     @pytest.mark.backends("fock", "tf")
     def test_thermal(self, setup_backend, tol, batch_size):
+        """Tests the parity operator for a thermal state"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
         backend = setup_backend(1)

--- a/tests/backend/test_states.py
+++ b/tests/backend/test_states.py
@@ -112,9 +112,7 @@ class TestBaseStateMeanPhotonNumber:
         mean_photon, var = state.mean_photon(0)
 
         assert np.allclose(mean_photon, np.sinh(r) ** 2, atol=tol, rtol=0)
-        assert np.allclose(
-            var, 2 * (np.sinh(r) ** 2 + np.sinh(r) ** 4), atol=tol, rtol=0
-        )
+        assert np.allclose(var, 2 * (np.sinh(r) ** 2 + np.sinh(r) ** 4), atol=tol, rtol=0)
 
     def test_mean_photon_displaced_squeezed(self, setup_backend, tol, batch_size):
         """Test that E(n) = sinh^2(r)+|a|^2 for a displaced squeezed state"""
@@ -304,9 +302,7 @@ class TestNumberExpectation:
         assert np.allclose(state.number_expectation([0]), 0.0, atol=tol, rtol=0)
         assert np.allclose(state.number_expectation([1]), 0.0, atol=tol, rtol=0)
 
-    def test_number_expectation_displaced_squeezed(
-        self, setup_backend, tol, batch_size
-    ):
+    def test_number_expectation_displaced_squeezed(self, setup_backend, tol, batch_size):
         """Tests the expectation value of photon numbers when there is no correlation"""
         if batch_size is not None:
             pytest.skip("Does not support batch mode")
@@ -331,9 +327,7 @@ class TestNumberExpectation:
         """Tests that the correct exception is raised for repeated modes"""
         backend = setup_backend(2)
         state = backend.state()
-        with pytest.raises(
-            ValueError, match="There can be no duplicates in the modes specified."
-        ):
+        with pytest.raises(ValueError, match="There can be no duplicates in the modes specified."):
             state.number_expectation([0, 0])
 
     @pytest.mark.backends("gaussian")
@@ -360,9 +354,7 @@ class TestNumberExpectation:
         backend.beamsplitter(np.sqrt(0.5), -np.sqrt(0.5), 0, 2)
         state = backend.state()
         nbar = np.sinh(r) ** 2
-        assert np.allclose(
-            state.number_expectation([2, 0]), 2 * nbar ** 2 + nbar, atol=tol, rtol=0
-        )
+        assert np.allclose(state.number_expectation([2, 0]), 2 * nbar ** 2 + nbar, atol=tol, rtol=0)
         assert np.allclose(state.number_expectation([0]), nbar, atol=tol, rtol=0)
         assert np.allclose(state.number_expectation([2]), nbar, atol=tol, rtol=0)
 
@@ -385,27 +377,17 @@ class TestNumberExpectation:
         state = backend.state()
         nbar = np.sinh(r) ** 2
         assert np.allclose(
-            state.number_expectation([0, 1, 2, 3]),
-            (2 * nbar ** 2 + nbar) ** 2,
-            atol=tol,
-            rtol=0,
+            state.number_expectation([0, 1, 2, 3]), (2 * nbar ** 2 + nbar) ** 2, atol=tol, rtol=0,
         )
         assert np.allclose(
-            state.number_expectation([0, 1, 3]),
-            nbar * (2 * nbar ** 2 + nbar),
-            atol=tol,
-            rtol=0,
+            state.number_expectation([0, 1, 3]), nbar * (2 * nbar ** 2 + nbar), atol=tol, rtol=0,
         )
         assert np.allclose(
-            state.number_expectation([3, 1, 2]),
-            nbar * (2 * nbar ** 2 + nbar),
-            atol=tol,
-            rtol=0,
+            state.number_expectation([3, 1, 2]), nbar * (2 * nbar ** 2 + nbar), atol=tol, rtol=0,
         )
 
 
 class TestParityExpectation:
-
     @pytest.mark.backends("fock", "tf")
     def test_parity_fock(self, setup_backend, tol, batch_size):
         """Tests the parity operator for an even superposition of the first two number states"""
@@ -437,7 +419,6 @@ class TestParityExpectation:
 
         assert np.allclose(state.parity_expectation([0, 1]), 1, atol=tol, rtol=0)
 
-    @pytest.mark.backends("fock", "tf")
     def test_coherent(self, setup_backend, tol, batch_size):
         """Tests the parity operator for a coherent state"""
         if batch_size is not None:
@@ -449,10 +430,9 @@ class TestParityExpectation:
         state = backend.state()
 
         assert np.allclose(
-            state.parity_expectation([0]), np.exp(-2 * (np.abs(alpha)**2)), atol=tol, rtol=0
+            state.parity_expectation([0]), np.exp(-2 * (np.abs(alpha) ** 2)), atol=tol, rtol=0
         )
 
-    @pytest.mark.backends("fock", "tf")
     def test_squeezed(self, setup_backend, tol, batch_size):
         """Tests the parity operator for a squeezed state"""
         if batch_size is not None:
@@ -466,7 +446,6 @@ class TestParityExpectation:
 
         assert np.allclose(state.parity_expectation([0]), 1, atol=tol, rtol=0)
 
-    @pytest.mark.backends("fock", "tf")
     def test_two_mode_squeezed(self, setup_backend, tol, batch_size):
         """Tests the parity operator for a two-mode squeezed state"""
         if batch_size is not None:
@@ -494,9 +473,7 @@ class TestParityExpectation:
         backend.prepare_thermal_state(m, 0)
         state = backend.state()
 
-        assert np.allclose(
-            state.parity_expectation([0]), (1 / ((2 * m) + 1)), atol=tol, rtol=0
-        )
+        assert np.allclose(state.parity_expectation([0]), (1 / ((2 * m) + 1)), atol=tol, rtol=0)
 
 
 class TestFidelities:
@@ -529,9 +506,7 @@ class TestFidelities:
         state = backend.state()
 
         if isinstance(backend, backends.BaseFock):
-            in_state = utils.squeezed_state(
-                r, phi, basis="fock", fock_dim=cutoff, hbar=hbar
-            )
+            in_state = utils.squeezed_state(r, phi, basis="fock", fock_dim=cutoff, hbar=hbar)
         else:
             in_state = utils.squeezed_state(r, phi, basis="gaussian", hbar=hbar)
 
@@ -550,9 +525,7 @@ class TestFidelities:
                 a, r, phi, basis="fock", fock_dim=cutoff, hbar=hbar
             )
         else:
-            in_state = utils.displaced_squeezed_state(
-                a, r, phi, basis="gaussian", hbar=hbar
-            )
+            in_state = utils.displaced_squeezed_state(a, r, phi, basis="gaussian", hbar=hbar)
 
         assert np.allclose(state.fidelity(in_state, 0), 1, atol=tol, rtol=0)
         assert np.allclose(state.fidelity(in_state, 1), 1, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**

https://github.com/XanaduAI/strawberryfields/issues/386

**Description of the Change:**

Adds the parity expectation value function to StrawberryFields for Gaussian backend states (previously only implemented for states in the Fock backend).

**Benefits:**

Parity expectations will now work for any state in any backend.

**Possible Drawbacks:**

None

**Related GitHub Issues:**

https://github.com/XanaduAI/strawberryfields/issues/386
