### PR TITLE
Fix issue with single parameter list

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -55,6 +55,10 @@
   information about the results.
   [(#493)](https://github.com/XanaduAI/strawberryfields/pull/493)
 
+* Fixes a bug where a single parameter list passed to the `TDMProgram`
+  context results in an error.
+  [(#503)](https://github.com/XanaduAI/strawberryfields/pull/503)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -19,7 +19,7 @@ This module implements the :class:`.TDMProgram` class which acts as a representa
 
 from operator import itemgetter
 from math import ceil
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import blackbird as bb

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -19,6 +19,7 @@ This module implements the :class:`.TDMProgram` class which acts as a representa
 
 from operator import itemgetter
 from math import ceil
+from collections import Iterable
 
 import numpy as np
 import blackbird as bb
@@ -408,6 +409,10 @@ class TDMProgram(sf.Program):
         self.tdm_params = args
         self.shift = shift
         self.loop_vars = self.params(*[f"p{i}" for i in range(len(args))])
+        # if a single parameter list is supplied, only a single free
+        # parameter will be created; turn it into a list
+        if not isinstance(self.loop_vars, Iterable):
+            self.loop_vars = [self.loop_vars]
         return self
 
     # pylint: disable=too-many-branches

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 r"""Unit tests for tdmprogram.py"""
 import copy
-from collections import Iterable
+from collections.abc import Iterable
 
 import pytest
 import numpy as np

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 r"""Unit tests for tdmprogram.py"""
 import copy
+from collections import Iterable
+
 import pytest
 import numpy as np
+
 import blackbird as bb
 import strawberryfields as sf
 from strawberryfields import ops
@@ -142,6 +145,21 @@ def test_str_tdm_method():
     """Testing the string method"""
     prog = tdmprogram.TDMProgram(N=1)
     assert prog.__str__() == "<TDMProgram: concurrent modes=1, time bins=0, spatial modes=0>"
+
+
+def test_single_parameter_list_program():
+    """Test that a TDMProgram with a single parameter list works."""
+    prog = sf.TDMProgram(2)
+    eng = sf.Engine("gaussian")
+
+    with prog.context([1, 2]) as (p, q):
+        ops.Sgate(p[0]) | q[0]
+        ops.MeasureHomodyne(p[0]) | q[0]
+
+    eng.run(prog)
+
+    assert isinstance(prog.loop_vars, Iterable)
+    assert prog.parameters == {'p0': [1, 2]}
 
 
 class TestSingleLoopNullifier:


### PR DESCRIPTION
**Context:**
`eng.run(prog)` crashes when attempting to use a single parameter list in the `TDMProgram` context.

**Description of the Change:**
A fix is added that changes a single free parameter to a list when only passing a single parameter list to the `TDMProgram` context.

**Benefits:**

The following now works:

```python
prog = sf.TDMProgram(2)
eng = sf.Engine("gaussian")

with prog.context([1, 2]) as (p, q):
    ops.Sgate(p[0]) | q[0]
    ops.MeasureHomodyne(p[0]) | q[0]

eng.run(prog)
```

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None