### PR TITLE
Fix bug in Dgate, Coherent, and DisplacedSqueezed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -99,7 +99,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Tom Bromley, Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada, Antal Száva.
+Tom Bromley, Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada,
+Antal Száva.
 
 # Release 0.16.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 * Fixes a bug where the `Dgate` does not support TensorFlow tensors if the tensor has an added
   dimension due to the existence of batching.
+  [(#507)](https://github.com/XanaduAI/strawberryfields/pull/507)
 
 * Fixed issue with `reshape_samples` where the samples were sometimes
   reshaped in the wrong way.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -46,6 +46,9 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where the `Dgate` does not support TensorFlow tensors if the tensor has an added
+  dimension due to the existence of batching.
+
 * Fixed issue with `reshape_samples` where the samples were sometimes
   reshaped in the wrong way.
   [(#489)](https://github.com/XanaduAI/strawberryfields/pull/489)
@@ -72,7 +75,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada, Antal Száva.
+Tom Bromley, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada, Antal Száva.
 
 # Release 0.16.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -69,8 +69,8 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where the `Dgate` does not support TensorFlow tensors if the tensor has an added
-  dimension due to the existence of batching.
+* Fixes a bug where `Dgate`, `Coherent` and `DisplacedSqueezed` do not support TensorFlow tensors
+  if the tensor has an added dimension due to the existence of batching.
   [(#507)](https://github.com/XanaduAI/strawberryfields/pull/507)
 
 * Fixed issue with `reshape_samples` where the samples were sometimes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -108,7 +108,7 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where `Dgate`, `Coherent` and `DisplacedSqueezed` do not support TensorFlow tensors
+* Fixes a bug where `Dgate`, `Coherent`, and `DisplacedSqueezed` do not support TensorFlow tensors
   if the tensor has an added dimension due to the existence of batching.
   [(#507)](https://github.com/XanaduAI/strawberryfields/pull/507)
 

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -595,7 +595,7 @@ class Coherent(Preparation):
         phi = par_evaluate(self.p[1])
 
         np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in [r, phi]]
-        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
+        is_complex = any([np.iscomplexobj(np.real_if_close(arg)) for arg in np_args])
 
         if is_complex:
             raise ValueError("The arguments of Coherent(r, phi) cannot be complex")
@@ -724,7 +724,7 @@ class DisplacedSqueezed(Preparation):
         p = par_evaluate(self.p)
 
         np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in p]
-        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
+        is_complex = any([np.iscomplexobj(np.real_if_close(arg)) for arg in np_args])
 
         if is_complex:
             raise ValueError(
@@ -1338,7 +1338,7 @@ class Dgate(Gate):
         r, phi = par_evaluate(self.p)
 
         np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in [r, phi]]
-        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
+        is_complex = any([np.iscomplexobj(np.real_if_close(arg)) for arg in np_args])
 
         if is_complex:
             raise ValueError("The arguments of Dgate(r, phi) cannot be complex")

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -594,12 +594,10 @@ class Coherent(Preparation):
         r = par_evaluate(self.p[0])
         phi = par_evaluate(self.p[1])
 
-        tf_complex = any(
-            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
-            for arg in [r, phi]
-        )
+        np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in [r, phi]]
+        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
 
-        if (np.iscomplex([r, phi])).any() or tf_complex:
+        if is_complex:
             raise ValueError("The arguments of Coherent(r, phi) cannot be complex")
 
         backend.prepare_coherent_state(r, phi, *reg)
@@ -725,12 +723,10 @@ class DisplacedSqueezed(Preparation):
     def _apply(self, reg, backend, **kwargs):
         p = par_evaluate(self.p)
 
-        tf_complex = any(
-            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
-            for arg in [p[0], p[1], p[2], p[3]]
-        )
+        np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in p]
+        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
 
-        if (np.iscomplex([p[0], p[1], p[2], p[3]])).any() or tf_complex:
+        if is_complex:
             raise ValueError(
                 "The arguments of DisplacedSqueezed(r_d, phi_d, r_s, phi_s) cannot be complex"
             )
@@ -1341,12 +1337,10 @@ class Dgate(Gate):
     def _apply(self, reg, backend, **kwargs):
         r, phi = par_evaluate(self.p)
 
-        tf_complex = any(
-            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
-            for arg in [r, phi]
-        )
+        np_args = [arg.numpy() if hasattr(arg, "numpy") else arg for arg in [r, phi]]
+        is_complex = any([np.iscomplexobj(arg) for arg in np_args])
 
-        if (np.iscomplex([r, phi])).any() or tf_complex:
+        if is_complex:
             raise ValueError("The arguments of Dgate(r, phi) cannot be complex")
 
         backend.displacement(r, phi, *reg)

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1337,7 +1337,10 @@ class Dgate(Gate):
     def _apply(self, reg, backend, **kwargs):
         r, phi = par_evaluate(self.p)
 
-        tf_complex = any(hasattr(arg, "numpy") and np.iscomplex(arg.numpy()) for arg in [r, phi])
+        tf_complex = any(
+            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
+            for arg in [r, phi]
+        )
 
         if (np.iscomplex([r, phi])).any() or tf_complex:
             raise ValueError("The arguments of Dgate(r, phi) cannot be complex")

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -594,7 +594,10 @@ class Coherent(Preparation):
         r = par_evaluate(self.p[0])
         phi = par_evaluate(self.p[1])
 
-        tf_complex = any(hasattr(arg, "numpy") and np.iscomplex(arg.numpy()) for arg in [r, phi])
+        tf_complex = any(
+            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
+            for arg in [r, phi]
+        )
 
         if (np.iscomplex([r, phi])).any() or tf_complex:
             raise ValueError("The arguments of Coherent(r, phi) cannot be complex")
@@ -723,7 +726,8 @@ class DisplacedSqueezed(Preparation):
         p = par_evaluate(self.p)
 
         tf_complex = any(
-            hasattr(arg, "numpy") and np.iscomplex(arg.numpy()) for arg in [p[0], p[1], p[2], p[3]]
+            hasattr(arg, "numpy") and np.any(np.iscomplex(arg.numpy().flatten()))
+            for arg in [p[0], p[1], p[2], p[3]]
         )
 
         if (np.iscomplex([p[0], p[1], p[2], p[3]])).any() or tf_complex:

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -243,7 +243,7 @@ def test_tf_batch_in_gates_previously_supporting_complex(gate):
 
 @pytest.mark.parametrize("gate", [ops.Dgate, ops.Coherent, ops.DisplacedSqueezed])
 def test_tf_batch_complex_raise(gate):
-    """Test if an error is raised if complex TF tensors are input with a batch dimension for gates
+    """Test if an error is raised if complex TF tensors with a batch dimension are input for gates
     that previously accepted complex arguments"""
     tf = pytest.importorskip("tensorflow")
 

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -229,9 +229,11 @@ def test_merge_measured_pars():
         assert D.merge(G)
 
 
+@pytest.mark.parametrize("gate", [ops.Dgate, ops.Coherent, ops.DisplacedSqueezed])
 @pytest.mark.skipif(not tf_available, reason="Test only works if TF is installed")
-def test_tf_batch_in_dgate():
-    """Test if the Dgate supports TF tensors in batch form"""
+def test_tf_batch_in_gates_previously_supporting_complex(gate):
+    """Test if gates that previously accepted complex arguments support the input of TF tensors in
+    batch form"""
     batch_size = 2
     prog = Program(1)
     eng = Engine(backend="tf", backend_options={"cutoff_dim": 3, "batch_size": batch_size})
@@ -240,6 +242,6 @@ def test_tf_batch_in_dgate():
     _theta = tf.Variable([0.1] * batch_size)
 
     with prog.context as q:
-        ops.Dgate(theta) | q[0]
+        gate(theta) | q[0]
 
     eng.run(prog, args={"theta": _theta})

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -26,13 +26,6 @@ from strawberryfields.program import Program
 from strawberryfields.program_utils import MergeFailure, RegRefError
 from strawberryfields.parameters import par_evaluate
 
-try:
-    import tensorflow as tf
-except (ImportError, ModuleNotFoundError):
-    tf_available = False
-else:
-    tf_available = True
-
 
 # make test deterministic
 np.random.seed(42)
@@ -230,10 +223,11 @@ def test_merge_measured_pars():
 
 
 @pytest.mark.parametrize("gate", [ops.Dgate, ops.Coherent, ops.DisplacedSqueezed])
-@pytest.mark.skipif(not tf_available, reason="Test only works if TF is installed")
 def test_tf_batch_in_gates_previously_supporting_complex(gate):
     """Test if gates that previously accepted complex arguments support the input of TF tensors in
     batch form"""
+    tf = pytest.importorskip("tensorflow")
+
     batch_size = 2
     prog = Program(1)
     eng = Engine(backend="tf", backend_options={"cutoff_dim": 3, "batch_size": batch_size})
@@ -245,3 +239,23 @@ def test_tf_batch_in_gates_previously_supporting_complex(gate):
         gate(theta) | q[0]
 
     eng.run(prog, args={"theta": _theta})
+
+
+@pytest.mark.parametrize("gate", [ops.Dgate, ops.Coherent, ops.DisplacedSqueezed])
+def test_tf_batch_complex_raise(gate):
+    """Test if an error is raised if complex TF tensors are input with a batch dimension for gates
+    that previously accepted complex arguments"""
+    tf = pytest.importorskip("tensorflow")
+
+    batch_size = 2
+    prog = Program(1)
+    eng = Engine(backend="tf", backend_options={"cutoff_dim": 3, "batch_size": batch_size})
+
+    theta = prog.params("theta")
+    _theta = tf.Variable([0.1j] * batch_size)
+
+    with prog.context as q:
+        gate(theta) | q[0]
+
+    with pytest.raises(ValueError, match="cannot be complex"):
+        eng.run(prog, args={"theta": _theta})


### PR DESCRIPTION
This PR fixes a bug in Dgate, Coherent, and DisplacedSqueezed where TensorFlow tensors raise an error if fed with an extra dimension due to batching.
