### PR TITLE
Add pytest-randomly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ matrix:
     - env: BATCHED=1 OPTIONS="tf and mixed"
 install:
   - pip install -r requirements.txt
-  - pip install wheel codecov pytest pytest-cov pytest-mock --upgrade
+  - pip install wheel codecov pytest pytest-cov pytest-randomly pytest-mock --upgrade
   - python3 setup.py bdist_wheel
   - pip install dist/StrawberryFields*.whl
 script:
-  - python3 -m pytest tests --cov=strawberryfields -p no:warnings --tb=native -m "$OPTIONS"
+  - python3 -m pytest tests --cov=strawberryfields -p no:warnings --randomly-seed=42 --tb=native -m "$OPTIONS"
 after_success:
   - codecov
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON := $(shell which python3 2>/dev/null)
-TESTRUNNER := -m pytest tests -p no:warnings
+TESTRUNNER := -m pytest tests -p no:warnings --randomly-seed=42
 COVERAGE := --cov=strawberryfields --cov-report=html:coverage_html_report --cov-append
 
 .PHONY: help

--- a/tests/apps/train/test_param.py
+++ b/tests/apps/train/test_param.py
@@ -23,6 +23,7 @@ import thewalrus
 from thewalrus.quantum import adj_scaling as rescale
 from thewalrus.quantum import adj_scaling_torontonian as rescale_tor
 
+import strawberryfields as sf
 from strawberryfields.apps import train
 from strawberryfields.apps.train.embed import Exp
 
@@ -94,8 +95,9 @@ def test_prob_photon_sample():
     assert np.allclose(p_two_clicks - p_two_clicks[0], np.zeros(len(p_two_clicks)))
 
 
-def test_A_to_cov():
+def test_A_to_cov(monkeypatch):
     """Test if A_to_cov returns the correct covariance matrix for a simple fixed example"""
+    monkeypatch.setattr(sf, "hbar", 2.0)
     x = np.sqrt(0.5)
     A = np.array([[0, x], [x, 0]])
     cov = train.param.A_to_cov(A)

--- a/tests/frontend/test_sf_cli.py
+++ b/tests/frontend/test_sf_cli.py
@@ -198,7 +198,7 @@ class TestConfigure:
             args.local = True
 
             cli.configure(args)
-            EXPECTED_KWARGS["location"] = "local"
+            m.setitem(EXPECTED_KWARGS, "location", "local")
 
             assert mock_store_account.kwargs == EXPECTED_KWARGS
 


### PR DESCRIPTION
**Context:**
Some tests in `test_tdmprogram.py` seems to be failing stochastically. They seem to pass locally when running a single test file, but fail in the PR, causing some confusion.

**Description of the Change:**
[pytest-randomly](https://pypi.org/project/pytest-randomly/) is added to the SF tests and automatically set to a seed of 42, which is the same that was used earlier in many cases. The makefile and travis are updated to use this.

**Benefits:**
Tests can now be run deterministically.

**Possible Drawbacks:**
Optimally, we would remove the `randomly-seed=42` from the tests, causing the seed to be set randomly each time, helping us discover potential bugs due to the stochastic nature of some tests. By resetting the seed before each test, we may miss failures that might be present. This might cause some headaches, though.

**Related GitHub Issues:**
None
