### PR TITLE
Add strict markers option for pytest

### DIFF
--- a/tests/backend/test_tf_import.py
+++ b/tests/backend/test_tf_import.py
@@ -19,6 +19,7 @@ import pytest
 
 import strawberryfields as sf
 
+pytestmark = pytest.mark.backends("tf")
 
 try:
     import tensorflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,3 +249,16 @@ def pytest_runtest_setup(item):
             pytest.skip("Broken test skipped: {}".format(*mark.args))
         else:
             pytest.skip("Test skipped as corresponding code base is currently broken!")
+
+# The list of pre-defined pytest markers
+pytest_std_markers = ['filterwarnings', 'parametrize', 'skip', 'skipif', 'usefixtures', 'xfail']
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # Check the markers for each test case and if they were not marked with
+        # a custom SF marker, then add a dummy marker. This will way such tests
+        # will fail when pytest is run with the  --strict-markers option
+        custom_markers = [marker for marker in item.iter_markers_with_node() if marker[1].name not in pytest_std_markers]
+        if not custom_markers:
+            print("  No Strawberry Fields marker specified for the test function: ", item)
+            item.add_marker('dummy_strawberry_fields_marker')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,5 +260,5 @@ def pytest_collection_modifyitems(items):
         # will fail when pytest is run with the  --strict-markers option
         custom_markers = [marker for marker in item.iter_markers_with_node() if marker[1].name not in pytest_std_markers]
         if not custom_markers:
-            print("  No Strawberry Fields marker specified for the test function: ", item)
+            print(" No Strawberry Fields marker specified for the test function: ", item)
             item.add_marker('dummy_strawberry_fields_marker')

--- a/tests/frontend/test_logger.py
+++ b/tests/frontend/test_logger.py
@@ -56,6 +56,8 @@ from strawberryfields.logger import logging_handler_defined, default_handler, cr
 
 modules_contain_logging = [job, connection, engine]
 
+pytestmark = pytest.mark.api
+
 @pytest.fixture(autouse=True)
 def reset_logging(pytestconfig):
     """Reset the logging specific configurations such as handlers or levels as

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -46,6 +46,7 @@ c = 0.312
 
 
 @pytest.mark.parametrize("name,expected", eng_backend_params)
+@pytest.mark.frontend
 def test_load_backend(name, expected, cutoff):
     """Test backends can be correctly loaded via strings"""
     eng = sf.Engine(name)

--- a/tests/integration/test_utils_integration.py
+++ b/tests/integration/test_utils_integration.py
@@ -266,6 +266,7 @@ def entangle_states(q):
     ops.BSgate(np.pi / 4, 0) | (q[0], q[1])
 
 
+@pytest.mark.backends("fock", "tf")
 class TestTeleportationOperationTest:
     """Run a teleportation algorithm but split the circuit into operations.
     Operations can be also methods of a class"""

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
+addopts = --strict-markers
 markers =
     backends(name1, name2, ...): test applies to named backends only
     frontend: test applies to frontend only
     apps: test applies to applications layer only
     api: test applies to API only
+    bosonic: test applies to files of the bosonic backend


### PR DESCRIPTION
**Context:**
TBD
**Description of the Change:**
TBD
**Benefits:**
TBD
**Possible Drawbacks:**
TBD
**Related GitHub Issues:**
TBD

Raises the following error if no custom marker was specified for a test case:
```python
Strawberry Fields marker specified for the test function:  <Function test_chop_in_blocks_multi[1]>
collected 8095 items
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/anaconda3/lib/python3.8/site-packages/_pytest/main.py", line 269, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
(...)
INTERNALERROR>     item.add_marker('dummy_strawberry_fields_marker')
INTERNALERROR>   File "/anaconda3/lib/python3.8/site-packages/_pytest/nodes.py", line 274, in add_marker
INTERNALERROR>     marker_ = getattr(MARK_GEN, marker)
INTERNALERROR>   File "/anaconda3/lib/python3.8/site-packages/_pytest/mark/structures.py", line 500, in __getattr__
INTERNALERROR>     fail(
INTERNALERROR>   File "/anaconda3/lib/python3.8/site-packages/_pytest/outcomes.py", line 153, in fail
INTERNALERROR>     raise Failed(msg=msg, pytrace=pytrace)
INTERNALERROR> Failed: 'dummy_strawberry_fields_marker' not found in `markers` configuration option
```