### PR TITLE
Add program code generator function

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,10 @@
 * `TDMProgram` objects can now be compiled and submitted via the API.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
+* Strawberry Fields code can be generated from a program (and an engine) by
+  calling `sf.io.generate_code(program, eng=engine)`.
+  [(#496)](https://github.com/XanaduAI/strawberryfields/pull/496)
+
 <h3>Improvements</h3>
 
 * The `copies` option when constructing a `TDMProgram` have been removed. Instead, the number of

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -300,7 +300,7 @@ def serialize_program(prog, eng=None):
     code_seq.append("    " + "\n    ".join(operations) + "\n")
 
     if eng:
-        code_seq.append(f"results = eng.run()")
+        code_seq.append("results = eng.run()")
 
     return "\n".join(code_seq)
 

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -332,7 +332,7 @@ def _factor_out_pi(num_list, precision=12):
             a.append(str(p))
             continue
 
-        if np.isclose(p % (), [0, factor]).any() and p != 0:
+        if np.isclose(p % factor, [0, factor]).any() and p != 0:
             gcd = np.gcd(int(p / factor), precision)
             if gcd == precision:
                 if int(p/np.pi) == 1:

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -316,7 +316,7 @@ def generate_code(prog, eng=None):
 
     # check if program is of TDM type and format the context as appropriate
     if prog.type == "tdm":
-        # if the context arrays contain pi-values, rewrite them as pi-expressions
+        # if the context arrays contain pi-values, factor out multiples of np.pi
         tdm_params = [f"[{_factor_out_pi(par)}]" for par in prog.tdm_params]
         code_seq.append("\nwith prog.context(" + ", ".join(tdm_params) + ") as (p, q):")
     else:

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -272,12 +272,10 @@ def generate_code(prog, eng=None):
         else:
             if eng.backend_options:
                 formatting_str = (
-                    f'"{eng.backend_name}", backend_options=' +
-                    f'{{"cutoff_dim": {eng.backend_options["cutoff_dim"]}}}'
+                    f'"{eng.backend_name}", backend_options='
+                    + f'{{"cutoff_dim": {eng.backend_options["cutoff_dim"]}}}'
                 )
-                code_seq.append(
-                    f'eng = sf.Engine({formatting_str})'
-                )
+                code_seq.append(f"eng = sf.Engine({formatting_str})")
             else:
                 code_seq.append(f'eng = sf.Engine("{eng.backend_name}")')
 
@@ -335,7 +333,7 @@ def _factor_out_pi(num_list, precision=12):
         if np.isclose(p % factor, [0, factor]).any() and p != 0:
             gcd = np.gcd(int(p / factor), precision)
             if gcd == precision:
-                if int(p/np.pi) == 1:
+                if int(p / np.pi) == 1:
                     a.append("np.pi")
                 else:
                     a.append(f"{int(p/np.pi)}*np.pi")

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -281,12 +281,11 @@ def generate_code(prog, eng=None):
         code_seq.append("\nwith prog.context as q:")
 
     for cmd in prog.circuit:
+        name = cmd.op.__class__.__name__
         if prog.type == "tdm":
             format_dict = {k: f"p[{k[1:]}]" for k in prog.parameters.keys()}
-            name = cmd.op.__class__.__name__
             params_str = str(cmd.op.p)[1:-1].format(**format_dict)
         else:
-            name = cmd.op.__class__.__name__
             params_str = str(cmd.op.p)[1:-1]
 
         modes = [f"q[{r.ind}]" for r in cmd.reg]

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -245,7 +245,7 @@ def _to_tdm_program(bb):
     return prog
 
 
-def serialize_program(prog, eng=None):
+def generate_code(prog, eng=None):
     """Converts a Strawberry Fields program into valid Strawberry Fields code.
 
     Args:
@@ -300,7 +300,7 @@ def serialize_program(prog, eng=None):
     code_seq.append("    " + "\n    ".join(operations) + "\n")
 
     if eng:
-        code_seq.append("results = eng.run()")
+        code_seq.append("results = eng.run(prog, shots=1)")
 
     return "\n".join(code_seq)
 

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -346,19 +346,19 @@ def generate_code(prog, eng=None):
     return "\n".join(code_seq)
 
 
-def _factor_out_pi(num_list, precision=12):
-    """Factors out pi, divided by the precision value, from all number in a list
+def _factor_out_pi(num_list, denominator=12):
+    """Factors out pi, divided by the denominator value, from all number in a list
     and returns a string representation.
 
     Args:
         num_list (list[Number, string]): a list of numbers and/or strings
-        precision (int): largest divisor used to factor out pi divided by precision;
+        denominator (int): factor out pi divided by denominator;
             e.g. default would be to factor out np.pi/12
 
     Return:
         string: containing strings of values and/or input string objects
     """
-    factor = np.pi / precision
+    factor = np.pi / denominator
 
     a = []
     for p in num_list:
@@ -368,8 +368,8 @@ def _factor_out_pi(num_list, precision=12):
             continue
 
         if np.isclose(p % factor, [0, factor]).any() and p != 0:
-            gcd = np.gcd(int(p / factor), precision)
-            if gcd == precision:
+            gcd = np.gcd(int(p / factor), denominator)
+            if gcd == denominator:
                 if int(p / np.pi) == 1:
                     a.append("np.pi")
                 else:
@@ -377,9 +377,9 @@ def _factor_out_pi(num_list, precision=12):
             else:
                 coeff = int(p / factor / gcd)
                 if coeff == 1:
-                    a.append(f"np.pi/{int(precision/gcd)}")
+                    a.append(f"np.pi/{int(denominator/gcd)}")
                 else:
-                    a.append(f"{coeff}*np.pi/{int(precision / gcd)}")
+                    a.append(f"{coeff}*np.pi/{int(denominator / gcd)}")
         else:
             a.append(str(p))
     return ", ".join(a)

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -272,7 +272,7 @@ def serialize_program(prog, eng=None):
 
         operations.append(op)
 
-    code_seq.append("from strawberryfields.ops import " +", ".join(op_imports) + "\n")
+    code_seq.append("from strawberryfields.ops import " + ", ".join(op_imports) + "\n")
 
     if prog.type == "tdm":
         code_seq.append(f"prog = sf.TDMProgram(N={prog.N})")
@@ -293,9 +293,7 @@ def serialize_program(prog, eng=None):
 
     if prog.type == "tdm":
         tdm_params = [f"{par}" for par in prog.tdm_params]
-        code_seq.append(
-            "with prog.context(" + ", ".join(tdm_params) + ") as (p, q):"
-        )
+        code_seq.append("with prog.context(" + ", ".join(tdm_params) + ") as (p, q):")
     else:
         code_seq.append("with prog.context as q:")
 

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -737,10 +737,9 @@ class TestGenerateCode:
 
         code_list = code.split("\n")
         formatting_str = f"\"{engine_kwargs['backend']}\""
-        '"fock", backend_options={"cutoff_dim": 5}'
         if "backend_options" in engine_kwargs:
             formatting_str += (
-                ", backend_options=" +
+                ", backend_options="
                 f'{{"cutoff_dim": {engine_kwargs["backend_options"]["cutoff_dim"]}}}'
             )
         expected = prog_txt.format(engine_args=formatting_str).split("\n")
@@ -778,7 +777,12 @@ class TestGenerateCode:
         ],
     )
     def test_factor_out_pi(self, value):
