### PR TITLE
Rewrite XQC API version to 0.2.0 and add User-Agent

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 <h3>Bug fixes</h3>
 
+* `Connection` objects now send requests to the platform API at version `0.2.0`
+  instead of the incorrect version number `1.0.0`.
+  [(#540)](https://github.com/XanaduAI/strawberryfields/pull/540)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+Jeremy Swinarton.
+
 # Release 0.17.0 (current release)
 
 <h3>New features since last release</h3>

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -21,7 +21,7 @@ from typing import List, Dict
 import numpy as np
 import requests
 
-from strawberryfields import version
+from strawberryfields._version import __version__
 from strawberryfields.configuration import load_config
 from strawberryfields.io import to_blackbird
 from strawberryfields.logger import create_logger
@@ -32,8 +32,6 @@ from .result import Result
 from .devicespec import DeviceSpec
 
 # pylint: disable=bad-continuation,protected-access
-
-USER_AGENT_STRING = f"StrawberryFields/{version()}"
 
 class RequestFailedError(Exception):
     """Raised when a request to the remote platform returns an error response."""
@@ -101,7 +99,7 @@ class Connection:
 
         self._headers = {
             "Accept-Version": self.api_version,
-            "User-Agent": USER_AGENT_STRING,
+            "User-Agent": self.user_agent,
         }
 
         self.log = create_logger(__name__)
@@ -110,6 +108,11 @@ class Connection:
     def api_version(self) -> str:
         """str: The platform API version to request."""
         return "0.2.0"
+
+    @property
+    def user_agent(self) -> str:
+        """str: The User-Agent header sent alongside requests to the platform."""
+        return f"StrawberryFields/{__version__}"
 
     @property
     def token(self) -> str:

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -33,6 +33,7 @@ from .devicespec import DeviceSpec
 
 # pylint: disable=bad-continuation,protected-access
 
+
 class RequestFailedError(Exception):
     """Raised when a request to the remote platform returns an error response."""
 
@@ -99,7 +100,7 @@ class Connection:
 
         self._headers = {
             "Accept-Version": self.api_version,
-            "User-Agent": self.user_agent,
+            "User-Agent": self.user_agentself.user_agent,
         }
 
         self.log = create_logger(__name__)

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -100,7 +100,7 @@ class Connection:
 
         self._headers = {
             "Accept-Version": self.api_version,
-            "User-Agent": self.user_agentself.user_agent,
+            "User-Agent": self.user_agent,
         }
 
         self.log = create_logger(__name__)

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -21,6 +21,7 @@ from typing import List, Dict
 import numpy as np
 import requests
 
+from strawberryfields import version
 from strawberryfields.configuration import load_config
 from strawberryfields.io import to_blackbird
 from strawberryfields.logger import create_logger
@@ -32,6 +33,7 @@ from .devicespec import DeviceSpec
 
 # pylint: disable=bad-continuation,protected-access
 
+USER_AGENT_STRING = f"StrawberryFields/{version()}"
 
 class RequestFailedError(Exception):
     """Raised when a request to the remote platform returns an error response."""
@@ -97,14 +99,17 @@ class Connection:
 
         self._base_url = "http{}://{}:{}".format("s" if self.use_ssl else "", self.host, self.port)
 
-        self._headers = {"Accept-Version": self.api_version}
+        self._headers = {
+            "Accept-Version": self.api_version,
+            "User-Agent": USER_AGENT_STRING,
+        }
 
         self.log = create_logger(__name__)
 
     @property
     def api_version(self) -> str:
         """str: The platform API version to request."""
-        return "1.0.0"
+        return "0.2.0"
 
     @property
     def token(self) -> str:

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -296,7 +296,10 @@ class TestConnection:
 
         conn = Connection(token=test_token, host=test_host)
         conn._refresh_access_token()
-        expected_headers = {'Accept-Version': conn.api_version}
+        expected_headers = {
+            'Accept-Version': conn.api_version,
+            'User-Agent': conn.user_agent,
+        }
         expected_url = f"https://{test_host}:443{path}"
         spy.assert_called_once_with(expected_url, headers=expected_headers, data=data)
 


### PR DESCRIPTION
**Context:**
The current version of StrawberryFields sends an incorrect version header to the Xanadu Quantum Cloud API.

**Description of the Change:**
- Update the `Accept-Version` header of requests sent from the `strawberryfields.api.connection` module to `0.2.0` instead of `1.0.0`
- Add a custom User-Agent string which sends a header in the standard format `StrawberryFields/0.17.0` where `0.17.0` is the current version of StrawberryFields

**Benefits:**
- Allows compability with the XQC platform in future iterations where API versioning will be more strict
- The `User-Agent` string gives important contextual information to the XQC API which can be used to provide custom behaviour in the future (for example, rewriting behaviour in the case of problematic requests, or providing deprecation notices in the event of lifecycle changes in the API)

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
