### PR TITLE
Remove antlr4 requirement + pin Blackbird>=0.3.0 in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.7.2
+antlr4-python3-runtime==4.8
 numpy>=1.17.4
 scipy==1.4.1
 sympy>=1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-antlr4-python3-runtime==4.8
 numpy>=1.17.4
 scipy==1.4.1
 sympy>=1.5

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "scipy>=1.0.0",
     "sympy>=1.5",
     "networkx>=2.0",
-    "quantum-blackbird>=0.2.3",
+    "quantum-blackbird>=0.3.0",
     "python-dateutil>=2.8.0",
     "thewalrus>=0.14.0",
     "numba",


### PR DESCRIPTION
**Context:**
`antlr4-python3-runtime` is pinned at 4.8 in Blackbird, while it's still pinned at 4.7.2 in Strawberry Fields. This causes version conflicts during install. This is likely found now due to the new pip version released today which uses the new dependency resolver by default (and thus discovered this issue and tried to fix it by downloading many different versions of packages and comparing them). 

Since antlr isn't required directly by SF (and was only added [here](https://github.com/XanaduAI/strawberryfields/pull/312/files#r391028692) due to failing tests), it can be removed, and is then installed with Blackbird instead.

**Description of the Change:**
`antlr4-python3-runtime` is removed from `requirements.txt`

**Benefits:**
No version conflicts between SF and Blackbird due to antlr.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
#493 (fails due to the above mentioned issue)