### PR TITLE
Increment version number to v0.15.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,4 @@
-# Release 0.16.0 (development release)
-
-<h3>New features since last release</h3>
+# Release 0.15.1 (current release)
 
 <h3>Improvements</h3>
 
@@ -23,13 +21,16 @@
 
 <h3>Documentation</h3>
 
+* Updates the `README.rst` and hardware access links.
+  [(#448)](https://github.com/XanaduAI/strawberryfields/pull/448)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Nicolás Quesada, Antal Száva
+Theodor Isacsson, Josh Izaac, Nathan Killoran, Nicolás Quesada, Antal Száva
 
-# Release 0.15.0 (current release)
+# Release 0.15.0
 
 <h3>New features since last release</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 <h3>Documentation</h3>
 
-* Updates the `README.rst` and hardware access links.
+* Updates the `README.rst` file and hardware access links.
   [(#448)](https://github.com/XanaduAI/strawberryfields/pull/448)
 
 <h3>Contributors</h3>

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.16.0-dev"
+__version__ = "0.15.1"

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -548,7 +548,7 @@ class RemoteEngine:
             self._spec = self._connection.get_device_spec(self.target)
         return self._spec
 
-    def run(self, program: Program, *, compile_options=None, **kwargs) -> Optional[Result]:
+    def run(self, program: Program, *, compile_options=None, recompile=False, **kwargs) -> Optional[Result]:
         """Runs a blocking job.
 
         In the blocking mode, the engine blocks until the job is completed, failed, or
@@ -560,6 +560,8 @@ class RemoteEngine:
         Args:
             program (strawberryfields.Program): the quantum circuit
             compile_options (None, Dict[str, Any]): keyword arguments for :meth:`.Program.compile`
+            recompile (bool): Specifies if ``program`` should be recompiled
+                using ``compile_options``, or if not provided, the default compilation options.
 
         Keyword Args:
             shots (Optional[int]): The number of shots for which to run the job. If this
@@ -569,7 +571,7 @@ class RemoteEngine:
             [strawberryfields.api.Result, None]: the job result if successful, and
             ``None`` otherwise
         """
-        job = self.run_async(program, compile_options=compile_options, **kwargs)
+        job = self.run_async(program, compile_options=compile_options, recompile=recompile, **kwargs)
         try:
             while True:
                 job.refresh()

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -548,7 +548,9 @@ class RemoteEngine:
             self._spec = self._connection.get_device_spec(self.target)
         return self._spec
 
-    def run(self, program: Program, *, compile_options=None, recompile=False, **kwargs) -> Optional[Result]:
+    def run(
+        self, program: Program, *, compile_options=None, recompile=False, **kwargs
+    ) -> Optional[Result]:
         """Runs a blocking job.
 
         In the blocking mode, the engine blocks until the job is completed, failed, or
@@ -571,7 +573,9 @@ class RemoteEngine:
             [strawberryfields.api.Result, None]: the job result if successful, and
             ``None`` otherwise
         """
-        job = self.run_async(program, compile_options=compile_options, recompile=recompile, **kwargs)
+        job = self.run_async(
+            program, compile_options=compile_options, recompile=recompile, **kwargs
+        )
         try:
             while True:
                 job.refresh()


### PR DESCRIPTION
**Summary:**
* Adjusts the signature of the `RemoteEngine.run` method to be able to accept the `recompile` argument added in #447 to the `RemoteEngine.run_async` method.
* Increments the version number to `0.15.1`