### PR TITLE
Add a function to qchem for computing state probability

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,10 +8,13 @@
 
 * Adds the `apps.qchem.dynamics` module for simulating vibrational quantum dynamics in molecules.
   The `dynamics.evolution()` function provides a custom operation that encodes the input chemical
-  information for use in a Strawberry Fields `Program`. The `sample_fock()` function allows for
-  generation of samples from an input Fock state.
+  information for use in a Strawberry Fields `Program`. The `dynamics.sample_fock()` function allows
+  for generation of samples from an input Fock state. The probability of an excited state can
+  then be estimated with the `dynamics.prob()` function, which calculates the relative frequency
+  of the excited state among the generated samples. 
   [(#402)](https://github.com/XanaduAI/strawberryfields/pull/402)
   [(#411)](https://github.com/XanaduAI/strawberryfields/pull/411)
+  [(#419)](https://github.com/XanaduAI/strawberryfields/pull/419)
 
 * The `GaussianState` returned from simulations using the Gaussian backend
   now has feature parity with the `FockState` object returned from the Fock backends.
@@ -64,7 +67,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jack Ceroni, Theodor Isacsson, Josh Izaac, Shreya P. Kumar, Nicolás Quesada
+Juan Miguel Arrazola, Tom Bromley, Jack Ceroni, Aroosa Ijaz, Theodor Isacsson, Josh Izaac, Soran
+Jahangiri, Shreya P. Kumar, Nicolás Quesada
 
 
 

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -222,6 +222,7 @@ def prob(samples: list, excited_state: list) -> float:
     r"""Generate probability of observing a Fock state.
 
     **Example usage:**
+
     >>> excited_state = [0, 2]
     >>> samples = [[0, 2], [1, 1], [0, 2], [2, 0], [1, 1], [0, 2], [1, 1], [1, 1], [1, 1], [0, 2]]
     >>> prob(samples, excited_state)

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -69,6 +69,9 @@ This module contains functions for implementing this algorithm.
 
 - The function :func:`~.sample_fock` generates samples for simulating vibrational quantum dynamics
   in molecules with a Fock input state.
+
+- The function :func:`~.prob` computes the probability of observing a desired excitation in the
+  generated samples.
 """
 import numpy as np
 from scipy.constants import c, pi
@@ -212,3 +215,35 @@ def sample_fock(
         s.append(eng.run(prog).samples[0].tolist())
 
     return s
+
+
+def prob(samples: list, excited_state: list) -> float:
+
+    r"""Generate probability of observing a Fock state.
+
+    **Example usage:**
+    >>> excited_state = [0, 2]
+    >>> samples = [[0, 2], [1, 1], [0, 2], [2, 0], [1, 1], [0, 2], [1, 1], [1, 1], [1, 1], [0, 2]]
+    >>> prob(samples, excited_state)
+    0.4
+
+    Args:
+        samples list[list[int]]: a list of samples
+        excited_state (list): a Fock state
+
+    Returns:
+        float: probability of observing a Fock state in the given samples
+    """
+    if len(samples) == 0:
+        raise ValueError("The samples list must not be empty")
+
+    if len(excited_state) == 0:
+        raise ValueError("The excited state list must not be empty")
+
+    if not len(excited_state) == len(samples[0]):
+        raise ValueError("The number of modes in the samples and the excited state must be equal")
+
+    if np.any(np.array(excited_state) < 0):
+        raise ValueError("The excited state must not contain negative values")
+
+    return samples.count(excited_state) / len(samples)

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -226,9 +226,9 @@ def prob(samples: list, excited_state: list) -> float:
     **Example usage:**
 
     >>> excited_state = [0, 2]
-    >>> samples = [[0, 2], [1, 1], [0, 2], [2, 0], [1, 1], [0, 2], [1, 1], [1, 1], [1, 1], [0, 2]]
+    >>> samples = [[0, 2], [1, 1], [0, 2], [2, 0], [1, 1], [0, 2], [1, 1], [1, 1], [1, 1]]
     >>> prob(samples, excited_state)
-    0.4
+    0.3333333333333333
 
     Args:
         samples list[list[int]]: a list of samples

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -218,7 +218,6 @@ def sample_fock(
 
 
 def prob(samples: list, excited_state: list) -> float:
-
     r"""Generate probability of observing a Fock state.
 
     **Example usage:**

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -218,7 +218,10 @@ def sample_fock(
 
 
 def prob(samples: list, excited_state: list) -> float:
-    r"""Generate probability of observing a Fock state.
+    r"""Estimate probability of observing an excited state.
+    
+    The probability is estimated by calculating the relative frequency of the excited
+    state among the samples.
 
     **Example usage:**
 

--- a/strawberryfields/apps/qchem/dynamics.py
+++ b/strawberryfields/apps/qchem/dynamics.py
@@ -219,7 +219,7 @@ def sample_fock(
 
 def prob(samples: list, excited_state: list) -> float:
     r"""Estimate probability of observing an excited state.
-    
+
     The probability is estimated by calculating the relative frequency of the excited
     state among the samples.
 

--- a/tests/apps/qchem/test_dynamics.py
+++ b/tests/apps/qchem/test_dynamics.py
@@ -312,8 +312,8 @@ class TestProb:
             dynamics.prob(samples, [])
 
     def test_n_modes(self, e):
-        """Test if function raises a ``ValueError`` when the number of modes in the samples and the
-        state are different."""
+        """Test if function raises a ``ValueError`` when the number of modes in the samples and
+        the state are different."""
         with pytest.raises(
             ValueError, match="The number of modes in the samples and the excited state must be"
         ):


### PR DESCRIPTION
This PR adds the function `prob` to `sf.apps.qchem.dynamics` to compute the probability of observing a desired excitation in a list of samples.
