### PR TITLE
Increment version number to v0.17.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.17.0 (development release)
+# Release 0.17.0 (current release)
 
 <h3>New features since last release</h3>
 
@@ -13,8 +13,8 @@
   eng = sf.Engine('fock', backend_options={"cutoff_dim": 10})
 
   with prog.context as q:
-    gamma = 2
-    Vgate(gamma) | q[0]
+      gamma = 2
+      Vgate(gamma) | q[0]
 
   state = eng.run(prog).state
 
@@ -73,7 +73,10 @@
 * `Connection` objects now send versioned requests to the platform API.
   [(#512)](https://github.com/XanaduAI/strawberryfields/pull/512)
 
-* The `copies` option when constructing a `TDMProgram` have been removed. Instead, the number of
+* `TDMProgram` allows application of gates with more than one symbolic parameter.
+  [#492](https://github.com/XanaduAI/strawberryfields/pull/492)
+
+* The `copies` option, when constructing a `TDMProgram`, has been removed. Instead, the number of
   copies of a TDM algorithm can now be set by passing the `shots` keyword argument to
   the `eng.run()` method.
   [(#489)](https://github.com/XanaduAI/strawberryfields/pull/489)
@@ -101,10 +104,11 @@
   potentially crop out the final shots containing these measurements.
   [(#489)](https://github.com/XanaduAI/strawberryfields/pull/489)
 
+* `pytest-randomly` is added to the SF tests
+  [(#480)](https://github.com/XanaduAI/strawberryfields/pull/480)
+
 * `TDMProgram` objects can now be serialized into Blackbird scripts, and vice versa.
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
-
-<h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
 
@@ -121,9 +125,12 @@
   [(#476)](https://github.com/XanaduAI/strawberryfields/pull/476)
 
 * Fixes a bug where printing the `Result` object containing samples from a time-domain
-  experiment would result in an error. Printing the result object now correctly displays
+  job would result in an error. Printing the result object now correctly displays
   information about the results.
   [(#493)](https://github.com/XanaduAI/strawberryfields/pull/493)
+
+* Removes the antlr4 requirement due to version conflicts.
+  [(#494)](https://github.com/XanaduAI/strawberryfields/pull/494)
 
 * `TDMProgram.run_options` is now correctly used when running a TDM program.
   [(#500)](https://github.com/XanaduAI/strawberryfields/pull/500)
@@ -133,6 +140,12 @@
   [(#503)](https://github.com/XanaduAI/strawberryfields/pull/503)
 
 <h3>Documentation</h3>
+
+* `TDMProgram` docstring is updated to make it clear that only Gaussian programs are allowed.
+  [(#519)](https://github.com/XanaduAI/strawberryfields/pull/519)
+
+* Clarifies special cases for the `MZgate` in the docstring.
+  [(#479)](https://github.com/XanaduAI/strawberryfields/pull/479)
 
 <h3>Contributors</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -104,7 +104,7 @@
   potentially crop out the final shots containing these measurements.
   [(#489)](https://github.com/XanaduAI/strawberryfields/pull/489)
 
-* `pytest-randomly` is added to the SF tests
+* `pytest-randomly` is added to the SF tests.
   [(#480)](https://github.com/XanaduAI/strawberryfields/pull/480)
 
 * `TDMProgram` objects can now be serialized into Blackbird scripts, and vice versa.
@@ -122,7 +122,7 @@
   if the tensor has an added dimension due to the existence of batching.
   [(#507)](https://github.com/XanaduAI/strawberryfields/pull/507)
 
-* Fixed issue with `reshape_samples` where the samples were sometimes
+* Fixes an issue with `reshape_samples` where the samples were sometimes
   reshaped in the wrong way.
   [(#489)](https://github.com/XanaduAI/strawberryfields/pull/489)
 
@@ -135,7 +135,7 @@
   information about the results.
   [(#493)](https://github.com/XanaduAI/strawberryfields/pull/493)
 
-* Removes the antlr4 requirement due to version conflicts.
+* Removes the `antlr4` requirement due to version conflicts.
   [(#494)](https://github.com/XanaduAI/strawberryfields/pull/494)
 
 * `TDMProgram.run_options` is now correctly used when running a TDM program.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -160,7 +160,7 @@ This release contains contributions from (in alphabetical order):
 Tom Bromley, Jack Brown, Theodor Isacsson, Josh Izaac, Fabian Laudenbach, Tim Leisti,
 Nicolas Quesada, Antal Száva.
 
-# Release 0.16.0 (current release)
+# Release 0.16.0
 
 <h3>New features since last release</h3>
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -79,17 +79,17 @@ def about():
         Strawberry Fields: a Python library for continuous-variable quantum circuits.
         Copyright 2018-2020 Xanadu Quantum Technologies Inc.
 
-        Python version:            3.6.8
-        Platform info:             Linux-5.0.0-36-generic-x86_64-with-debian-buster-sid
-        Installation path:         /home/josh/Dropbox/Work/Xanadu/sf_cloud/strawberryfields
-        Strawberry Fields version: 0.12.0-dev
-        Numpy version:             1.17.4
-        Scipy version:             1.3.0
-        Sympy version:             1.5
+        Python version:            3.6.10
+        Platform info:             Linux-5.8.18-1-MANJARO-x86_64-with-arch-Manjaro-Linux
+        Installation path:         /home/strawberryfields/
+        Strawberry Fields version: 0.17.0
+        Numpy version:             1.19.5
+        Scipy version:             1.4.1
+        SymPy version:             1.5.1
         NetworkX version:          2.4
-        The Walrus version:        0.10.0
-        Blackbird version:         0.2.1
-        TensorFlow version:        2.0.0
+        The Walrus version:        0.15.0-dev
+        Blackbird version:         0.3.1-dev
+        TensorFlow version:        2.4.0
     """
     # pylint: disable=import-outside-toplevel
     import sys

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -87,8 +87,8 @@ def about():
         Scipy version:             1.4.1
         SymPy version:             1.5.1
         NetworkX version:          2.4
-        The Walrus version:        0.15.0-dev
-        Blackbird version:         0.3.1-dev
+        The Walrus version:        0.14.0
+        Blackbird version:         0.3.0
         TensorFlow version:        2.4.0
     """
     # pylint: disable=import-outside-toplevel

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.17.0"


### PR DESCRIPTION
Increments the version to v0.17.0.

Also, updates the changelog (adds some new entries) as well as the docstring for the `sf.about()` method.