### PR TITLE
Adds api_version property, adds 'Accept-Version' to headers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 <h3>New features since last release</h3>
 
-* `Connection` objects now send versioned requests to the platform API.
-  [(#512)](https://github.com/XanaduAI/strawberryfields/pull/512)
-
 * `TDMProgram` objects can now be compiled and submitted via the API.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
@@ -33,6 +30,9 @@
   [(#496)](https://github.com/XanaduAI/strawberryfields/pull/496)
 
 <h3>Improvements</h3>
+
+* `Connection` objects now send versioned requests to the platform API.
+  [(#512)](https://github.com/XanaduAI/strawberryfields/pull/512)
 
 * The `copies` option when constructing a `TDMProgram` have been removed. Instead, the number of
   copies of a TDM algorithm can now be set by passing the `shots` keyword argument to
@@ -95,7 +95,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada, Antal Száva.
+Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada, Antal Száva.
 
 # Release 0.16.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <h3>New features since last release</h3>
 
+* `Connection` objects now send versioned requests to the platform API.
+  [(#512)](https://github.com/XanaduAI/strawberryfields/pull/512)
+
 * `TDMProgram` objects can now be compiled and submitted via the API.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -102,11 +102,7 @@ class Connection:
 
     @property
     def api_version(self) -> str:
-        """The platform API version to request.
-
-        Returns:
-            str
-        """
+        """str: The platform API version to request."""
         return "1.0.0"
 
     @property

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -96,9 +96,18 @@ class Connection:
         self._verbose = verbose
 
         self._base_url = "http{}://{}:{}".format("s" if self.use_ssl else "", self.host, self.port)
-        self._headers = {"Authorization": self.token}
+        self._headers = {"Authorization": self.token, "Accept-Version": self.api_version}
 
         self.log = create_logger(__name__)
+
+    @property
+    def api_version(self) -> str:
+        """The platform API version to request.
+
+        Returns:
+            str
+        """
+        return "1.0.0"
 
     @property
     def token(self) -> str:


### PR DESCRIPTION
**Context:**
The Xanadu platform API will soon be implementing versioning, allowing clients to 
request a  particular version of the API using the 'Accept-Version' HTTP header. This header will eventually be mandatory.

**Description of the Change:**
Adds an `api_version` str property to `Connection` with the value `1.0.0`. On init, adds
'Accept-Version' header to `Connection._headers` with the value of `api_version`.

**Benefits:**
Future releases of sf will be able to use the platform API once versioning becomes
mandatory. Platform will be able to support older versions of sf following breaking
API changes.

**Possible Drawbacks:**
None, beyond the established drawbacks of versioning the platform API - older
releases of sf will eventually be incompatible with the platform once versioning
becomes mandatory. The current (non-versioned) platform API's behavior is 
unchanged by the 'Accept-Version' header. 

**Related GitHub Issues:**