### PR TITLE
Update link in the challenges file.

### DIFF
--- a/.github/CHALLENGES.md
+++ b/.github/CHALLENGES.md
@@ -5,7 +5,7 @@ Xanadu Swag™? Check out some ideas below to get started. If you get stuck, or 
 simply ask over at our [Slack community](https://u.strawberryfields.ai/slack).
 
 For more details on contributing to Strawberry Fields, see our
-[contributing guidelines](.github/CONTRIBUTING.md).
+[contributing guidelines](CONTRIBUTING.md).
 
 ## Community :strawberry:
 


### PR DESCRIPTION
The link to `contribution guidelines` is incorrect in CHALLENGES.md, and has been updated.

Fixes #453.