### PR TITLE
Implement OAuth refresh token flow

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -104,7 +104,11 @@
 * `TDMProgram` objects can now be serialized into Blackbird scripts, and vice versa.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
-<h3>Breaking changes</h3>
+<h3>Breaking Changes</h3>
+
+* Jobs are submitted to the Xanadu Quantum Cloud through a new OAuth based
+  authentication flow using offline refresh tokens and access tokens.
+  [(#520)](https://github.com/XanaduAI/strawberryfields/pull/520)
 
 <h3>Bug fixes</h3>
 
@@ -138,8 +142,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Tom Bromley, Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Nicolas Quesada,
-Antal Száva.
+Tom Bromley, Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Tim Leisti,
+Nicolas Quesada, Antal Száva.
 
 # Release 0.16.0 (current release)
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -187,7 +187,9 @@ class Connection:
         circuit = bb.serialize()
 
         path = "/jobs"
-        response = self._request("POST", self._url(path), headers=self._headers, json={"circuit": circuit})
+        response = self._request(
+            "POST", self._url(path), headers=self._headers, json={"circuit": circuit}
+        )
         if response.status_code == 201:
             job_id = response.json()["id"]
             if self._verbose:
@@ -257,8 +259,7 @@ class Connection:
         """
         path = "/jobs/{}/result".format(job_id)
         response = self._request(
-            "GET", self._url(path),
-            headers={"Accept": "application/x-numpy", **self._headers}
+            "GET", self._url(path), headers={"Accept": "application/x-numpy", **self._headers}
         )
         if response.status_code == 200:
             # Read the numpy binary data in the payload into memory
@@ -287,8 +288,10 @@ class Connection:
         """
         path = "/jobs/{}".format(job_id)
         response = self._request(
-            "PATCH", self._url(path),
-            headers=self._headers, json={"status": JobStatus.CANCELLED.value}
+            "PATCH",
+            self._url(path),
+            headers=self._headers,
+            json={"status": JobStatus.CANCELLED.value},
         )
         if response.status_code == 204:
             if self._verbose:
@@ -316,22 +319,25 @@ class Connection:
         self._headers.pop("Authorization", None)
         path = "/auth/realms/platform/protocol/openid-connect/token"
         headers = {**self._headers}
-        response = self._request("POST", self._url(path), headers=headers, data={
-            'grant_type': 'refresh_token',
-            'refresh_token': self._token,
-            'client_id': 'public',
-        })
+        response = self._request(
+            "POST",
+            self._url(path),
+            headers=headers,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": self._token,
+                "client_id": "public",
+            },
+        )
         if response.status_code == 200:
-            self._headers["Authorization"] = "Bearer {}".format(response.json().get('access_token'))
+            self._headers["Authorization"] = "Bearer {}".format(response.json().get("access_token"))
         else:
-            raise RequestFailedError(
-                "Authorization failed for request"
-            )
+            raise RequestFailedError("Authorization failed for request")
 
-    def _request(self, method: str, path: str, headers: Dict = {}, **kwargs ):
+    def _request(self, method: str, path: str, headers: Dict = {}, **kwargs):
         """Wrap all API requests with an authentication token refresh if a 401 status
         is received from the initial request.
-        
+
         Args:
             method (str): the HTTP request method to use
             path (str): path of the endpoint to use

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -89,6 +89,7 @@ class Connection:
     ):
         default_config = load_config()
 
+        print(token)
         self._token = token or default_config["api"]["authentication_token"]
         self._host = host or default_config["api"]["hostname"]
         self._port = port or default_config["api"]["port"]
@@ -333,7 +334,7 @@ class Connection:
             access_token = response.json().get("access_token")
             self._headers["Authorization"] = f"Bearer {access_token}"
         else:
-            raise RequestFailedError("Authorization failed for request.")
+            raise RequestFailedError("Authorization failed for request, please check your token provided.")
 
     def _request(self, method: str, path: str, headers: Dict = None, **kwargs):
         """Wrap all API requests with an authentication token refresh if a 401 status

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -319,8 +319,7 @@ class Connection:
         self._headers.pop("Authorization", None)
         path = "/auth/realms/platform/protocol/openid-connect/token"
         headers = {**self._headers}
-        response = self._request(
-            "POST",
+        response = requests.post(
             self._url(path),
             headers=headers,
             data={

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -98,7 +98,6 @@ class Connection:
         self._base_url = "http{}://{}:{}".format("s" if self.use_ssl else "", self.host, self.port)
 
         self._headers = {"Accept-Version": self.api_version}
-        self._refresh_access_token()
 
         self.log = create_logger(__name__)
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -334,7 +334,7 @@ class Connection:
         else:
             raise RequestFailedError("Authorization failed for request")
 
-    def _request(self, method: str, path: str, headers: Dict = {}, **kwargs):
+    def _request(self, method: str, path: str, headers: Dict = None, **kwargs):
         """Wrap all API requests with an authentication token refresh if a 401 status
         is received from the initial request.
 
@@ -346,6 +346,7 @@ class Connection:
         Returns:
             requests.Response: the response received for the sent request
         """
+        headers = headers or {}
         request_headers = {**headers, **self._headers}
         response = requests.request(method, path, headers=request_headers, **kwargs)
         if response.status_code == 401:

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -330,9 +330,10 @@ class Connection:
             },
         )
         if response.status_code == 200:
-            self._headers["Authorization"] = "Bearer {}".format(response.json().get("access_token"))
+            access_token = response.json().get("access_token")
+            self._headers["Authorization"] = f"Bearer {access_token}"
         else:
-            raise RequestFailedError("Authorization failed for request")
+            raise RequestFailedError("Authorization failed for request.")
 
     def _request(self, method: str, path: str, headers: Dict = None, **kwargs):
         """Wrap all API requests with an authentication token refresh if a 401 status
@@ -353,7 +354,7 @@ class Connection:
             # Refresh the access_token and retry the request
             self._refresh_access_token()
             request_headers = {**headers, **self._headers}
-            response = requests.request(method, self._url(path), headers=request_headers, **kwargs)
+            response = requests.request(method, path, headers=request_headers, **kwargs)
         return response
 
     @staticmethod

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -332,7 +332,7 @@ class Connection:
             self._headers["Authorization"] = f"Bearer {access_token}"
         else:
             raise RequestFailedError(
-                "Authorization failed for request, please check your token provided."
+                "Could not retrieve access token. Please check that your API key is correct."
             )
 
     def _request(self, method: str, path: str, headers: Dict = None, **kwargs):

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -332,7 +332,9 @@ class Connection:
             access_token = response.json().get("access_token")
             self._headers["Authorization"] = f"Bearer {access_token}"
         else:
-            raise RequestFailedError("Authorization failed for request, please check your token provided.")
+            raise RequestFailedError(
+                "Authorization failed for request, please check your token provided."
+            )
 
     def _request(self, method: str, path: str, headers: Dict = None, **kwargs):
         """Wrap all API requests with an authentication token refresh if a 401 status

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -89,7 +89,6 @@ class Connection:
     ):
         default_config = load_config()
 
-        print(token)
         self._token = token or default_config["api"]["authentication_token"]
         self._host = host or default_config["api"]["hostname"]
         self._port = port or default_config["api"]["port"]

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -315,7 +315,7 @@ class Connection:
         """ Use the offline token to request a new access token """
         self._headers.pop("Authorization", None)
         # TODO: Make sure this is the right path
-        path = "/auth/token"
+        path = "/auth/realms/platform/protocol/openid-connect/token"
         headers = {**self._headers}
         response = self._request("POST", self._url(path), headers=headers, data={
             'grant_type': 'refresh_token',
@@ -323,7 +323,7 @@ class Connection:
             'client_id': 'public',
         })
         if response.status_code == 200:
-            self._headers["Authorization"] = "Bearer {}".format(response.cookies["access_token"])
+            self._headers["Authorization"] = "Bearer {}".format(response.json().get('access_token'))
         else:
             raise RequestFailedError(
                 "Authorization failed for request"
@@ -334,7 +334,7 @@ class Connection:
         from the initial request.
         """
         request_headers = {**headers, **self._headers}
-        response = requests.request(method, self._url(path), headers=request_headers, **kwargs)
+        response = requests.request(method, path, headers=request_headers, **kwargs)
         if response.status_code == 401:
             # Refresh the access_token and retry the request
             self._refresh_access_token()

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -305,7 +305,7 @@ class TestConnection:
         generated while creating the Connection object."""
         monkeypatch.setattr(requests, "post", mock_return(MockResponse(500, {})))
         conn = Connection(token=test_token, host=test_host)
-        with pytest.raises(RequestFailedError, match="Authorization failed for request"):
+        with pytest.raises(RequestFailedError, match="Could not retrieve access token"):
             conn._refresh_access_token()
 
     def test_wrapped_request_refreshes(self, mocker, monkeypatch):

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -314,12 +314,12 @@ class TestConnection:
             Connection(token=test_token, host=test_host)
 
     def test_wrapped_request_refreshes(self, mocker, monkeypatch):
-        """Test that a wrapped request refreshes the access token when getting
-        a 401 response."""
-        # Mock post used while refreshing
+        """Test that the _request method refreshes the access token when
+        getting a 401 response."""
+        # Mock post function used while refreshing
         monkeypatch.setattr(requests, "post", mock_return(MockResponse(200, {})))
 
-        # Mock request used for general requests
+        # Mock request function used for general requests
         monkeypatch.setattr(requests, "request", mock_return(MockResponse(401, {})))
 
         conn = Connection(token=test_token, host=test_host)

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -103,7 +103,6 @@ class TestConnection:
                 {"layout": "", "modes": 42, "compiler": [], "gate_parameters": {"param": [[0, 1]]}}
             )),
         )
