### PR TITLE
Fix result representation for TDM programs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,6 +50,10 @@
   `io.to_blackbird` function.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
+* Printing the `Result` object containing samples from a TDM experiment (with shape
+  `(shots, spatial_modes, timebins)`) works.
+  [(#493)](https://github.com/XanaduAI/strawberryfields/pull/493)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,8 +50,9 @@
   `io.to_blackbird` function.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
-* Printing the `Result` object containing samples from a TDM experiment (with shape
-  `(shots, spatial_modes, timebins)`) works.
+* Fixes a bug where printing the `Result` object containing samples from a time-domain
+  experiment would result in an error. Printing the result object now correctly displays
+  information about the results.
   [(#493)](https://github.com/XanaduAI/strawberryfields/pull/493)
 
 <h3>Documentation</h3>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.7.2
+antlr4-python3-runtime==4.8
 numpy>=1.17.4
 scipy==1.4.1
 sympy>=1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.8
+antlr4-python3-runtime==4.7.2
 numpy>=1.17.4
 scipy==1.4.1
 sympy>=1.5

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -86,7 +86,7 @@ class Result:
 
         Returns:
             dict[int, list]: mode index associated with the list of
-                measurement outcomes
+            measurement outcomes
         """
         return self._all_samples
 
@@ -116,15 +116,18 @@ class Result:
 
     def __repr__(self):
         """String representation."""
-        try:
+        if self.samples.ndim == 2:
+            # if samples has dim 2, assume they're GBS
             shots, modes = self.samples.shape
-        except ValueError:
-            # if samples has dim 3, then we assume they're from a TDMProgram
+            return "<Result: shots={}, num_modes={}, contains state={}>".format(
+                shots, modes, self._is_stateful
+            )
+
+        if self.samples.ndim == 3:
+            # if samples has dim 3, assume they're TDM
             shots, modes, timebins = self.samples.shape
-            return "<Result: shots={}, spatial_modes={}, timebins={} contains state={}>".format(
+            return "<Result: shots={}, spatial_modes={}, timebins={}, contains state={}>".format(
                 shots, modes, timebins, self._is_stateful
             )
 
-        return "<Result: shots={}, num_modes={}, contains state={}>".format(
-            shots, modes, self._is_stateful
-        )
+        return "<Result: contains state={}>".format(self._is_stateful)

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -119,7 +119,7 @@ class Result:
         try:
             shots, modes = self.samples.shape
         except ValueError:
-            # if the samples has dim 3, then they're from a TDMProgram
+            # if samples has dim 3, then we assume they're from a TDMProgram
             shots, modes, timebins = self.samples.shape
             return "<Result: shots={}, spatial_modes={}, timebins={} contains state={}>".format(
                 shots, modes, timebins, self._is_stateful

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -44,9 +44,7 @@ class Result:
     >>> eng = sf.Engine("gaussian")
     >>> results = eng.run(prog)
     >>> print(results)
-    Result: 3 subsystems
-        state: <GaussianState: num_modes=3, pure=True, hbar=2>
-        samples: [[0, 0, 0]]
+    <Result: shots=1, num_modes=3, contains state=True>
     >>> results.samples
     np.array([[0, 0, 0]])
     >>> results.state.is_pure()
@@ -123,10 +121,10 @@ class Result:
         except ValueError:
             # if the samples has dim 3, then they're from a TDMProgram
             shots, modes, timebins = self.samples.shape
-            return "<Result: spatial_modes={}, shots={}, timebins={} contains state={}>".format(
-                modes, shots, timebins, self._is_stateful
+            return "<Result: shots={}, spatial_modes={}, timebins={} contains state={}>".format(
+                shots, modes, timebins, self._is_stateful
             )
 
-        return "<Result: num_modes={}, shots={}, contains state={}>".format(
-            modes, shots, self._is_stateful
+        return "<Result: shots={}, num_modes={}, contains state={}>".format(
+            shots, modes, self._is_stateful
         )

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -117,7 +117,7 @@ class Result:
     def __repr__(self):
         """String representation."""
         if self.samples.ndim == 2:
-            # if samples has dim 2, assume they're GBS
+            # if samples has dim 2, assume they're from a standard Program
             shots, modes = self.samples.shape
             return "<Result: shots={}, num_modes={}, contains state={}>".format(
                 shots, modes, self._is_stateful

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -118,7 +118,15 @@ class Result:
 
     def __repr__(self):
         """String representation."""
-        shots, modes = self.samples.shape
+        try:
+            shots, modes = self.samples.shape
+        except ValueError:
+            # if the samples has dim 3, then they're from a TDMProgram
+            shots, modes, timebins = self.samples.shape
+            return "<Result: spatial_modes={}, shots={}, timebins={} contains state={}>".format(
+                modes, shots, timebins, self._is_stateful
+            )
+
         return "<Result: num_modes={}, shots={}, contains state={}>".format(
             modes, shots, self._is_stateful
         )

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -598,7 +598,7 @@ class RemoteEngine:
 
         Returns:
             [strawberryfields.api.Result, None]: the job result if successful, and
-            ``None`` otherwise
+                ``None`` otherwise
         """
         job = self.run_async(
             program, compile_options=compile_options, recompile=recompile, **kwargs

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -597,8 +597,7 @@ class RemoteEngine:
                 argument is not provided, the shots are derived from the given ``program``.
 
         Returns:
-            [strawberryfields.api.Result, None]: the job result if successful, and
-                ``None`` otherwise
+            strawberryfields.api.Result, None: the job result if successful, and ``None`` otherwise
         """
         job = self.run_async(
             program, compile_options=compile_options, recompile=recompile, **kwargs

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -54,3 +54,14 @@ class TestResult:
         assert "modes=2" in out
         assert "shots=3" in out
         assert "contains state=True" in out
+
+    def test_tdm_print(self, capfd):
+        """Test that printing a result object with TDM samples provides the correct output."""
+        samples = np.ones((2, 3, 4))
+        result = Result(samples)
+        print(result)
+        out, err = capfd.readouterr()
+        assert "spatial_modes=3" in out
+        assert "shots=2" in out
+        assert "timebins=4" in out
+        assert "contains state=True" in out

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -55,13 +55,28 @@ class TestResult:
         assert "shots=3" in out
         assert "contains state=True" in out
 
-    def test_tdm_print(self, capfd):
+    @pytest.mark.parametrize("stateful", [True, False])
+    def test_tdm_print(self, stateful, capfd):
         """Test that printing a result object with TDM samples provides the correct output."""
         samples = np.ones((2, 3, 4))
-        result = Result(samples)
+        result = Result(samples, is_stateful=stateful)
         print(result)
         out, err = capfd.readouterr()
         assert "spatial_modes=3" in out
         assert "shots=2" in out
         assert "timebins=4" in out
-        assert "contains state=True" in out
+        assert f"contains state={stateful}" in out
+
+    @pytest.mark.parametrize("stateful", [True, False])
+    def test_unkown_shape_print(self, stateful, capfd):
+        """Test that printing a result object with samples with an unknown shape
+        provides the correct output."""
+        samples = np.ones((2, 3, 4, 5))
+        result = Result(samples, is_stateful=stateful)
+        print(result)
+        out, err = capfd.readouterr()
+        assert "modes" not in out
+        assert "shots" not in out
+        assert "timebins" not in out
+        assert f"contains state={stateful}" in out
+


### PR DESCRIPTION
**Context:**
Currently the representation of the `Result` object doesn't work for TDM programs due to the samples having dimension 3 (shots, spatial modes, timebins) instead of 2.

**Description of the Change:**
Quick fix that assumes that it's a TDM program if the samples dim is 3, and thus prints the correct representation.

**Benefits:**
Just writing `eng.run(tdm_prog)` or `res = eng.run(tdm_prog); print(res)` works, and actually prints something useful.

**Possible Drawbacks:**
Might not be the nicest solution, but since `Result` doesn't know what type of program the samples are from, I think this works well for now. Might need to be revisited later with some further changes to the `Result` class (incorporating e.g. where the results are from).

**Related GitHub Issues:**
None