### PR TITLE
Update fidelity_coherent and fidelity_vacuum

### DIFF
--- a/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
+++ b/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
@@ -301,8 +301,8 @@ class BosonicModes:
         """ Returns a function that evaluates the Q function of the given state """
         if modes is None:
             modes = list(range(self.nlen))
-        mode_ind = np.sort(np.append(2 * np.array(modes), 2 * np.array(modes) + 1))
-        alpha_mean = np.append(alpha.real, alpha.imag)
+        mode_ind = np.append(2 * np.array(modes), 2 * np.array(modes) + 1)
+        alpha_mean = np.append(alpha.real, alpha.imag) * np.sqrt(2 * self.hbar)
         deltas = self.means[:, mode_ind] - alpha_mean
         cov_sum = (
             self.covs[:, mode_ind, :][:, :, mode_ind] + self.hbar * np.eye((len(mode_ind))) / 2

--- a/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
+++ b/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
@@ -308,7 +308,12 @@ class BosonicModes:
             self.covs[:, mode_ind, :][:, :, mode_ind] + self.hbar * np.eye((len(mode_ind))) / 2
         )
         exp_arg = np.einsum("...j,...jk,...k", deltas, np.linalg.inv(cov_sum), deltas)
-        weighted_exp = np.array(self.weights) * np.exp(-exp_arg)
+        weighted_exp = (
+            np.array(self.weights)
+            * self.hbar ** len(modes)
+            * np.exp(-0.5 * exp_arg)
+            / np.sqrt(np.linalg.det(cov_sum))
+        )
         fidelity = np.sum(weighted_exp)
         return fidelity
 


### PR DESCRIPTION
Redefines these functions to work with the form of the state (linear combination of Gaussians). Uses the overlap integral between two Gaussians, since coherent states are pure.

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Strawberry Fields source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint strawberryfields/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
