### PR TITLE
Fix docs building

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,7 +9,7 @@ plotly
 quantum-blackbird
 scipy>=1.0.0
 sklearn
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints==1.10.3
 sphinx-copybutton
 sphinx-automodapi
 sphinx-gallery==0.5.0

--- a/tests/apps/test_similarity.py
+++ b/tests/apps/test_similarity.py
@@ -316,7 +316,7 @@ class TestProbOrbitExact:
 
         s = similarity._get_state(g, 2)
         temp = s.fock_prob([1, 1, 0]) + s.fock_prob([1, 0, 1]) + s.fock_prob([0, 1, 1])
-        assert p == temp
+        assert np.allclose(p, temp)
 
         assert np.allclose(similarity.prob_orbit_exact(g, [4], 1), 0)
 
@@ -390,7 +390,7 @@ class TestProbEventExact:
         p3 = similarity.prob_orbit_exact(graph, [1, 1], 1)
         p4 = similarity.prob_event_exact(graph, 2, 2, 4)
         assert np.allclose(p1 - p2, 0)
-        assert p2 == p3
+        assert np.allclose(p2, p3)
         assert np.allclose(p4, 0.21087781178526066)
 
 


### PR DESCRIPTION
A [new version](https://pypi.org/project/sphinx-autodoc-typehints/#history) of sphinx-autodoc-typehints was released yesterday that [drops support](https://github.com/agronholm/sphinx-autodoc-typehints/commit/9a966fe012c7d10baeacd7a55c32cb378d5f5320) for `sphinx < 3.0`. However, we currently version pin `sphinx` to `2.2.2`.

This new release hence caused the documentation to stop building, and a quick fix is to version pin `sphinx-autodoc-typehints` to `1.10.3` as is done in this PR.

Current RTD builds are breaking:
![image](https://user-images.githubusercontent.com/49409390/85318405-f14d8800-b48d-11ea-87af-ba559426a994.png)
