### PR TITLE
Changes the default compiler to be Xunitary

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 <h3>Breaking Changes</h3>
 
+* Changes the default compiler for devices that don't specify a default from `"Xcov"` to `"Xunitary"`.
+  This compiler is slightly more strict and only compiles the unitary, not the initial squeezers,
+  however avoids any unintentional permutations.
+  [(#445)](https://github.com/XanaduAI/strawberryfields/pull/445)
+
 <h3>Bug fixes</h3>
 
 * Fixes a bug where a program that amounts to the identity operation would cause an error when
@@ -18,7 +23,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Nicolás Quesada
+Josh Izaac, Nicolás Quesada
 
 # Release 0.15.0 (current release)
 

--- a/strawberryfields/api/devicespec.py
+++ b/strawberryfields/api/devicespec.py
@@ -74,7 +74,7 @@ class DeviceSpec:
 
         # For now, use Xcov compiler by default for devices
         # if the default compiler is not specified.
-        return "Xcov"
+        return "Xunitary"
 
     @property
     def gate_parameters(self):

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -613,7 +613,7 @@ class RemoteEngine:
 
         device = self.device_spec
 
-        compiler_name = compile_options.get("force_compiler", device.default_compiler)
+        compiler_name = compile_options.get("compiler", device.default_compiler)
         msg = f"Compiling program for device {device.target} using compiler {compiler_name}."
         self.log.info(msg)
 

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -194,7 +194,7 @@ class TestRemoteEngineIntegration:
 
     def test_default_compiler(self, prog, monkeypatch, caplog):
         """Test that if the device does not provide a default compiler,
-        that Xcov is used by default."""
+        that Xunitary is used by default."""
         caplog.set_level(logging.INFO)
         test_device_dict = mock_device_dict.copy()
         test_device_dict["compiler"] = []
@@ -205,5 +205,5 @@ class TestRemoteEngineIntegration:
         engine = RemoteEngine("X8")
         _, target, res_prog, _ = engine.run_async(prog, shots=10)
 
-        assert engine.device_spec.default_compiler == "Xcov"
-        assert caplog.records[-1].message == "Compiling program for device X8_01 using compiler Xcov."
+        assert engine.device_spec.default_compiler == "Xunitary"
+        assert caplog.records[-1].message == "Compiling program for device X8_01 using compiler Xunitary."


### PR DESCRIPTION
**Context:** The current default compiler for devices that don't specify a preferred compiler is `Xcov`. This compiler is the most general, but can lead to permutations of the unitary.

**Description of the Change:** Changes the default compiler to `Xunitary`. This compiler only compiles the unitary, not the initial squeezers, however avoids any unintentional permutations.

**Benefits:** Avoids permutations of the qumodes

**Possible Drawbacks:** Slightly more strict; initial `S2gate` operations must match the chip layout.

**Related GitHub Issues:** n/a