-        monkeypatch.setattr(connection, "_refresh_access_token", lambda: None)
 
         device_spec = connection.get_device_spec(target)
 

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -74,7 +74,7 @@ class MockResponse:
 class TestConnection:
     """Tests for the ``Connection`` class."""
 
-    def test_init(self, monkeypatch):
+    def test_init(self):
         """Tests that a ``Connection`` is initialized correctly."""
         token, host, port, use_ssl = "token", "host", 123, True
 

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -77,8 +77,6 @@ class TestConnection:
     def test_init(self):
         """Tests that a ``Connection`` is initialized correctly."""
         token, host, port, use_ssl = "token", "host", 123, True
-
-        monkeypatch.setattr(requests, "request", mock_return(MockResponse(200, {})))
         connection = Connection(token, host, port, use_ssl)
 
         assert connection.token == token


### PR DESCRIPTION

**Context:**

The platform backend is moving to a new OAuth based authentication flow using offline refresh tokens and access tokens. 

**Description of the Change:**

* Adds an authentication call to retrieve a short-lived access token using the long lived refresh token stored in the configuration (offline token)
* Wraps all API calls to retrieve a new access token if the current one has expired (resulting in a 401 response)

**Benefits:**

More secure and easier user credential management.

**Possible Drawbacks:**

Not backwards compatible, all users will be required to generate new tokens and update strawberry fields when the new authentication mechanism is activated.

**Related GitHub Issues:**

N/A