### PR TITLE
Reverting TFBackend import & TheWalrus rc in docs requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,5 +16,5 @@ sphinx-gallery==0.5.0
 sphinxcontrib-bibtex==0.4.2
 tensorflow-tensorboard==0.1.8
 tensorflow==2.0.1
-http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.13.0.dev0+20200527003218-cp36-cp36m-manylinux2010_x86_64.whl
+thewalrus>=0.13.0rc1
 toml

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -30,7 +30,7 @@ preserved between engine runs.
 
     FockBackend
     GaussianBackend
-    TFBackend
+    ~tfbackend.TFBackend
 
 .. raw:: html
 
@@ -80,9 +80,10 @@ backend development.
 from .base import BaseBackend, BaseFock, BaseGaussian, ModeMap
 from .gaussianbackend import GaussianBackend
 from .fockbackend import FockBackend
-from .tfbackend import TFBackend
 from .states import BaseState, BaseGaussianState, BaseFockState
 
+# There is no import for the TFBackend to avoid TensorFlow being a direct
+# requirement of SF through a chain of imports
 
 __all__ = [
     "BaseBackend",

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -112,7 +112,7 @@ def load_backend(name):
     if name == "tf":
         # treat the tensorflow backend differently, to
         # isolate the import of tensorflow
-        from .tfbackend import TFBackend
+        from .tfbackend import TFBackend #pylint: disable=import-outside-toplevel
 
         return TFBackend()
 

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -112,7 +112,7 @@ def load_backend(name):
     if name == "tf":
         # treat the tensorflow backend differently, to
         # isolate the import of tensorflow
-        from .tfbackend import TFBackend #pylint: disable=import-outside-toplevel
+        from .tfbackend import TFBackend  # pylint: disable=import-outside-toplevel
 
         return TFBackend()
 

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -111,7 +111,7 @@ def load_backend(name):
     """
     if name == "tf":
         # treat the tensorflow backend differently, to
-        # isolate the import of tensorflow
+        # isolate the import of TensorFlow
         from .tfbackend import TFBackend  # pylint: disable=import-outside-toplevel
 
         return TFBackend()


### PR DESCRIPTION
**Context:**
With #378, the import for the `TFBackend` was changed. This unfortunately caused TF to be a requirement for StraberryFields.

As a further item, for the requirements of the docs, a wheel is specified for TheWalrus. As instead, the latest release candidate could help out to choose the correct wheel,

**Description of the Change:**
* Reverts changes to the TF import
* Uses the release candidate of TheWalrus for the docs

**Benefits:**
TF doesn't have to be a requirement for SF

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A