-        """Test for the factor_out_pi function"""
+        """Test that the factor_out_pi function is able to convert floats
+        that are equal to a pi expression, to strings containing a pi
+        expression.
+
+        For example, the float 6.28318530718 should be converted to the string "2*np.pi"
+        """
         try:
             val = eval(value)
         except NameError:

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -644,6 +644,151 @@ class TestBlackbirdToSFConversion:
         with pytest.raises(NameError, match="operation np not defined"):
             io.to_program(bb)
 
+
+prog_txt = textwrap.dedent('''\
+    import strawberryfields as sf
+    from strawberryfields import ops
+
+    prog = sf.Program(3)
+    eng = sf.Engine({engine_args})
+
+    with prog.context as q:
+        ops.Sgate(0.54, 0) | q[0]
+        ops.BSgate(0.45, np.pi/2) | (q[0], q[2])
+        ops.Sgate(3*np.pi/2, 0) | q[1]
+        ops.BSgate(2*np.pi, 0.62) | (q[0], q[1])
+        ops.MeasureFock() | q[0]
+
+    results = eng.run(prog)
+''')
+
+prog_txt_no_engine = textwrap.dedent('''\
+    import strawberryfields as sf
+    from strawberryfields import ops
+
+    prog = sf.Program(3)
+
+    with prog.context as q:
+        ops.Sgate(0.54, 0) | q[0]
+        ops.BSgate(0.45, np.pi/2) | (q[0], q[2])
+        ops.Sgate(3*np.pi/2, 0) | q[1]
+        ops.BSgate(2*np.pi, 0.62) | (q[0], q[1])
+        ops.MeasureFock() | q[0]
+''')
+
+prog_txt_tdm = textwrap.dedent('''\
+    import strawberryfields as sf
+    from strawberryfields import ops
+
+    prog = sf.TDMProgram(N=[2, 3])
+    eng = sf.Engine("gaussian")
+
+    with prog.context([np.pi, 3*np.pi/2, 0], [1, 0.5, np.pi], [0, 0, 0]) as (p, q):
+        ops.Sgate(0.123, np.pi/4) | q[2]
+        ops.BSgate(p[0], 0.0) | (q[1], q[2])
+        ops.Rgate(p[1]) | q[2]
+        ops.MeasureHomodyne(p[0]) | q[0]
+        ops.MeasureHomodyne(p[2]) | q[2]
+
+    results = eng.run(prog)
+''')
+
+class TestGenerateCode:
+    """Tests for the generate_code function"""
+
+    def test_generate_code_no_engine(self):
+        """Test generating code for a regular program with no engine"""
+        prog = sf.Program(3)
+
+        with prog.context as q:
+            ops.Sgate(0.54, 0) | q[0]
+            ops.BSgate(0.45, np.pi/2) | (q[0], q[2])
+            ops.Sgate(3*np.pi/2, 0) | q[1]
+            ops.BSgate(2*np.pi, 0.62) | (q[0], q[1])
+            ops.MeasureFock() | q[0]
+
+        code = io.generate_code(prog)
+
+        code_list = code.split("\n")
+        expected = prog_txt_no_engine.split("\n")
+
+        for i, row in enumerate(code_list):
+            assert row == expected[i]
+
+    @pytest.mark.parametrize("engine_kwargs", [
+        {"backend": "fock", "backend_options": {"cutoff_dim": 5}},
+        {"backend": "gaussian"},
+    ])
+    def test_generate_code_with_engine(self, engine_kwargs):
+        """Test generating code for a regular program with an engine"""
+        prog = sf.Program(3)
+        eng = sf.Engine(**engine_kwargs)
+
+        with prog.context as q:
+            ops.Sgate(0.54, 0) | q[0]
+            ops.BSgate(0.45, np.pi/2) | (q[0], q[2])
+            ops.Sgate(3*np.pi/2, 0) | q[1]
+            ops.BSgate(2*np.pi, 0.62) | (q[0], q[1])
+            ops.MeasureFock() | q[0]
+
+        results = eng.run(prog)
+
+        code = io.generate_code(prog, eng)
+
+        code_list = code.split("\n")
+        formatting_str = f"\"{engine_kwargs['backend']}\""
+        '"fock", backend_options={"cutoff_dim": 5}'
+        if "backend_options" in engine_kwargs:
+            formatting_str += (
+                ", backend_options=" +
+                f'{{"cutoff_dim": {engine_kwargs["backend_options"]["cutoff_dim"]}}}'
+            )
+        expected = prog_txt.format(engine_args=formatting_str).split("\n")
+
+        for i, row in enumerate(code_list):
+            assert row == expected[i]
+
+
+    def test_generate_code_tdm(self):
+        """Test generating code for a TDM program with an engine"""
+        prog = sf.TDMProgram(N=[2, 3])
+        eng = sf.Engine("gaussian")
+
+        with prog.context([np.pi, 3*np.pi/2, 0], [1, 0.5, np.pi], [0, 0, 0]) as (p, q):
+            ops.Sgate(0.123, np.pi/4) | q[2]
+            ops.BSgate(p[0]) | (q[1], q[2])
+            ops.Rgate(p[1]) | q[2]
+            ops.MeasureHomodyne(p[0]) | q[0]
+            ops.MeasureHomodyne(p[2]) | q[2]
+
+        results = eng.run(prog)
+
+        code = io.generate_code(prog, eng)
+
+        code_list = code.split("\n")
+        expected = prog_txt_tdm.split("\n")
+
+        for i, row in enumerate(code_list):
+            assert row == expected[i]
+
+    @pytest.mark.parametrize(
+        "value", [
+            "np.pi", "np.pi/2", "np.pi/12", "2*np.pi", "2*np.pi/3",
+            "0", "42", "9.87", "-0.2", "no_number", "{p3}"
+        ],
+    )
+    def test_factor_out_pi(self, value):
+        """Test for the factor_out_pi function"""
+        try:
+            val = eval(value)
+        except NameError:
+            val = value
+        res = sf.io._factor_out_pi([val])
+        expected = value
+
+        assert res == expected
+
+
 class DummyResults:
     """Dummy results object"""
 


### PR DESCRIPTION
**Context:**
The convert-to-python-code functionality in SF interactive should be moved to SF.

**Description of the Change:**
Added a `generate_code` function to `io.py` that generates SF code from a `Program` or a `TDMProgram`, returning the code as a string. If an engine is passed, the engine-related code is also serialized.

**Benefits:**
It's possible to convert a program/engine into code directly via SF.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None