### PR TITLE
Update github format.yml for python 3.8

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,9 +5,22 @@ on:
 jobs:
   black:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Black Code Formatter
-      uses: lgeiger/black-action@v1.0.1
-      with:
-        args: "-l 100 strawberryfields/ --check"
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: pip install black
+
+      - uses: actions/checkout@v2
+
+      - name: Run Black
+        run: black -l 100 strawberryfields/ --check


### PR DESCRIPTION
This PR changes the github format file so that checks are made against python 3.8. This fixes issues that were arising in other PRs, e.g., in #463 