### PR TITLE
Bosonic backend nongaussian

### DIFF
--- a/strawberryfields/backends/base.py
+++ b/strawberryfields/backends/base.py
@@ -693,7 +693,7 @@ class BaseBosonic(BaseGaussian):
     """Abstract base class for backends that are only capable of manipulating states
     represented as linear combinations of Gaussian functions in phase space."""
 
-    compiler = None
+    compiler = "bosonic"
 
     def __init__(self):
         super().__init__()

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # pylint: disable=too-many-public-methods
+# pylint: disable=import-outside-toplevel
 
 """Bosonic backend"""
 import itertools as it
@@ -28,8 +29,6 @@ from strawberryfields.backends.states import BaseBosonicState
 
 from strawberryfields.backends.bosonicbackend.bosoniccircuit import BosonicModes
 from strawberryfields.backends.base import NotApplicableError
-
-import strawberryfields.ops as ops
 
 
 def kron_list(l):
@@ -85,6 +84,16 @@ class BosonicBackend(BaseBosonic):
             NotApplicableError: if an op in the program does not apply to the bosonic backend
             NotImplementedError: if an op in the program is not implemented in the bosonic backend
         """
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+            MbSgate,
+            _New_modes,
+        )
 
         # Initialize the circuit. This applies all non-Gaussian state-prep
         self.init_circuit(prog)
@@ -97,15 +106,15 @@ class BosonicBackend(BaseBosonic):
         all_samples = {}
 
         non_gauss_preps = (
-            ops.Bosonic,
-            ops.Catstate,
-            ops.DensityMatrix,
-            ops.Fock,
-            ops.GKP,
-            ops.Ket,
-            ops._New_modes,
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+            _New_modes,
         )
-        ancilla_gates = (ops.MbSgate,)
+        ancilla_gates = (MbSgate,)
         for cmd in prog.circuit:
             # For ancilla-assisted gates, if they return measurement values, store
             # them in ancillae_samples_dict
@@ -164,8 +173,17 @@ class BosonicBackend(BaseBosonic):
         Raises:
             NotImplementedError: if ``Ket`` or ``DensityMatrix`` preparation used
         """
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+            _New_modes,
+        )
 
-        non_gauss_preps = (ops.Bosonic, ops.Catstate, ops.DensityMatrix, ops.Fock, ops.GKP, ops.Ket)
+        non_gauss_preps = (Bosonic, Catstate, DensityMatrix, Fock, GKP, Ket)
         nmodes = prog.init_num_subsystems
         self.begin_circuit(nmodes)
         # Dummy initial weights, means and covs
@@ -187,25 +205,25 @@ class BosonicBackend(BaseBosonic):
                 pars = cmd.op.p
                 for reg in labels:
                     # All the possible preparations should go in this loop
-                    if isinstance(cmd.op, ops.Bosonic):
+                    if isinstance(cmd.op, Bosonic):
                         weights, means, covs = [pars[i] for i in range(3)]
 
-                    elif isinstance(cmd.op, ops.Catstate):
+                    elif isinstance(cmd.op, Catstate):
                         weights, means, covs = self.prepare_cat(*pars)
 
-                    elif isinstance(cmd.op, ops.GKP):
+                    elif isinstance(cmd.op, GKP):
                         weights, means, covs = self.prepare_gkp(*pars)
 
-                    elif isinstance(cmd.op, ops.Fock):
+                    elif isinstance(cmd.op, Fock):
                         weights, means, covs = self.prepare_fock(*pars)
 
-                    elif isinstance(cmd.op, (ops.Ket, ops.DensityMatrix)):
+                    elif isinstance(cmd.op, (Ket, DensityMatrix)):
                         raise NotImplementedError(
                             "Ket and DensityMatrix preparation not implemented in the bosonic backend."
                         )
 
                     # If a new mode is added in the program context, then add it here
-                    elif isinstance(cmd.op, ops._New_modes):
+                    elif isinstance(cmd.op, _New_modes):
                         cmd.op.apply(cmd.reg, self)
                         init_weights.append([0])
                         init_means.append([0])
@@ -225,7 +243,7 @@ class BosonicBackend(BaseBosonic):
                 # Add the mode to the list of already prepared modes, unless the command was
                 # just to create the new mode, in which case it checks again to see if there is
                 # a subsequent non-Gaussian state creation
-                if not isinstance(cmd.op, ops._New_modes):
+                if not isinstance(cmd.op, _New_modes):
                     reg_list += labels
 
             else:

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -27,6 +27,16 @@ from strawberryfields.backends.states import BaseBosonicState
 from strawberryfields.backends.bosonicbackend.bosoniccircuit import BosonicModes
 from strawberryfields.backends.base import NotApplicableError
 
+from strawberryfields.ops import (
+    Bosonic,
+    Catstate,
+    DensityMatrix,
+    Fock,
+    GKP,
+    Ket,
+    MbSgate,
+)
+
 
 def kron_list(l):
     """Take Kronecker products of a list of lists."""
@@ -86,16 +96,6 @@ class BosonicBackend(BaseBosonic):
             NotImplementedError: if an op in the program is not implemented
                                  in the bosonic backend
         """
-
-        from strawberryfields.ops import (
-            Bosonic,
-            Catstate,
-            DensityMatrix,
-            Fock,
-            GKP,
-            Ket,
-            MbSgate,
-        )
 
         # Initialize the circuit. This applies all non-Gaussian state-prep
         self.init_circuit(prog)
@@ -165,15 +165,6 @@ class BosonicBackend(BaseBosonic):
         Raises:
             NotImplementedError: if Ket or DensityMatrix preparation used
         """
-
-        from strawberryfields.ops import (
-            Bosonic,
-            Catstate,
-            DensityMatrix,
-            Fock,
-            GKP,
-            Ket,
-        )
 
         nmodes = prog.num_subsystems
         self.begin_circuit(nmodes)
@@ -474,7 +465,7 @@ class BosonicBackend(BaseBosonic):
         return weights, means, cov
 
     def prepare_gkp(self, state, epsilon, cutoff, desc="real", shape="square"):
-        """Prepares the arrays of weights, means and covs for a finite energy GKP state.
+        r"""Prepares the arrays of weights, means and covs for a finite energy GKP state.
 
         GKP states are qubits, with the qubit state defined by:
 

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -267,9 +267,7 @@ class BosonicBackend(BaseBosonic):
         # Tensor product of the weights.
         tensored_weights = kron_list(init_weights)
         # De-nest the means iterator.
-        tensored_means = np.array(
-            [[a for b in tup for a in b] for tup in mean_combos], dtype=complex
-        )
+        tensored_means = np.array([np.concatenate(tup) for tup in mean_combos], dtype=complex)
         # Stack covs appropriately.
         tensored_covs = np.array([block_diag(*tup) for tup in cov_combos])
 

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -131,7 +131,7 @@ class BosonicBackend(BaseBosonic):
                 applied.append(cmd)
 
             # Rest of operations applied as normal
-            if not isinstance(cmd.op, non_gauss_preps + ancilla_gates):
+            elif not isinstance(cmd.op, non_gauss_preps):
                 try:
                     # try to apply it to the backend and if op is a measurement, store outcome in values
                     val = cmd.op.apply(cmd.reg, self, **kwargs)

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -458,12 +458,11 @@ class BosonicBackend(BaseBosonic):
         p_means = 0.5 * np.array(range(-2 * z_max, 2 * z_max + 1), dtype=float)
 
         # Creating and calculating the weights array for oscillating terms
-        odd_terms = np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) % 2
+        term_inds = np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int)
+        odd_terms = term_inds % 2
         even_terms = (odd_terms + 1) % 2
-        even_phases = (-1) ** ((np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) % 4) // 2)
-        odd_phases = (-1) ** (
-            1 + ((np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) + 2) % 4) // 2
-        )
+        even_phases = (-1) ** ((term_inds % 4) // 2)
+        odd_phases = (-1) ** (1 + ((term_inds + 2) % 4) // 2)
         weights = np.cos(phi) * even_terms * even_phases * np.exp(
             -0.5 * coef_sigma * p_means ** 2
         ) - np.sin(phi) * odd_terms * odd_phases * np.exp(-0.5 * coef_sigma * p_means ** 2)

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -337,7 +337,7 @@ class BosonicBackend(BaseBosonic):
              tuple: arrays of the weights, means and covariances for the state
         """
 
-        if desc != "complex" or desc != "real":
+        if desc != "complex" and desc != "real":
             raise ValueError(r'``desc`` accepts only "real" or "complex" as arguments.')
 
         # Case alpha = 0, prepare vacuum

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -330,22 +330,22 @@ class BosonicBackend(BaseBosonic):
 
     def prepare_cat(self, alpha, phi, cutoff, desc, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
-        
-        .. math::
-       \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
 
-        Args:
-            alpha (float): alpha value of cat state
-            phi (float): phi value of cat state
-            cutoff (float): if using the 'real' representation, this determines
-                how many terms to keep
-            desc (string): whether to use the 'real' or 'complex' representation
-            D (float): for 'real rep., quality parameter of approximation
+         .. math::
+        \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
 
-        Returns:
-            tuple: arrays of the weights, means and covariances for the state
+         Args:
+             alpha (float): alpha value of cat state
+             phi (float): phi value of cat state
+             cutoff (float): if using the 'real' representation, this determines
+                 how many terms to keep
+             desc (string): whether to use the 'real' or 'complex' representation
+             D (float): for 'real rep., quality parameter of approximation
+
+         Returns:
+             tuple: arrays of the weights, means and covariances for the state
         """
-        
+
         if desc != "complex" or desc != "real":
             raise ValueError(r'``desc`` accepts only "real" or "complex" as arguments.')
 
@@ -375,33 +375,33 @@ class BosonicBackend(BaseBosonic):
             covs = 0.5 * hbar * np.identity(2, dtype=float)
             covs = np.repeat(covs[None, :], weights.size, axis=0)
             return weights, means, covs
-        
-        #The only remaining option is a real-valued cat state
+
+        # The only remaining option is a real-valued cat state
         return self.prepare_cat_real_rep(alpha, phi, cutoff, D)
-        
+
     def prepare_cat_real_rep(self, alpha, phi, cutoff, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
-        
-        .. math::
-       \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
-            
-        For this representation, weights, means and covariances are real-valued.
 
-        Args:
-            alpha (float): alpha value of cat state
-            phi (float): phi value of cat state
-            cutoff (float): if using the 'real' representation, this determines
-                how many terms to keep
-            D (float): for 'real rep., quality parameter of approximation
+         .. math::
+        \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
 
-        Returns:
-            tuple: arrays of the weights, means and covariances for the state
+         For this representation, weights, means and covariances are real-valued.
+
+         Args:
+             alpha (float): alpha value of cat state
+             phi (float): phi value of cat state
+             cutoff (float): if using the 'real' representation, this determines
+                 how many terms to keep
+             D (float): for 'real rep., quality parameter of approximation
+
+         Returns:
+             tuple: arrays of the weights, means and covariances for the state
         """
         # Normalization factor
         norm = 1 / (2 * (1 + np.exp(-2 * np.absolute(alpha) ** 2) * np.cos(phi)))
         phi = np.pi * phi
         hbar = self.circuit.hbar
-        
+
         # Defining useful constants
         a = np.absolute(alpha)
         phase = np.angle(alpha)
@@ -410,9 +410,7 @@ class BosonicBackend(BaseBosonic):
         num_mean = 8 * a * np.sqrt(hbar) / (np.pi * D * np.sqrt(2))
         denom_mean = 16 * a ** 2 / (np.pi ** 2 * D) + 2
         coef_sigma = np.pi ** 2 * hbar / (8 * a ** 2 * (E + v))
-        prefac = (
-            np.sqrt(np.pi * hbar) * np.exp(0.25 * np.pi ** 2 * D) / (4 * a) / (np.sqrt(E + v))
-        )
+        prefac = np.sqrt(np.pi * hbar) * np.exp(0.25 * np.pi ** 2 * D) / (4 * a) / (np.sqrt(E + v))
         z_max = int(
             np.ceil(
                 2
@@ -474,16 +472,15 @@ class BosonicBackend(BaseBosonic):
             cov = S @ cov @ S.T
 
         return weights, means, cov
-            
 
     def prepare_gkp(self, state, epsilon, cutoff, desc="real", shape="square"):
         """Prepares the arrays of weights, means and covs for a finite energy GKP state.
-        
+
         GKP states are qubits, with the qubit state defined by:
-        
+
         .. math::
         \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
-        
+
         where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 
         Args:
@@ -501,10 +498,10 @@ class BosonicBackend(BaseBosonic):
             NotImplementedError: if the complex representation or a non-square lattice
                                 is attempted
         """
-        
+
         if desc == "complex":
             raise NotImplementedError("The complex description of GKP is not implemented")
-            
+
         if shape != "square":
             raise NotImplementedError("Only square GKP are implemented for now")
 
@@ -572,9 +569,7 @@ class BosonicBackend(BaseBosonic):
 
         # Create set of means before finite energy effects
         means_gen = it.tee(
-            it.starmap(
-                lambda l, m: l + 1j * m, it.product(range(-z_max, z_max + 1), repeat=2)
-            ),
+            it.starmap(lambda l, m: l + 1j * m, it.product(range(-z_max, z_max + 1), repeat=2)),
             2,
         )
         means = np.concatenate(
@@ -607,7 +602,7 @@ class BosonicBackend(BaseBosonic):
         )
         covs = np.repeat(covs[None, :], weights.size, axis=0)
 
-        return weights, means, covs          
+        return weights, means, covs
 
     def prepare_fock(self, n, r=0.05):
         """Prepares the arrays of weights, means and covs of a Fock state.

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -13,13 +13,26 @@
 # limitations under the License.
 # pylint: disable=too-many-public-methods
 """Bosonic backend"""
+import itertools as it
+
 import numpy as np
+
+from scipy.special import comb
+from scipy.linalg import block_diag
 
 from strawberryfields.backends import BaseBosonic
 from strawberryfields.backends.shared_ops import changebasis
 from strawberryfields.backends.states import BaseBosonicState
 
 from .bosoniccircuit import BosonicModes
+from ..base import NotApplicableError
+
+
+def kron_list(l):
+    """Take Kronecker products of a list of lists."""
+    if len(l) == 1:
+        return l[0]
+    return np.kron(l[0], kron_list(l[1:]))
 
 
 class BosonicBackend(BaseBosonic):
@@ -54,6 +67,187 @@ class BosonicBackend(BaseBosonic):
         self._supported["mixed_states"] = True
         self._init_modes = None
         self.circuit = None
+
+    def run_prog(self, prog, **kwargs):
+        """Runs a strawberryfields program using the bosonic backend.
+
+        Args:
+            prog (object): sf.Program instance
+
+        Returns:
+            tuple: list of applied commands,
+                    dictionary of measurement samples,
+                    dictionary of ancilla measurement samples
+
+        Raises:
+            NotApplicableError: if an op in the program does not apply to
+                                the bosonic backend
+            NotImplementedError: if an op in the program is not implemented
+                                 in the bosonic backend
+        """
+
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+            MbSgate,
+        )
+
+        # Initialize the circuit. This applies all non-Gaussian state-prep
+        self.init_circuit(prog)
+
+        # Apply operations to circuit. For now, copied from LocalEngine;
+        # only change is to ignore preparation classes and ancilla-assisted gates
+        # TODO: Deal with Preparation classes in the middle of a circuit.
+        applied = []
+        samples_dict = {}
+        all_samples = {}
+        for cmd in prog.circuit:
+            nongausspreps = (Bosonic, Catstate, DensityMatrix, Fock, GKP, Ket)
+            ancilla_gates = (MbSgate,)
+            # For ancilla-assisted gates, if they return measurement values, store
+            # them in ancillae_samples_dict
+            if type(cmd.op) in ancilla_gates:
+                # if the op returns a measurement outcome store it in a dictionary
+                val = cmd.op.apply(cmd.reg, self, **kwargs)
+                if val is not None:
+                    for i, r in enumerate(cmd.reg):
+                        if r.ind not in self.ancillae_samples_dict.keys():
+                            self.ancillae_samples_dict[r.ind] = [val[:, i]]
+                        else:
+                            self.ancillae_samples_dict[r.ind].append(val[:, i])
+
+                applied.append(cmd)
+
+            # Rest of operations applied as normal
+            if type(cmd.op) not in (nongausspreps + ancilla_gates):
+                try:
+                    # try to apply it to the backend and, if op is a measurement, store outcome in values
+                    val = cmd.op.apply(cmd.reg, self, **kwargs)
+                    if val is not None:
+                        for i, r in enumerate(cmd.reg):
+                            samples_dict[r.ind] = val[:, i]
+
+                            # Internally also store all the measurement outcomes
+                            if r.ind not in all_samples:
+                                all_samples[r.ind] = list()
+                            all_samples[r.ind].append(val[:, i])
+
+                    applied.append(cmd)
+
+                except NotApplicableError:
+                    # command is not applicable to the current backend type
+                    raise NotApplicableError(
+                        "The operation {} cannot be used with the Bosonic Backend.".format(cmd.op)
+                    ) from None
+
+                except NotImplementedError:
+                    # command not directly supported by backend API
+                    raise NotImplementedError(
+                        "The operation {} has not been implemented in the Bosonic Backend for the arguments {}.".format(
+                            cmd.op, kwargs
+                        )
+                    ) from None
+
+        return applied, samples_dict, all_samples
+
+    def init_circuit(self, prog, **kwargs):
+        """Instantiate the circuit and initialize weights, means, and covs
+        depending on the Preparation classes.
+
+        Args:
+            prog (object): sf.Program instance
+
+        Raises:
+            NotImplementedError: if Ket or DensityMatrix preparation used
+        """
+
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+        )
+
+        nmodes = prog.num_subsystems
+        self.begin_circuit(nmodes)
+        self.ancillae_samples_dict = {}
+        # Dummy initial weights, means and covs
+        init_weights, init_means, init_covs = [[0] * nmodes for i in range(3)]
+
+        vac_means = np.zeros((1, 2), dtype=complex)  # .tolist()
+        vac_covs = np.array([0.5 * self.circuit.hbar * np.identity(2)])
+
+        # List of modes that have been traversed through
+        reg_list = []
+
+        # Go through the operations in the circuit
+        for cmd in prog.circuit:
+            # Check if an operation has already acted on these modes.
+            labels = [label.ind for label in cmd.reg]
+            isitnew = 1 - np.isin(labels, reg_list)
+            if np.any(isitnew):
+                # Operation parameters
+                pars = cmd.op.p
+                for reg in labels:
+                    # All the possible preparations should go in this loop
+                    if type(cmd.op) == Bosonic:
+                        weights, means, covs = [pars[i].tolist() for i in range(3)]
+
+                    elif type(cmd.op) == Catstate:
+                        weights, means, covs = self.prepare_cat(*pars)
+
+                    elif type(cmd.op) == GKP:
+                        weights, means, covs = self.prepare_gkp(*pars)
+
+                    elif type(cmd.op) == Fock:
+                        weights, means, covs = self.prepare_fock(*pars)
+
+                    elif type(cmd.op) in (Ket, DensityMatrix):
+                        raise NotImplementedError(
+                            "Ket and DensityMatrix preparation not implemented in bosonic backend."
+                        )
+
+                    # The rest of the preparations are gaussian.
+                    # TODO: initialize with Gaussian |vacuum> state
+                    # directly by asking preparation methods below for
+                    # the right weights, means, covs.
+                    else:
+                        weights, means, covs = np.array([1], dtype=complex), vac_means, vac_covs
+
+                    init_weights[reg] = weights
+                    init_means[reg] = means
+                    init_covs[reg] = covs
+
+                reg_list += labels
+
+        # Assume unused modes in the circuit are vacua.
+        # If there are any Gaussian state preparations, these will be handled
+        # by run_prog
+        for i in set(range(nmodes)).difference(reg_list):
+            init_weights[i], init_means[i], init_covs[i] = np.array([1]), vac_means, vac_covs
+
+        # Find all possible combinations of means and combs of the
+        # Gaussians between the modes.
+        mean_combos = it.product(*init_means)
+        cov_combos = it.product(*init_covs)
+
+        # Tensor product of the weights.
+        weights = kron_list(init_weights)
+        # De-nest the means iterator.
+        means = np.array([[a for b in tup for a in b] for tup in mean_combos], dtype=complex)
+        # Stack covs appropriately.
+        covs = np.array([block_diag(*tup) for tup in cov_combos])
+
+        # Declare circuit attributes.
+        self.circuit.weights = weights
+        self.circuit.means = means
+        self.circuit.covs = covs
 
     def begin_circuit(self, num_subsystems, **kwargs):
         self._init_modes = num_subsystems
@@ -134,6 +328,295 @@ class BosonicBackend(BaseBosonic):
         self.circuit.from_covmat(cov, modes)
         self.circuit.from_mean(means, modes)
 
+    def prepare_cat(self, alpha, phi, cutoff, desc, D):
+        r"""Prepares the arrays of weights, means and covs for a cat state:
+            ``(|alpha> + exp(i*phi*pi)|-alpha>)/N``.
+
+        Args:
+            alpha (float): alpha value of cat state
+            phi (float): phi value of cat state
+            cutoff (float): if using the 'real' representation, this determines 
+                how many terms to keep
+            desc (string): whether to use the 'real' or 'complex' representation
+            D (float): for 'real rep., quality parameter of approximation
+
+        Returns:
+            tuple: arrays of the weights, means and covariances for the state
+        """
+
+        # Case alpha = 0, prepare vacuum
+        if np.isclose(np.absolute(alpha), 0):
+            weights = np.array([1], dtype=complex)
+            means = np.array([[0, 0]], dtype=complex)
+            covs = np.array([0.5 * self.circuit.hbar * np.identity(2)])
+            return (weights, means, covs)
+
+        # Normalization factor
+        norm = 1 / (2 * (1 + np.exp(-2 * np.absolute(alpha) ** 2) * np.cos(phi)))
+        phi = np.pi * phi
+        hbar = self.circuit.hbar
+
+        if desc == "complex":
+            # Mean of |alpha><alpha| term
+            rplus = np.sqrt(2 * hbar) * np.array([alpha.real, alpha.imag])
+            # Mean of |alpha><-alpha| term
+            rcomplex = np.sqrt(2 * hbar) * np.array([1j * alpha.imag, -1j * alpha.real])
+            # Coefficient for complex Gaussians
+            cplx_coef = np.exp(-2 * np.absolute(alpha) ** 2 - 1j * phi)
+            # Arrays of weights, means and covs
+            weights = norm * np.array([1, 1, cplx_coef, np.conjugate(cplx_coef)])
+            weights /= np.sum(weights)
+            means = np.array([rplus, -rplus, rcomplex, np.conjugate(rcomplex)])
+            covs = 0.5 * hbar * np.identity(2, dtype=float)
+            covs = np.repeat(covs[None, :], weights.size, axis=0)
+            return weights, means, covs
+
+        elif desc == "real":
+            # Defining useful constants
+            a = np.absolute(alpha)
+            phase = np.angle(alpha)
+            E = np.pi ** 2 * D * hbar / (16 * a ** 2)
+            v = hbar / 2
+            num_mean = 8 * a * np.sqrt(hbar) / (np.pi * D * np.sqrt(2))
+            denom_mean = 16 * a ** 2 / (np.pi ** 2 * D) + 2
+            coef_sigma = np.pi ** 2 * hbar / (8 * a ** 2 * (E + v))
+            prefac = (
+                np.sqrt(np.pi * hbar) * np.exp(0.25 * np.pi ** 2 * D) / (4 * a) / (np.sqrt(E + v))
+            )
+            z_max = int(
+                np.ceil(
+                    2
+                    * np.sqrt(2)
+                    * a
+                    / (np.pi * np.sqrt(hbar))
+                    * np.sqrt((-2 * (E + v) * np.log(cutoff / prefac)))
+                )
+            )
+
+            x_means = np.zeros(4 * z_max + 1, dtype=float)
+            p_means = 0.5 * np.array(range(-2 * z_max, 2 * z_max + 1), dtype=float)
+
+            # Creating and calculating the weigths array for oscillating terms
+            odd_terms = np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) % 2
+            even_terms = (odd_terms + 1) % 2
+            even_phases = (-1) ** ((np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) % 4) // 2)
+            odd_phases = (-1) ** (
+                1 + ((np.array(range(-2 * z_max, 2 * z_max + 1), dtype=int) + 2) % 4) // 2
+            )
+            weights = np.cos(phi) * even_terms * even_phases * np.exp(
+                -0.5 * coef_sigma * p_means ** 2
+            ) - np.sin(phi) * odd_terms * odd_phases * np.exp(-0.5 * coef_sigma * p_means ** 2)
+            weights *= prefac
+            weights_real = np.ones(2, dtype=float)
+            weights = norm * np.concatenate((weights_real, weights))
+
+            # making sure the state is properly normalized
+            weights /= np.sum(weights)
+
+            # computing the means array
+            means = np.concatenate(
+                (
+                    np.reshape(x_means, (-1, 1)),
+                    np.reshape(p_means, (-1, 1)),
+                ),
+                axis=1,
+            )
+            means *= num_mean / denom_mean
+            means_real = np.sqrt(2 * hbar) * np.array([[a, 0], [-a, 0]], dtype=float)
+            means = np.concatenate((means_real, means))
+
+            # computing the covariance array
+            cov = np.array([[0.5 * hbar, 0], [0, (E * v) / (E + v)]])
+            cov = np.repeat(cov[None, :], 4 * z_max + 1, axis=0)
+            cov_real = 0.5 * hbar * np.array([[[1, 0], [0, 1]], [[1, 0], [0, 1]]], dtype=float)
+            cov = np.concatenate((cov_real, cov))
+
+            # filter out 0 components
+            filt = ~np.isclose(weights, 0, atol=cutoff)
+            weights = weights[filt]
+            means = means[filt]
+            cov = cov[filt]
+
+            # applying a rotation if necessary
+            if not np.isclose(phase, 0):
+                S = np.array([[np.cos(phase), -np.sin(phase)], [np.sin(phase), np.cos(phase)]])
+                means = np.dot(S, means.T).T
+                cov = S @ cov @ S.T
+
+            return weights, means, cov
+
+        else:
+            raise ValueError('desc accept only "real" or "complex" arguments')
+
+    def prepare_gkp(self, state, epsilon, cutoff, desc="real", shape="square"):
+        """Prepares the arrays of weights, means and covs for a gkp state:
+            ``cos(theta/2)|0>_{gkp} + exp(-i*phi)sin(theta/2)|1>_{gkp}``
+
+        Args:
+            state (list): [theta,phi] for qubit definition above
+            epsilon (float): finite energy parameter of the state
+            cutoff (float): if using the 'real' representation, this determines 
+                how many terms to keep
+            desc (string): 'real' or 'complex' reprsentation
+            shape (string): 'square' lattice or otherwise
+
+        Returns:
+            tuple: arrays of the weights, means and covariances for the state
+
+        Raises:
+            NotImplementedError: if the complex representation or a non-square lattice
+                                is attempted
+        """
+
+        theta, phi = state[0], state[1]
+
+        if shape == "square":
+            if desc == "real":
+
+                def coef(peak_loc):
+                    """Returns the value of the weight for a given peak.
+
+                    Args:
+                        peak_loc (array): location of the ideal peak in phase space
+
+                    Returns:
+                        float: weight of the peak
+                    """
+                    l, m = peak_loc[:, 0], peak_loc[:, 1]
+                    t = np.zeros(peak_loc.shape[0], dtype=complex)
+                    t += np.logical_and(l % 2 == 0, m % 2 == 0)
+                    t += np.logical_and(l % 4 == 0, m % 2 == 1) * (
+                        np.cos(0.5 * theta) ** 2 - np.sin(0.5 * theta) ** 2
+                    )
+                    t += np.logical_and(l % 4 == 2, m % 2 == 1) * (
+                        np.sin(0.5 * theta) ** 2 - np.cos(0.5 * theta) ** 2
+                    )
+                    t += np.logical_and(l % 4 % 2 == 1, m % 4 == 0) * np.sin(theta) * np.cos(phi)
+                    t -= np.logical_and(l % 4 % 2 == 1, m % 4 == 2) * np.sin(theta) * np.cos(phi)
+                    t -= (
+                        np.logical_or(
+                            np.logical_and(l % 4 == 3, m % 4 == 3),
+                            np.logical_and(l % 4 == 1, m % 4 == 1),
+                        )
+                        * np.sin(theta)
+                        * np.sin(phi)
+                    )
+                    t += (
+                        np.logical_or(
+                            np.logical_and(l % 4 == 3, m % 4 == 1),
+                            np.logical_and(l % 4 == 1, m % 4 == 3),
+                        )
+                        * np.sin(theta)
+                        * np.sin(phi)
+                    )
+                    prefactor = np.exp(
+                        -np.pi
+                        * 0.25
+                        * (l ** 2 + m ** 2)
+                        * (1 - np.exp(-2 * epsilon))
+                        / (1 + np.exp(-2 * epsilon))
+                    )
+                    weight = t * prefactor
+                    return weight
+
+                # Set the max peak value
+                z_max = int(
+                    np.ceil(
+                        np.sqrt(
+                            -4
+                            / np.pi
+                            * np.log(cutoff)
+                            * (1 + np.exp(-2 * epsilon))
+                            / (1 - np.exp(-2 * epsilon))
+                        )
+                    )
+                )
+                damping = 2 * np.exp(-epsilon) / (1 + np.exp(-2 * epsilon))
+
+                # Create set of means before finite energy effects
+                means_gen = it.tee(
+                    it.starmap(
+                        lambda l, m: l + 1j * m, it.product(range(-z_max, z_max + 1), repeat=2)
+                    ),
+                    2,
+                )
+                means = np.concatenate(
+                    (
+                        np.reshape(
+                            np.fromiter(means_gen[0], complex, count=(2 * z_max + 1) ** 2), (-1, 1)
+                        ).real,
+                        np.reshape(
+                            np.fromiter(means_gen[1], complex, count=(2 * z_max + 1) ** 2), (-1, 1)
+                        ).imag,
+                    ),
+                    axis=1,
+                )
+
+                # Calculate the weights for each peak
+                weights = coef(means)
+                filt = abs(weights) > cutoff
+                weights = weights[filt]
+                weights /= np.sum(weights)
+                # Apply finite energy effect to means
+                means = means[filt]
+                means *= 0.5 * damping * np.sqrt(np.pi * self.circuit.hbar)
+                # Covariances all the same
+                covs = (
+                    0.5
+                    * self.circuit.hbar
+                    * (1 - np.exp(-2 * epsilon))
+                    / (1 + np.exp(-2 * epsilon))
+                    * np.identity(2)
+                )
+                covs = np.repeat(covs[None, :], weights.size, axis=0)
+
+                return weights, means, covs
+
+            elif desc == "complex":
+                raise NotImplementedError("The complex description of GKP is not implemented")
+        else:
+            raise ValueError("Only square GKP are implemented for now")
+
+    def prepare_fock(self, n, r=0.05):
+        """Prepares the arrays of weights, means and covs of a Fock state.
+
+        Args:
+            n (int): photon number
+            r (float): quality parameter for the approximation
+
+        Returns:
+            tuple: arrays of the weights, means and covariances for the state
+
+        Raises:
+            ValueError: if 1/r**2 is less than n
+        """
+        if 1 / r ** 2 < n:
+            raise ValueError(
+                "The parameter 1 / r ** 2={} is smaller than n={}".format(1 / r ** 2, n)
+            )
+        # A simple function to calculate the parity
+        parity = lambda n: 1 if n % 2 == 0 else -1
+        # All the means are zero
+        means = np.zeros([n + 1, 2])
+        covs = np.array(
+            [
+                0.5
+                * self.circuit.hbar
+                * np.identity(2)
+                * (1 + (n - j) * r ** 2)
+                / (1 - (n - j) * r ** 2)
+                for j in range(n + 1)
+            ]
+        )
+        weights = np.array(
+            [
+                (1 - n * (r ** 2)) / (1 - (n - j) * (r ** 2)) * comb(n, j) * parity(j)
+                for j in range(n + 1)
+            ]
+        )
+        weights = weights / np.sum(weights)
+        return weights, means, covs
+
     def rotation(self, phi, mode):
         self.circuit.phase_shift(phi, mode)
 
@@ -143,11 +626,9 @@ class BosonicBackend(BaseBosonic):
     def squeeze(self, r, phi, mode):
         self.circuit.squeeze(r, phi, mode)
 
-    def mb_squeeze(self, mode, r, phi, r_anc, eta_anc, avg):
+    def mb_squeeze_avg(self, mode, r, phi, r_anc, eta_anc):
         r"""Squeeze mode by the amount ``r*exp(1j*phi)`` using measurement-based squeezing.
-
-        Depending on avg, this applies the average or single-shot map, returning the ancillary
-        measurement outcome.
+        Here, the average, deterministic Gaussian CPTP map is applied.
 
         Args:
             k (int): mode to be squeezed
@@ -155,15 +636,23 @@ class BosonicBackend(BaseBosonic):
             phi (float): target squeezing phase
             r_anc (float): squeezing magnitude of the ancillary mode
             eta_anc(float): detection efficiency of the ancillary mode
-            avg (bool): whether to apply the average or single-shot map
+        """
+        self.circuit.mb_squeeze_avg(mode, r, phi, r_anc, eta_anc)
+    
+    def mb_squeeze_single_shot(self, mode, r, phi, r_anc, eta_anc):
+        r"""Squeeze mode by the amount ``r*exp(1j*phi)`` using measurement-based squeezing.
+        Here, the single-shot map is applied, returning the ancillary measurement outcome.
+
+        Args:
+            k (int): mode to be squeezed
+            r (float): target squeezing magnitude
+            phi (float): target squeezing phase
+            r_anc (float): squeezing magnitude of the ancillary mode
+            eta_anc(float): detection efficiency of the ancillary mode
 
         Returns:
-            float or None: if not avg, the measurement outcome of the ancilla
+            float: the measurement outcome of the ancilla
         """
-        if avg:
-            self.circuit.mb_squeeze_avg(mode, r, phi, r_anc, eta_anc)
-            return None
-
         ancilla_val = self.circuit.mb_squeeze_single_shot(mode, r, phi, r_anc, eta_anc)
         return ancilla_val
 
@@ -197,12 +686,12 @@ class BosonicBackend(BaseBosonic):
             val = select * 2 / np.sqrt(2 * self.circuit.hbar)
             self.circuit.post_select_homodyne(mode, val, **kwargs)
 
-        return np.array([val * np.sqrt(2 * self.circuit.hbar) / 2])
+        return np.array([[val * np.sqrt(2 * self.circuit.hbar) / 2]])
 
     def measure_heterodyne(self, mode, shots=1, select=None):
         if select is None:
             res = 0.5 * self.circuit.heterodyne(mode, shots=shots)
-            return np.array([res[:, 0] + 1j * res[:, 1]])
+            return np.array([[res[:, 0] + 1j * res[:, 1]]])
 
         res = select
         self.circuit.post_select_heterodyne(mode, select)

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -330,8 +330,7 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat(self, alpha, phi, cutoff, desc, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-        math::
-        \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
+        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha})`.
 
         Args:
             alpha (float): alpha value of cat state
@@ -381,8 +380,7 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat_real_rep(self, alpha, phi, cutoff, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-        math::
-        \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
+        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha})`.
 
         For this representation, weights, means and covariances are real-valued.
 
@@ -477,8 +475,7 @@ class BosonicBackend(BaseBosonic):
 
         GKP states are qubits, with the qubit state defined by:
 
-        math::
-        \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
+        :math:`\ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}`
 
         where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -83,10 +83,8 @@ class BosonicBackend(BaseBosonic):
                     dictionary of ancilla measurement samples
 
         Raises:
-            NotApplicableError: if an op in the program does not apply to
-                                the bosonic backend
-            NotImplementedError: if an op in the program is not implemented
-                                 in the bosonic backend
+            NotApplicableError: if an op in the program does not apply to the bosonic backend
+            NotImplementedError: if an op in the program is not implemented in the bosonic backend
         """
         from strawberryfields.ops import (
             Bosonic,
@@ -141,19 +139,19 @@ class BosonicBackend(BaseBosonic):
 
                     applied.append(cmd)
 
-                except NotApplicableError:
+                except NotApplicableError as e:
                     # command is not applicable to the current backend type
                     raise NotApplicableError(
                         "The operation {} cannot be used with the Bosonic Backend.".format(cmd.op)
-                    ) from None
+                    ) from e
 
-                except NotImplementedError:
+                except NotImplementedError as e:
                     # command not directly supported by backend API
                     raise NotImplementedError(
                         "The operation {} has not been implemented in the Bosonic Backend for the arguments {}.".format(
                             cmd.op, kwargs
                         )
-                    ) from None
+                    ) from e
 
         return applied, samples_dict, all_samples
 
@@ -165,7 +163,7 @@ class BosonicBackend(BaseBosonic):
             prog (object): sf.Program instance
 
         Raises:
-            NotImplementedError: if Ket or DensityMatrix preparation used
+            NotImplementedError: if ``Ket`` or ``DensityMatrix`` preparation used
         """
         from strawberryfields.ops import (
             Bosonic,
@@ -213,7 +211,7 @@ class BosonicBackend(BaseBosonic):
 
                     elif type(cmd.op) in (Ket, DensityMatrix):
                         raise NotImplementedError(
-                            "Ket and DensityMatrix preparation not implemented in bosonic backend."
+                            "Ket and DensityMatrix preparation not implemented in the bosonic backend."
                         )
 
                     # If a new mode is added in the program context, then add it here,
@@ -361,7 +359,7 @@ class BosonicBackend(BaseBosonic):
             cutoff (float): if using the 'real' representation, this determines
                  how many terms to keep
             desc (string): whether to use the 'real' or 'complex' representation
-            D (float): for 'real rep., quality parameter of approximation
+            D (float): for 'real' representation, quality parameter of approximation
 
         Returns:
             tuple: arrays of the weights, means and covariances for the state
@@ -383,18 +381,21 @@ class BosonicBackend(BaseBosonic):
 
         if desc == "complex":
             phi = np.pi * phi
+
             # Mean of |alpha><alpha| term
             rplus = np.sqrt(2 * hbar) * np.array([alpha.real, alpha.imag])
             # Mean of |alpha><-alpha| term
             rcomplex = np.sqrt(2 * hbar) * np.array([1j * alpha.imag, -1j * alpha.real])
             # Coefficient for complex Gaussians
             cplx_coef = np.exp(-2 * np.absolute(alpha) ** 2 - 1j * phi)
+
             # Arrays of weights, means and covs
             weights = norm * np.array([1, 1, cplx_coef, np.conjugate(cplx_coef)])
             weights /= np.sum(weights)
             means = np.array([rplus, -rplus, rcomplex, np.conjugate(rcomplex)])
             covs = 0.5 * hbar * np.identity(2, dtype=float)
             covs = np.repeat(covs[None, :], weights.size, axis=0)
+            
             return weights, means, covs
 
         # The only remaining option is a real-valued cat state
@@ -412,7 +413,7 @@ class BosonicBackend(BaseBosonic):
             phi (float): phi value of cat state
             cutoff (float): if using the 'real' representation, this determines
                  how many terms to keep
-            D (float): for 'real rep., quality parameter of approximation
+            D (float): for 'real' representation, quality parameter of approximation
 
         Returns:
             tuple: arrays of the weights, means and covariances for the state
@@ -498,7 +499,7 @@ class BosonicBackend(BaseBosonic):
 
         GKP states are qubits, with the qubit state defined by:
 
-        :math:`\ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}`
+        :math:`\ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^{-i\phi}\sin\frac{\theta}{2}\ket{1}_{gkp}`
 
         where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 
@@ -507,15 +508,14 @@ class BosonicBackend(BaseBosonic):
             epsilon (float): finite energy parameter of the state
             cutoff (float): if using the 'real' representation, this determines
                 how many terms to keep
-            desc (string): 'real' or 'complex' reprsentation
-            shape (string): 'square' lattice or otherwise
+            desc (str): 'real' or 'complex' reprsentation
+            shape (str): shape of the lattice; default 'square'
 
         Returns:
             tuple: arrays of the weights, means and covariances for the state
 
         Raises:
-            NotImplementedError: if the complex representation or a non-square lattice
-                                is attempted
+            NotImplementedError: if the complex representation or a non-square lattice is attempted
         """
 
         if desc == "complex":
@@ -634,7 +634,7 @@ class BosonicBackend(BaseBosonic):
             tuple: arrays of the weights, means and covariances for the state
 
         Raises:
-            ValueError: if 1/r**2 is less than n
+            ValueError: if :math:`1/r^2` is less than n
         """
         if 1 / r ** 2 < n:
             raise ValueError(
@@ -681,7 +681,7 @@ class BosonicBackend(BaseBosonic):
             r (float): target squeezing magnitude
             phi (float): target squeezing phase
             r_anc (float): squeezing magnitude of the ancillary mode
-            eta_anc(float): detection efficiency of the ancillary mode
+            eta_anc (float): detection efficiency of the ancillary mode
         """
         self.circuit.mb_squeeze_avg(mode, r, phi, r_anc, eta_anc)
 

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -335,7 +335,7 @@ class BosonicBackend(BaseBosonic):
         Args:
             alpha (float): alpha value of cat state
             phi (float): phi value of cat state
-            cutoff (float): if using the 'real' representation, this determines 
+            cutoff (float): if using the 'real' representation, this determines
                 how many terms to keep
             desc (string): whether to use the 'real' or 'complex' representation
             D (float): for 'real rep., quality parameter of approximation
@@ -455,7 +455,7 @@ class BosonicBackend(BaseBosonic):
         Args:
             state (list): [theta,phi] for qubit definition above
             epsilon (float): finite energy parameter of the state
-            cutoff (float): if using the 'real' representation, this determines 
+            cutoff (float): if using the 'real' representation, this determines
                 how many terms to keep
             desc (string): 'real' or 'complex' reprsentation
             shape (string): 'square' lattice or otherwise
@@ -638,7 +638,7 @@ class BosonicBackend(BaseBosonic):
             eta_anc(float): detection efficiency of the ancillary mode
         """
         self.circuit.mb_squeeze_avg(mode, r, phi, r_anc, eta_anc)
-    
+
     def mb_squeeze_single_shot(self, mode, r, phi, r_anc, eta_anc):
         r"""Squeeze mode by the amount ``r*exp(1j*phi)`` using measurement-based squeezing.
         Here, the single-shot map is applied, returning the ancillary measurement outcome.

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -27,16 +27,6 @@ from strawberryfields.backends.states import BaseBosonicState
 from strawberryfields.backends.bosonicbackend.bosoniccircuit import BosonicModes
 from strawberryfields.backends.base import NotApplicableError
 
-from strawberryfields.ops import (
-    Bosonic,
-    Catstate,
-    DensityMatrix,
-    Fock,
-    GKP,
-    Ket,
-    MbSgate,
-)
-
 
 def kron_list(l):
     """Take Kronecker products of a list of lists."""
@@ -96,6 +86,15 @@ class BosonicBackend(BaseBosonic):
             NotImplementedError: if an op in the program is not implemented
                                  in the bosonic backend
         """
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+            MbSgate,
+        )
 
         # Initialize the circuit. This applies all non-Gaussian state-prep
         self.init_circuit(prog)
@@ -165,7 +164,14 @@ class BosonicBackend(BaseBosonic):
         Raises:
             NotImplementedError: if Ket or DensityMatrix preparation used
         """
-
+        from strawberryfields.ops import (
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            GKP,
+            Ket,
+        )
         nmodes = prog.num_subsystems
         self.begin_circuit(nmodes)
         # Dummy initial weights, means and covs

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -364,7 +364,9 @@ class BosonicBackend(BaseBosonic):
         """
 
         if desc not in ("complex", "real"):
-            raise ValueError('The representation argument accepts only "real" or "complex" as arguments.')
+            raise ValueError(
+                'The representation argument accepts only "real" or "complex" as arguments.'
+            )
 
         # Case alpha = 0, prepare vacuum
         if np.isclose(np.absolute(alpha), 0):
@@ -637,9 +639,7 @@ class BosonicBackend(BaseBosonic):
             ValueError: if :math:`1/r^2` is less than :math:`n`
         """
         if 1 / r ** 2 < n:
-            raise ValueError(
-                f"The parameter 1 / r ** 2={1 / r ** 2} is smaller than n={n}"
-            )
+            raise ValueError(f"The parameter 1 / r ** 2={1 / r ** 2} is smaller than n={n}")
         # A simple function to calculate the parity
         parity = lambda n: 1 if n % 2 == 0 else -1
         # All the means are zero

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -360,12 +360,12 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat(self, alpha, phi, representation, cutoff, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha})`.
+        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi\pi} \ket{-\alpha})`.
 
         Args:
             alpha (float): alpha value of cat state
             phi (float): phi value of cat state
-            representation (string): whether to use the ``'real'`` or ``'complex'`` representation
+            representation (str): whether to use the ``'real'`` or ``'complex'`` representation
             cutoff (float): if using the ``'real'`` representation, this determines
                  how many terms to keep
             D (float): for ``'real'`` representation, quality parameter of approximation
@@ -419,7 +419,7 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat_real_rep(self, alpha, phi, cutoff, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha})`.
+        :math:`\ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi\pi} \ket{-\alpha})`.
 
         For this representation, weights, means and covariances are real-valued.
 
@@ -691,7 +691,7 @@ class BosonicBackend(BaseBosonic):
         Here, the average, deterministic Gaussian CPTP map is applied.
 
         Args:
-            k (int): mode to be squeezed
+            mode (int): mode to be squeezed
             r (float): target squeezing magnitude
             phi (float): target squeezing phase
             r_anc (float): squeezing magnitude of the ancillary mode
@@ -705,7 +705,7 @@ class BosonicBackend(BaseBosonic):
         Here, the single-shot map is applied, returning the ancillary measurement outcome.
 
         Args:
-            k (int): mode to be squeezed
+            mode (int): mode to be squeezed
             r (float): target squeezing magnitude
             phi (float): target squeezing phase
             r_anc (float): squeezing magnitude of the ancillary mode

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -753,7 +753,7 @@ class BosonicBackend(BaseBosonic):
 
         res = select
         self.circuit.post_select_heterodyne(mode, select)
-        return res
+        return np.array([[res]])
 
     def is_vacuum(self, tol=1e-10, **kwargs):
         return self.circuit.is_vacuum(tol=tol)

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -322,22 +322,22 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat(self, alpha, phi, cutoff, desc, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-         .. math::
+        math::
         \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
 
-         Args:
-             alpha (float): alpha value of cat state
-             phi (float): phi value of cat state
-             cutoff (float): if using the 'real' representation, this determines
+        Args:
+            alpha (float): alpha value of cat state
+            phi (float): phi value of cat state
+            cutoff (float): if using the 'real' representation, this determines
                  how many terms to keep
-             desc (string): whether to use the 'real' or 'complex' representation
-             D (float): for 'real rep., quality parameter of approximation
+            desc (string): whether to use the 'real' or 'complex' representation
+            D (float): for 'real rep., quality parameter of approximation
 
-         Returns:
-             tuple: arrays of the weights, means and covariances for the state
+        Returns:
+            tuple: arrays of the weights, means and covariances for the state
         """
 
-        if desc != "complex" and desc != "real":
+        if desc not in ("complex","real"):
             raise ValueError(r'``desc`` accepts only "real" or "complex" as arguments.')
 
         # Case alpha = 0, prepare vacuum
@@ -373,20 +373,20 @@ class BosonicBackend(BaseBosonic):
     def prepare_cat_real_rep(self, alpha, phi, cutoff, D):
         r"""Prepares the arrays of weights, means and covs for a cat state:
 
-         .. math::
+        math::
         \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}).
 
-         For this representation, weights, means and covariances are real-valued.
+        For this representation, weights, means and covariances are real-valued.
 
-         Args:
-             alpha (float): alpha value of cat state
-             phi (float): phi value of cat state
-             cutoff (float): if using the 'real' representation, this determines
+        Args:
+            alpha (float): alpha value of cat state
+            phi (float): phi value of cat state
+            cutoff (float): if using the 'real' representation, this determines
                  how many terms to keep
-             D (float): for 'real rep., quality parameter of approximation
+            D (float): for 'real rep., quality parameter of approximation
 
-         Returns:
-             tuple: arrays of the weights, means and covariances for the state
+        Returns:
+            tuple: arrays of the weights, means and covariances for the state
         """
         # Normalization factor
         norm = 1 / (2 * (1 + np.exp(-2 * np.absolute(alpha) ** 2) * np.cos(phi)))
@@ -469,7 +469,7 @@ class BosonicBackend(BaseBosonic):
 
         GKP states are qubits, with the qubit state defined by:
 
-        .. math::
+        math::
         \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
 
         where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # pylint: disable=too-many-public-methods
+# pylint: disable=import-outside-toplevel
 """Bosonic backend"""
 import itertools as it
 
@@ -172,6 +173,7 @@ class BosonicBackend(BaseBosonic):
             GKP,
             Ket,
         )
+
         nmodes = prog.num_subsystems
         self.begin_circuit(nmodes)
         # Dummy initial weights, means and covs
@@ -343,7 +345,7 @@ class BosonicBackend(BaseBosonic):
             tuple: arrays of the weights, means and covariances for the state
         """
 
-        if desc not in ("complex","real"):
+        if desc not in ("complex", "real"):
             raise ValueError(r'``desc`` accepts only "real" or "complex" as arguments.')
 
         # Case alpha = 0, prepare vacuum

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -395,7 +395,7 @@ class BosonicBackend(BaseBosonic):
             means = np.array([rplus, -rplus, rcomplex, np.conjugate(rcomplex)])
             covs = 0.5 * hbar * np.identity(2, dtype=float)
             covs = np.repeat(covs[None, :], weights.size, axis=0)
-            
+
             return weights, means, covs
 
         # The only remaining option is a real-valued cat state

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # pylint: disable=too-many-public-methods
 # pylint: disable=import-outside-toplevel
+# pylint: disable=too-many-branches
 """Bosonic backend"""
 import itertools as it
 
@@ -215,8 +216,8 @@ class BosonicBackend(BaseBosonic):
                             "Ket and DensityMatrix preparation not implemented in bosonic backend."
                         )
 
-                    # If a new mode is added in the program context, then add it
-                    # but don't add it to the reg_list in case there is a subsequent
+                    # If a new mode is added in the program context, then add it here,
+                    # but don't add its label to the reg_list in case there is a subsequent
                     # non-Gaussian state prep added
                     elif isinstance(cmd.op, _New_modes):
                         cmd.op.apply(cmd.reg, self)

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # pylint: disable=too-many-public-methods
-# pylint: disable=import-outside-toplevel
 
 """Bosonic backend"""
 import itertools as it
@@ -70,6 +69,7 @@ class BosonicBackend(BaseBosonic):
         self.circuit = None
         self.ancillae_samples_dict = {}
 
+    # pylint: disable=import-outside-toplevel
     def run_prog(self, prog, **kwargs):
         """Runs a strawberryfields program using the bosonic backend.
 
@@ -91,7 +91,7 @@ class BosonicBackend(BaseBosonic):
             Fock,
             GKP,
             Ket,
-            MbSgate,
+            MSgate,
             _New_modes,
         )
 
@@ -114,7 +114,7 @@ class BosonicBackend(BaseBosonic):
             Ket,
             _New_modes,
         )
-        ancilla_gates = (MbSgate,)
+        ancilla_gates = (MSgate,)
         for cmd in prog.circuit:
             # For ancilla-assisted gates, if they return measurement values, store
             # them in ancillae_samples_dict
@@ -163,6 +163,7 @@ class BosonicBackend(BaseBosonic):
         return applied, samples_dict, all_samples
 
     # pylint: disable=too-many-branches
+    # pylint: disable=import-outside-toplevel
     def init_circuit(self, prog):
         """Instantiate the circuit and initialize weights, means, and covs
         depending on the ``Preparation`` classes.
@@ -367,7 +368,7 @@ class BosonicBackend(BaseBosonic):
             representation (string): whether to use the ``'real'`` or ``'complex'`` representation
             cutoff (float): if using the ``'real'`` representation, this determines
                  how many terms to keep
-            D (float): for 'real' representation, quality parameter of approximation
+            D (float): for ``'real'`` representation, quality parameter of approximation
 
         Returns:
             tuple: arrays of the weights, means and covariances for the state
@@ -394,15 +395,19 @@ class BosonicBackend(BaseBosonic):
 
             # Mean of |alpha><alpha| term
             rplus = np.sqrt(2 * hbar) * np.array([alpha.real, alpha.imag])
+
             # Mean of |alpha><-alpha| term
             rcomplex = np.sqrt(2 * hbar) * np.array([1j * alpha.imag, -1j * alpha.real])
+
             # Coefficient for complex Gaussians
             cplx_coef = np.exp(-2 * np.absolute(alpha) ** 2 - 1j * phi)
 
             # Arrays of weights, means and covs
             weights = norm * np.array([1, 1, cplx_coef, np.conjugate(cplx_coef)])
             weights /= np.sum(weights)
+
             means = np.array([rplus, -rplus, rcomplex, np.conjugate(rcomplex)])
+
             covs = 0.5 * hbar * np.identity(2, dtype=float)
             covs = np.repeat(covs[None, :], weights.size, axis=0)
 
@@ -503,7 +508,7 @@ class BosonicBackend(BaseBosonic):
 
         return weights, means, cov
 
-    def prepare_gkp(self, state, epsilon, cutoff, desc="real", shape="square"):
+    def prepare_gkp(self, state, epsilon, cutoff, representation="real", shape="square"):
         r"""Prepares the arrays of weights, means and covs for a finite energy GKP state.
 
         GKP states are qubits, with the qubit state defined by:
@@ -515,9 +520,8 @@ class BosonicBackend(BaseBosonic):
         Args:
             state (list): ``[theta,phi]`` for qubit definition above
             epsilon (float): finite energy parameter of the state
-            cutoff (float): if using the ``'real'`` representation, this determines
-                how many terms to keep
-            desc (str): 'real' or 'complex' reprsentation
+            cutoff (float): this determines how many terms to keep
+            representation (str): ``'real'`` or ``'complex'`` reprsentation
             shape (str): shape of the lattice; default 'square'
 
         Returns:
@@ -527,7 +531,7 @@ class BosonicBackend(BaseBosonic):
             NotImplementedError: if the complex representation or a non-square lattice is attempted
         """
 
-        if desc == "complex":
+        if representation == "complex":
             raise NotImplementedError("The complex description of GKP is not implemented")
 
         if shape != "square":

--- a/strawberryfields/compilers/__init__.py
+++ b/strawberryfields/compilers/__init__.py
@@ -42,12 +42,14 @@ from .xstrict import Xstrict
 from .xunitary import Xunitary
 from .fock import Fock
 from .gaussian import Gaussian
+from .bosonic import Bosonic
 from .gbs import GBS
 from .gaussian_unitary import GaussianUnitary
 
 compilers = (
     Fock,
     Gaussian,
+    Bosonic,
     GBS,
     GaussianUnitary,
     Xcov,

--- a/strawberryfields/compilers/bosonic.py
+++ b/strawberryfields/compilers/bosonic.py
@@ -43,8 +43,8 @@ class Bosonic(Compiler):
         # measurements
         "MeasureHomodyne",
         "MeasureHeterodyne",
-        # "MeasureFock",
-        # "MeasureThreshold",
+        # TODO: "MeasureFock",
+        # TODO: "MeasureThreshold",
         # channels
         "LossChannel",
         "ThermalLossChannel",

--- a/strawberryfields/compilers/bosonic.py
+++ b/strawberryfields/compilers/bosonic.py
@@ -53,7 +53,7 @@ class Bosonic(Compiler):
         "Sgate",
         "Rgate",
         "BSgate",
-        "MbSgate",
+        "MSgate",
     }
 
     decompositions = {

--- a/strawberryfields/compilers/bosonic.py
+++ b/strawberryfields/compilers/bosonic.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Circuit specifications for general Gaussian simulator backends."""
+from .compiler import Compiler
+
+
+class Bosonic(Compiler):
+    """Compiler for general Bosonic backends."""
+
+    short_name = "bosonic"
+    interactive = True
+
+    primitives = {
+        # meta operations
+        "All",
+        "_New_modes",
+        "_Delete",
+        # state preparations
+        "Vacuum",
+        "Coherent",
+        "Squeezed",
+        "DisplacedSqueezed",
+        "Thermal",
+        "Gaussian",
+        "Fock",
+        "Ket",
+        "DensityMatrix",
+        "Bosonic",
+        "GKP",
+        "Catstate",
+        "Comb",
+        # measurements
+        "MeasureHomodyne",
+        "MeasureHeterodyne",
+        # "MeasureFock",
+        # "MeasureThreshold",
+        # channels
+        "LossChannel",
+        "ThermalLossChannel",
+        # single mode gates
+        "Dgate",
+        "Sgate",
+        "Rgate",
+        "BSgate",
+        "MbSgate",
+    }
+
+    decompositions = {
+        "Pgate": {},
+        "S2gate": {},
+        "CXgate": {},
+        "CZgate": {},
+        "MZgate": {},
+        "Xgate": {},
+        "Zgate": {},
+        "Fouriergate": {},
+    }

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -823,6 +823,12 @@ class Catstate(Preparation):
         alpha (complex): displacement parameter
         p (float): parity, where :math:`\phi=p\pi`. ``p=0`` corresponds to an even
             cat state, and ``p=1`` an odd cat state.
+        representation (str): whether to use the ``'real'`` or ``'complex'`` representation
+            (Bosonic backend only)
+        cutoff (float): if using the ``'real'`` representation, this determines
+            how many terms to keep (Bosonic backend only)
+        D (float): for ``'real'`` representation, quality parameter of approximation
+            (Bosonic backend only)
 
     .. details::
 

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -888,7 +888,7 @@ class GKP(Preparation):
     GKP states are qubits, with the qubit state defined by:
 
     .. math::
-        
+
     \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
 
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -794,15 +794,15 @@ class Fock(Preparation):
 
 class Bosonic(Preparation):
     """Prepare a mode as a linear combination of Gaussian functions in phase space.
-    
+
     Args:
         weights (array): coefficients for each Gaussian in the linear combination
         means (array): array of means for each Gaussian in the linear combination
         covs (array): array of covariance matrices for each Gaussian in the linear combination
     """
+
     def __init__(self, weights=None, means=None, covs=None):
-        super().__init__([weights,means,covs])
-        
+        super().__init__([weights, means, covs])
 
 
 class Catstate(Preparation):
@@ -880,24 +880,24 @@ class Catstate(Preparation):
 
 class GKP(Preparation):
     r"""Prepare a mode in a finite energy Gottesman-Kitaev-Preskill (GKP) state.
-    
+
     In their ideal form, square lattice GKP states are linear combinations of position eigenkets :math:`\ket{\cdot}_q`
     spaced every :math:`\sqrt{\pi\hbar}`. Finite energy GKPs are attained by applying the Fock damping
     operator :math:`e^{-\epsilon\hat{n}}` to the ideal states.
-    
+
     GKP states are qubits, with the qubit state defined by:
     .. math::
     \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
-    
+
     Square lattice GKPs have Wigner functions with peaks arranged on a square lattice, whereas alternative
-    lattices, such has hexagonal GKPs, can be obtained by applying symplectic transformations to the 
+    lattices, such has hexagonal GKPs, can be obtained by applying symplectic transformations to the
     square lattice GKPs.
-    
+
     Args:
         state (list): [theta,phi] for qubit definition above
         epsilon (float): finite energy parameter of the state
-        cutoff (float): if using the 'real' representation, this determines 
+        cutoff (float): if using the 'real' representation, this determines
                 how many terms to keep
         desc (string): 'real' or 'complex' reprsentation
         shape (string): 'square' lattice or otherwise
@@ -905,7 +905,6 @@ class GKP(Preparation):
 
     def __init__(self, state=[0, 0], epsilon=0.2, cutoff=1e-12, desc="real", shape="square"):
         super().__init__([state, epsilon, cutoff, desc, shape])
-
 
 
 class Ket(Preparation):
@@ -1337,11 +1336,11 @@ class ThermalLossChannel(Channel):
 
 class MbSgate(Channel):
     r"""Phase space measurement-based squeezing gate.
-    
-    This mode can either be implemented as the average transformation, 
-    corresponding to a Gaussian CPTP map, or as a single-shot instance 
+
+    This mode can either be implemented as the average transformation,
+    corresponding to a Gaussian CPTP map, or as a single-shot instance
     of the measurement-based squeezing circuit.
-    
+
     Measurement-based squeezing consists of adding an ancillary squeezed
     mode, entangling it with the target mode at a beamsplitter, performing
     a homodyne measurement on the ancillary mode, and then applying a feedforward

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -847,8 +847,8 @@ class Catstate(Preparation):
         the squeezed single photon state :math:`S\ket{1}`.
     """
 
-    def __init__(self, alpha=0, p=0, cutoff=1e-12, desc="complex", D=2):
-        super().__init__([alpha, p, cutoff, desc, D])
+    def __init__(self, alpha=0, p=0, representation="complex", cutoff=1e-12, D=2):
+        super().__init__([alpha, p, representation, cutoff, D])
 
     def _apply(self, reg, backend, **kwargs):
         alpha = self.p[0]

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -2895,7 +2895,7 @@ one_args_gates = (Xgate, Zgate, Rgate, Pgate, Vgate, Kgate, CXgate, CZgate, CKga
 two_args_gates = (Dgate, Sgate, BSgate, MZgate, S2gate)
 gates = zero_args_gates + one_args_gates + two_args_gates
 
-channels = (LossChannel, ThermalLossChannel)
+channels = (LossChannel, ThermalLossChannel, MSgate)
 
 simple_state_preparations = (
     Vacuum,

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -888,6 +888,7 @@ class GKP(Preparation):
     GKP states are qubits, with the qubit state defined by:
 
     .. math::
+        
     \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
 
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -886,8 +886,10 @@ class GKP(Preparation):
     operator :math:`e^{-\epsilon\hat{n}}` to the ideal states.
 
     GKP states are qubits, with the qubit state defined by:
+    
     .. math::
     \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
+    
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 
     Square lattice GKPs have Wigner functions with peaks arranged on a square lattice, whereas alternative
@@ -903,7 +905,9 @@ class GKP(Preparation):
         shape (string): 'square' lattice or otherwise
     """
 
-    def __init__(self, state=[0, 0], epsilon=0.2, cutoff=1e-12, desc="real", shape="square"):
+    def __init__(self, state=None, epsilon=0.2, cutoff=1e-12, desc="real", shape="square"):
+        if state is None:
+            state = [0, 0]
         super().__init__([state, epsilon, cutoff, desc, shape])
 
 
@@ -948,6 +952,8 @@ class Ket(Preparation):
             super().__init__([state.ket()])
         elif isinstance(state, BaseGaussianState):
             raise ValueError("Gaussian states are not supported for the Ket operation.")
+        elif isinstance(state, BaseBosonicState):
+            raise ValueError("Bosonic states are not supported for the Ket operation.")
         else:
             super().__init__([state])
 
@@ -1345,6 +1351,13 @@ class MbSgate(Channel):
     mode, entangling it with the target mode at a beamsplitter, performing
     a homodyne measurement on the ancillary mode, and then applying a feedforward
     displacement to the target mode.
+    
+    Args:
+        r (float): target squeezing magnitude
+        phi (float): target squeezing phase
+        r_anc (float): squeezing magnitude of the ancillary mode
+        eta_anc(float): detection efficiency of the ancillary mode
+        avg (bool): whether to apply the average or single-shot map
     """
 
     def __init__(self, r, phi=0.0, r_anc=10.0, eta_anc=1.0, avg=True):
@@ -1355,10 +1368,10 @@ class MbSgate(Channel):
         if avg:
             backend.mb_squeeze_avg(*reg, r, phi, r_anc, eta_anc)
             return None
-        if not avg:
-            s = np.sqrt(sf.hbar / 2)
-            ancilla_val = backend.mb_squeeze_single_shot(*reg, r, phi, r_anc, eta_anc)
-            return ancilla_val / s
+        
+        s = np.sqrt(sf.hbar / 2)
+        ancilla_val = backend.mb_squeeze_single_shot(*reg, r, phi, r_anc, eta_anc)
+        return ancilla_val / s
 
 
 # ====================================================================

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -888,8 +888,7 @@ class GKP(Preparation):
     GKP states are qubits, with the qubit state defined by:
 
     .. math::
-
-    \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
+        \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^{-i\phi}\sin\frac{\theta}{2}\ket{1}_{gkp}
 
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 
@@ -902,8 +901,8 @@ class GKP(Preparation):
         epsilon (float): finite energy parameter of the state
         cutoff (float): if using the 'real' representation, this determines
                 how many terms to keep
-        desc (string): 'real' or 'complex' reprsentation
-        shape (string): 'square' lattice or otherwise
+        desc (str): 'real' or 'complex' reprsentation
+        shape (str): shape of the lattice; default 'square'
     """
 
     def __init__(self, state=None, epsilon=0.2, cutoff=1e-12, desc="real", shape="square"):

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -886,10 +886,10 @@ class GKP(Preparation):
     operator :math:`e^{-\epsilon\hat{n}}` to the ideal states.
 
     GKP states are qubits, with the qubit state defined by:
-    
+
     .. math::
     \ket{\psi}_{gkp} = \cos\frac{\theta}{2}\ket{0}_{gkp} + e^(-i\phi)\sin\frac{\theta}{2}\ket{1}_{gkp}
-    
+
     where the computational basis states are :math:`\ket{\mu}_{gkp} = \sum_{n} \ket{(2n+\mu)\sqrt{\pi\hbar}}_{q}`.
 
     Square lattice GKPs have Wigner functions with peaks arranged on a square lattice, whereas alternative
@@ -1351,7 +1351,7 @@ class MbSgate(Channel):
     mode, entangling it with the target mode at a beamsplitter, performing
     a homodyne measurement on the ancillary mode, and then applying a feedforward
     displacement to the target mode.
-    
+
     Args:
         r (float): target squeezing magnitude
         phi (float): target squeezing phase
@@ -1368,7 +1368,7 @@ class MbSgate(Channel):
         if avg:
             backend.mb_squeeze_avg(*reg, r, phi, r_anc, eta_anc)
             return None
-        
+
         s = np.sqrt(sf.hbar / 2)
         ancilla_val = backend.mb_squeeze_single_shot(*reg, r, phi, r_anc, eta_anc)
         return ancilla_val / s

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -899,16 +899,17 @@ class GKP(Preparation):
     Args:
         state (list): [theta,phi] for qubit definition above
         epsilon (float): finite energy parameter of the state
-        cutoff (float): if using the 'real' representation, this determines
-                how many terms to keep
-        desc (str): 'real' or 'complex' reprsentation
-        shape (str): shape of the lattice; default 'square'
+        cutoff (float): this determines how many terms to keep
+        representation (str): ``'real'`` or ``'complex'`` reprsentation
+        shape (str): shape of the lattice; default ``'square'``
     """
 
-    def __init__(self, state=None, epsilon=0.2, cutoff=1e-12, desc="real", shape="square"):
+    def __init__(
+        self, state=None, epsilon=0.2, cutoff=1e-12, representation="real", shape="square"
+    ):
         if state is None:
             state = [0, 0]
-        super().__init__([state, epsilon, cutoff, desc, shape])
+        super().__init__([state, epsilon, cutoff, representation, shape])
 
 
 class Ket(Preparation):
@@ -1340,7 +1341,7 @@ class ThermalLossChannel(Channel):
         backend.thermal_loss(p[0], p[1], *reg)
 
 
-class MbSgate(Channel):
+class MSgate(Channel):
     r"""Phase space measurement-based squeezing gate.
 
     This mode can either be implemented as the average transformation,

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -23,47 +23,49 @@ import pytest
 
 pytestmark = pytest.mark.bosonic
 
-ALPHA_VALS = np.linspace(-1,1,5)
-PHI_VALS = np.linspace(0,1,3)
-FOCK_VALS = np.arange(5,dtype=int)
-r_fock = 0.05  
-EPS_VALS = np.array([0.01,0.05,0.1,0.5])
-R_VALS = np.linspace(-1,1,5)
+ALPHA_VALS = np.linspace(-1, 1, 5)
+PHI_VALS = np.linspace(0, 1, 3)
+FOCK_VALS = np.arange(5, dtype=int)
+r_fock = 0.05
+EPS_VALS = np.array([0.01, 0.05, 0.1, 0.5])
+R_VALS = np.linspace(-1, 1, 5)
 
-class TestKronList():
+
+class TestKronList:
     """Test kron_list function from the bosonic backend."""
+
     def test_kron_list(self):
-        l1 = [1,2]
-        l2 = [3,4,5]
-        list_compare = [3,4,5,6,8,10]
-        assert np.allclose(list_compare, bosonic.kron_list([l1,l2]))
+        l1 = [1, 2]
+        l2 = [3, 4, 5]
+        list_compare = [3, 4, 5, 6, 8, 10]
+        assert np.allclose(list_compare, bosonic.kron_list([l1, l2]))
+
 
 class TestBosonicCatStates:
     r"""Tests cat state method of the BosonicBackend class."""
-    
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
-    def test_cat_complex(self,alpha,phi):
+    def test_cat_complex(self, alpha, phi):
         r"""Checks the complex cat state representation."""
         prog = sf.Program(1)
         with prog.context as q:
-            sf.ops.Catstate(alpha,phi) | q[0]
-              
+            sf.ops.Catstate(alpha, phi) | q[0]
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        
-       
+
         if alpha != 0:
             # Check shapes
             assert state.num_weights == 4
             assert state.weights().shape == (4,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (4,2)
-            assert state.covs().shape == (4,2,2)
-            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(4,1,1))
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (4, 2)
+            assert state.covs().shape == (4, 2, 2)
+            covs_compare = np.tile(np.eye(2) * sf.hbar / 2, (4, 1, 1))
             assert np.allclose(state.covs(), covs_compare)
-            
+
             # Weights not real if phi != 0 or 1
             if phi % 1 == 0:
                 assert np.allclose(state.weights().real, state.weights())
@@ -75,305 +77,308 @@ class TestBosonicCatStates:
         else:
             assert state.num_weights == 1
             assert state.weights().shape == (1,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (1,2)
-            assert state.covs().shape == (1,2,2)
-            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(1,1,1))
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (1, 2)
+            assert state.covs().shape == (1, 2, 2)
+            covs_compare = np.tile(np.eye(2) * sf.hbar / 2, (1, 1, 1))
             assert np.allclose(state.covs(), covs_compare)
-    
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
-    def test_cat_real(self,alpha,phi):
+    def test_cat_real(self, alpha, phi):
         r"""Checks the real cat state representation."""
         # Check that low cutoff and low D produce fewer weights when alpha !=0
         prog = sf.Program(1)
         with prog.context as q:
-            sf.ops.Catstate(alpha,phi,cutoff=1e-6,desc="real",D=1) | q[0]
-              
+            sf.ops.Catstate(alpha, phi, cutoff=1e-6, desc="real", D=1) | q[0]
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
         num_weights_low = state.num_weights
-        
-        assert np.allclose(sum(state.weights()),1)
-        assert state.means().shape == (num_weights_low,2)
-        assert state.covs().shape == (num_weights_low,2,2)
-        
+
+        assert np.allclose(sum(state.weights()), 1)
+        assert state.means().shape == (num_weights_low, 2)
+        assert state.covs().shape == (num_weights_low, 2, 2)
+
         # Weights, means and covs should be real
         assert np.allclose(state.weights().real, state.weights())
         assert np.allclose(state.means().real, state.means())
         assert np.allclose(state.covs().real, state.covs())
-        
+
         prog = sf.Program(1)
         with prog.context as q:
-            sf.ops.Catstate(alpha,phi,cutoff=1e-12,desc="real",D=10) | q[0]
-              
+            sf.ops.Catstate(alpha, phi, cutoff=1e-12, desc="real", D=10) | q[0]
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
         num_weights_high = state.num_weights
-        
-        assert np.allclose(sum(state.weights()),1)
-        assert state.means().shape == (num_weights_high,2)
-        assert state.covs().shape == (num_weights_high,2,2)
-        
+
+        assert np.allclose(sum(state.weights()), 1)
+        assert state.means().shape == (num_weights_high, 2)
+        assert state.covs().shape == (num_weights_high, 2, 2)
+
         if alpha != 0:
             assert num_weights_low < num_weights_high
         else:
             assert num_weights_low == num_weights_high
-    
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
-    def test_cat_state_wigners(self,alpha,phi):
+    def test_cat_state_wigners(self, alpha, phi):
         r"""Checks that the real and complex cat state representations
-        have the same Wigner functions as the cat state from the Fock 
+        have the same Wigner functions as the cat state from the Fock
         backend."""
-        x = np.linspace(-2*alpha,2*alpha,100)
-        p = np.linspace(-2*alpha,2*alpha,100)
-        
+        x = np.linspace(-2 * alpha, 2 * alpha, 100)
+        p = np.linspace(-2 * alpha, 2 * alpha, 100)
+
         prog_complex_cat = sf.Program(1)
         with prog_complex_cat.context as qc:
-            sf.ops.Catstate(alpha,phi) | qc[0]
-        
+            sf.ops.Catstate(alpha, phi) | qc[0]
+
         prog_real_cat = sf.Program(1)
         with prog_real_cat.context as qr:
-            sf.ops.Catstate(alpha,phi,desc="real",D=10) | qr[0]
-        
+            sf.ops.Catstate(alpha, phi, desc="real", D=10) | qr[0]
+
         backend_complex = bosonic.BosonicBackend()
         backend_complex.run_prog(prog_complex_cat)
-        wigner_complex = backend_complex.state().wigner(0,x,p)
-        
+        wigner_complex = backend_complex.state().wigner(0, x, p)
+
         backend_real = bosonic.BosonicBackend()
         backend_real.run_prog(prog_real_cat)
-        wigner_real = backend_real.state().wigner(0,x,p)
-        
+        wigner_real = backend_real.state().wigner(0, x, p)
+
         prog_cat_fock = sf.Program(1)
         with prog_cat_fock.context as qf:
             if alpha != 0:
-                sf.ops.Catstate(alpha,phi) | qf[0]
+                sf.ops.Catstate(alpha, phi) | qf[0]
             else:
                 sf.ops.Vacuum() | qf[0]
         eng = sf.Engine("fock", backend_options={"cutoff_dim": 20})
         results = eng.run(prog_cat_fock)
-        wigner_fock = results.state.wigner(0,x,p)
-        
+        wigner_fock = results.state.wigner(0, x, p)
+
         assert np.allclose(wigner_complex, wigner_real, rtol=1e-3, atol=1e-6)
         assert np.allclose(wigner_complex, wigner_fock, rtol=1e-3, atol=1e-6)
         assert np.allclose(wigner_fock, wigner_real, rtol=1e-3, atol=1e-6)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
-    def test_cat_state_parity(self,alpha):
+    def test_cat_state_parity(self, alpha):
         r"""Checks that the real and complex cat state representations
-        yield the correct parity."""    
+        yield the correct parity."""
         # for phi = 0, should yield parity of 1
         prog_complex_cat = sf.Program(1)
         with prog_complex_cat.context as qc:
             sf.ops.Catstate(alpha) | qc[0]
-        
+
         prog_real_cat = sf.Program(1)
         with prog_real_cat.context as qr:
-            sf.ops.Catstate(alpha,desc="real") | qr[0]
-        
+            sf.ops.Catstate(alpha, desc="real") | qr[0]
+
         backend_complex = bosonic.BosonicBackend()
         backend_complex.run_prog(prog_complex_cat)
         state_complex = backend_complex.state()
         parity_complex = state_complex.parity_expectation([0])
-        
+
         backend_real = bosonic.BosonicBackend()
         backend_real.run_prog(prog_real_cat)
         state_real = backend_real.state()
         parity_real = state_real.parity_expectation([0])
-               
+
         assert np.allclose(parity_complex, 1)
         assert np.allclose(parity_real, 1)
-        
+
         # for phi = 1, should yield parity of -1 unless alpha == 0
         if alpha != 0:
             prog_complex_cat = sf.Program(1)
             with prog_complex_cat.context as qc:
-                sf.ops.Catstate(alpha,1) | qc[0]
-            
+                sf.ops.Catstate(alpha, 1) | qc[0]
+
             prog_real_cat = sf.Program(1)
             with prog_real_cat.context as qr:
-                sf.ops.Catstate(alpha,1,desc="real") | qr[0]
-            
+                sf.ops.Catstate(alpha, 1, desc="real") | qr[0]
+
             backend_complex = bosonic.BosonicBackend()
             backend_complex.run_prog(prog_complex_cat)
             state_complex = backend_complex.state()
             parity_complex = state_complex.parity_expectation([0])
-            
+
             backend_real = bosonic.BosonicBackend()
             backend_real.run_prog(prog_real_cat)
             state_real = backend_real.state()
             parity_real = state_real.parity_expectation([0])
-                   
+
             assert np.allclose(parity_complex, -1)
             assert np.allclose(parity_real, -1)
 
+
 class TestBosonicFockStates:
     r"""Tests fock state method of the BosonicBackend class."""
-    
+
     @pytest.mark.parametrize("n", FOCK_VALS)
-    def test_fock(self,n):
+    def test_fock(self, n):
         r"""Checks fock states in the bosonic representation."""
         prog = sf.Program(1)
         with prog.context as q:
             sf.ops.Fock(n) | q[0]
-              
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        
-        # check shapes
-        assert state.num_weights == n+1
-        assert state.weights().shape == (n+1,)
-        assert np.allclose(sum(state.weights()),1)
-        assert state.means().shape == (n+1,2)
-        assert state.covs().shape == (n+1,2,2)
-        
-        # check mean photon is close to n
-        mean,var = state.mean_photon(0)
+
+        # Check shapes
+        assert state.num_weights == n + 1
+        assert state.weights().shape == (n + 1,)
+        assert np.allclose(sum(state.weights()), 1)
+        assert state.means().shape == (n + 1, 2)
+        assert state.covs().shape == (n + 1, 2, 2)
+
+        # Check mean photon is close to n
+        mean, var = state.mean_photon(0)
         assert np.allclose(mean, n, atol=r_fock)
         assert np.allclose(var, 0, atol=r_fock)
-        
+
         # Weights, means and covs should be real
         assert np.allclose(state.weights().real, state.weights())
         assert np.allclose(state.means().real, state.means())
         assert np.allclose(state.covs().real, state.covs())
-        
+
         if n == 0:
-            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(1,1,1))
+            covs_compare = np.tile(np.eye(2) * sf.hbar / 2, (1, 1, 1))
             assert np.allclose(state.covs(), covs_compare)
-            assert np.allclose(state.fidelity_vacuum(),1)
-    
+            assert np.allclose(state.fidelity_vacuum(), 1)
+
     @pytest.mark.parametrize("n", FOCK_VALS)
-    def test_fock_state_wigners(self,n):
+    def test_fock_state_wigners(self, n):
         r"""Checks that fock state Wigner functions in the bosonic and Fock
         backends match."""
-        x = np.linspace(-n,n,100)
-        p = np.linspace(-n,n,100)
-        
+        x = np.linspace(-n, n, 100)
+        p = np.linspace(-n, n, 100)
+
         prog = sf.Program(1)
         with prog as q:
             sf.ops.Fock(n) | q[0]
-        
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
-        wigner_bosonic = backend.state().wigner(0,x,p)
-        
-        eng = sf.Engine("fock", backend_options={"cutoff_dim": int(n+1)})
+        wigner_bosonic = backend.state().wigner(0, x, p)
+
+        eng = sf.Engine("fock", backend_options={"cutoff_dim": int(n + 1)})
         results = eng.run(prog)
-        wigner_fock = results.state.wigner(0,x,p)
-        
-        assert np.allclose(wigner_fock,wigner_bosonic,atol=r_fock)
+        wigner_fock = results.state.wigner(0, x, p)
+
+        assert np.allclose(wigner_fock, wigner_bosonic, atol=r_fock)
 
     @pytest.mark.parametrize("n", FOCK_VALS)
-    def test_fock_state_parity(self,n):
-        r"""Checks that fock states have the right parity."""    
+    def test_fock_state_parity(self, n):
+        r"""Checks that fock states have the right parity."""
         prog = sf.Program(1)
         with prog.context as q:
             sf.ops.Fock(n) | q[0]
-              
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        assert np.allclose(state.parity_expectation([0]),(-1.0)**n,atol=r_fock)
+        assert np.allclose(state.parity_expectation([0]), (-1.0) ** n, atol=r_fock)
+
 
 class TestBosonicGKPStates:
     r"""Tests the gkp method of the BosonicBackend class."""
-    
+
     @pytest.mark.parametrize("eps", EPS_VALS)
-    def test_gkp(self,eps):
+    def test_gkp(self, eps):
         r"""Checks the GKP state weights, means and covariances are correct."""
         prog = sf.Program(1)
         with prog.context as q:
             sf.ops.GKP(epsilon=eps) | q[0]
-              
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
         num_weights = state.num_weights
         assert state.weights().shape == (num_weights,)
-        assert np.allclose(sum(state.weights()),1)
-        assert state.means().shape == (num_weights,2)
-        assert state.covs().shape == (num_weights,2,2)
-        
+        assert np.allclose(sum(state.weights()), 1)
+        assert state.means().shape == (num_weights, 2)
+        assert state.covs().shape == (num_weights, 2, 2)
+
         # Weights, means and covs should be real
         assert np.allclose(state.weights().real, state.weights())
         assert np.allclose(state.means().real, state.means())
         assert np.allclose(state.covs().real, state.covs())
-        
+
         # Covariance should be diagonal with these entries
-        cov_val = (1 - np.exp(-2 * eps))/ (1 + np.exp(-2 * eps))*sf.hbar/2
-        covs_compare = np.tile(cov_val*np.eye(2),(num_weights,1,1))
-        assert np.allclose(state.covs(),covs_compare)
-        
+        cov_val = (1 - np.exp(-2 * eps)) / (1 + np.exp(-2 * eps)) * sf.hbar / 2
+        covs_compare = np.tile(cov_val * np.eye(2), (num_weights, 1, 1))
+        assert np.allclose(state.covs(), covs_compare)
+
         # Means should be integer multiples of sqrt(pi*hbar)/2 times a damping
         damping = 2 * np.exp(-eps) / (1 + np.exp(-2 * eps))
-        mean_ints = state.means()/(damping*np.sqrt(np.pi*sf.hbar)/2)
+        mean_ints = state.means() / (damping * np.sqrt(np.pi * sf.hbar) / 2)
         # Round to make sure numerical errors are washed out
-        mean_ints = np.round(np.real_if_close(mean_ints),10)
+        mean_ints = np.round(np.real_if_close(mean_ints), 10)
         assert np.allclose(mean_ints % 1, np.zeros(mean_ints.shape))
-    
+
     @pytest.mark.parametrize("eps", EPS_VALS)
-    def test_gkp_logical(self,eps):
+    def test_gkp_logical(self, eps):
         r"""Checks that logically equivalent GKP states have
         Wigner functions that agree."""
-        x = np.linspace(-3*np.sqrt(np.pi),3*np.sqrt(np.pi),40)
-        p = np.linspace(-3*np.sqrt(np.pi),3*np.sqrt(np.pi),40)
-        
+        x = np.linspace(-3 * np.sqrt(np.pi), 3 * np.sqrt(np.pi), 40)
+        p = np.linspace(-3 * np.sqrt(np.pi), 3 * np.sqrt(np.pi), 40)
+
         # Prepare GKP 0 and apply Hadamard
         prog_0H = sf.Program(1)
         with prog_0H.context as q0:
             sf.ops.GKP(epsilon=eps) | q0[0]
-            sf.ops.Rgate(np.pi/2) | q0[0]
-              
+            sf.ops.Rgate(np.pi / 2) | q0[0]
+
         backend_0H = bosonic.BosonicBackend()
         backend_0H.run_prog(prog_0H)
         state_0H = backend_0H.state()
-        wigner_0H = state_0H.wigner(0,x,p)
-        
+        wigner_0H = state_0H.wigner(0, x, p)
+
         # Prepare GKP +
         prog_plus = sf.Program(1)
         with prog_plus.context as qp:
-            sf.ops.GKP(state=[np.pi/2,0],epsilon=eps) | qp[0]
-              
+            sf.ops.GKP(state=[np.pi / 2, 0], epsilon=eps) | qp[0]
+
         backend_plus = bosonic.BosonicBackend()
         backend_plus.run_prog(prog_plus)
         state_plus = backend_plus.state()
-        wigner_plus = state_plus.wigner(0,x,p)
-        
-        assert np.allclose(wigner_0H,wigner_plus)
-    
+        wigner_plus = state_plus.wigner(0, x, p)
+
+        assert np.allclose(wigner_0H, wigner_plus)
+
     @pytest.mark.parametrize("eps", EPS_VALS)
-    def test_gkp_state_parity(self,eps):
-        r"""Checks that GKP states yield the right parity."""    
+    def test_gkp_state_parity(self, eps):
+        r"""Checks that GKP states yield the right parity."""
         prog = sf.Program(1)
         with prog.context as q:
             sf.ops.GKP(epsilon=eps) | q[0]
-              
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        assert np.allclose(state.parity_expectation([0]),1,atol=r_fock)
-    
+        assert np.allclose(state.parity_expectation([0]), 1, atol=r_fock)
+
     def test_gkp_complex(self):
         r"""Checks that trying to call a complex representation
         raises an error.
-        
+
         This test can be updated once the complex representation is
-        implemented."""   
+        implemented."""
         with pytest.raises(NotImplementedError):
             prog = sf.Program(1)
             with prog.context as q:
                 sf.ops.GKP(desc="complex") | q[0]
-                  
+
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)
 
+
 class TestBosonicUserSpecifiedState:
     """Checks the Bosonic preparation method."""
-    
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     def test_complex_weight(self, alpha):
         r"""Checks that Bosonic creates a state with user-specifed weights, means
@@ -381,33 +386,34 @@ class TestBosonicUserSpecifiedState:
         dummy_backend = bosonic.BosonicBackend()
         dummy_backend.begin_circuit(1)
         # Get weights, means and covs for a cat state
-        weights, means, covs = dummy_backend.prepare_cat(alpha,0,0,'complex',0)
-        
+        weights, means, covs = dummy_backend.prepare_cat(alpha, 0, 0, "complex", 0)
+
         # Initiate the state, but use Bosonic method
         backend = bosonic.BosonicBackend()
         prog = sf.Program(1)
         with prog.context as q1:
-            sf.ops.Bosonic(weights,means,covs) | q1[0]
+            sf.ops.Bosonic(weights, means, covs) | q1[0]
         backend.run_prog(prog)
         state = backend.state()
-        
-        #Prepare using the Catstate method
+
+        # Prepare using the Catstate method
         backend2 = bosonic.BosonicBackend()
         prog2 = sf.Program(1)
         with prog2.context as q2:
             sf.ops.Catstate(alpha) | q2[0]
         backend2.run_prog(prog2)
         state2 = backend2.state()
-        
-        #Check the two states are equal
+
+        # Check the two states are equal
         assert state.__eq__(state2)
-        
+
+
 class TestBosonicPrograms:
     """Tests that small programs run and return the correct output."""
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)
-    def test_init_circuit(self,alpha,r):
+    def test_init_circuit(self, alpha, r):
         """Checks init_circuit only prepares non-Gaussian states and vacuum."""
         prog = sf.Program(3)
         with prog.context as q:
@@ -418,21 +424,21 @@ class TestBosonicPrograms:
         backend = bosonic.BosonicBackend()
         backend.init_circuit(prog)
         state = backend.state()
-                
-        #Check that second and third mode are still in vacuum
-        weights,means,covs = state.reduced_bosonic([1,2])
-        
+
+        # Check that second and third mode are still in vacuum
+        weights, means, covs = state.reduced_bosonic([1, 2])
+
         mean_compare = np.zeros(4)
-        means_compare = np.tile(mean_compare,(4,1))
-        assert np.allclose(means,means_compare) 
-        
-        cov_compare = np.diag([1,1,1,1])
-        covs_compare = np.tile(cov_compare*sf.hbar/2,(4,1,1))
-        assert np.allclose(covs,covs_compare)    
+        means_compare = np.tile(mean_compare, (4, 1))
+        assert np.allclose(means, means_compare)
+
+        cov_compare = np.diag([1, 1, 1, 1])
+        covs_compare = np.tile(cov_compare * sf.hbar / 2, (4, 1, 1))
+        assert np.allclose(covs, covs_compare)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)
-    def test_different_preparations(self,alpha,r):
+    def test_different_preparations(self, alpha, r):
         """Runs a program with non-Gaussian and Gaussian preparations."""
         prog = sf.Program(3)
         with prog.context as q:
@@ -441,28 +447,28 @@ class TestBosonicPrograms:
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        
-        #Check output shapes
+
+        # Check output shapes
         if alpha != 0:
             assert state.weights().shape == (4,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (4,6)
-            assert state.covs().shape == (4,6,6)
-        
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (4, 6)
+            assert state.covs().shape == (4, 6, 6)
+
         else:
             assert state.weights().shape == (1,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (1,6)
-            assert state.covs().shape == (1,6,6)
-        
-        #Check covariance is correct
-        cov_compare = np.diag([1,1,np.exp(-2*r),np.exp(2*r),1,1])
-        covs_compare = np.tile(cov_compare*sf.hbar/2,(4,1,1))
-        assert np.allclose(state.covs(),covs_compare)
-        
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (1, 6)
+            assert state.covs().shape == (1, 6, 6)
+
+        # Check covariance is correct
+        cov_compare = np.diag([1, 1, np.exp(-2 * r), np.exp(2 * r), 1, 1])
+        covs_compare = np.tile(cov_compare * sf.hbar / 2, (4, 1, 1))
+        assert np.allclose(state.covs(), covs_compare)
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)
-    def test_measurement(self,alpha,r):
+    def test_measurement(self, alpha, r):
         """Runs a program with measurements."""
         prog = sf.Program(2)
         with prog.context as q:
@@ -473,40 +479,40 @@ class TestBosonicPrograms:
         backend = bosonic.BosonicBackend()
         applied, samples, all_samples = backend.run_prog(prog)
         state = backend.state()
-        
-        #Check output is vacuum since everything was measured
-        assert np.allclose(state.fidelity_vacuum(),1)
-        
-        #Check samples
+
+        # Check output is vacuum since everything was measured
+        assert np.allclose(state.fidelity_vacuum(), 1)
+
+        # Check samples
         for i in range(2):
             assert i in samples.keys()
             assert samples[i].shape == (1,)
-            
+
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)
-    def test_mb_gates(self,alpha,r):
+    def test_mb_gates(self, alpha, r):
         """Runs a program with measurement-based gates."""
         prog = sf.Program(2)
         with prog.context as q:
-            sf.ops.MbSgate(1,0,1,1,avg=True) | q[0]
-            sf.ops.MbSgate(1,0,1,1,avg=False) | q[1]
-            sf.ops.MbSgate(1,0,1,1,avg=False) | q[1]
+            sf.ops.MbSgate(1, 0, 1, 1, avg=True) | q[0]
+            sf.ops.MbSgate(1, 0, 1, 1, avg=False) | q[1]
+            sf.ops.MbSgate(1, 0, 1, 1, avg=False) | q[1]
         backend = bosonic.BosonicBackend()
         applied, samples, all_samples = backend.run_prog(prog)
-        
-        #Check number of active modes did not change
-        assert backend.get_modes() == [0,1]
-        
-        #Check samples for the data modes are empty
+
+        # Check number of active modes did not change
+        assert backend.get_modes() == [0, 1]
+
+        # Check samples for the data modes are empty
         assert samples == {}
-        
-        #Check ancilla samples exist for the second mode
+
+        # Check ancilla samples exist for the second mode
         ancilla_samples = backend.ancillae_samples_dict
         assert 1 in ancilla_samples.keys()
         assert len(ancilla_samples[1]) == 2
-        
-    @pytest.mark.parametrize("alpha", ALPHA_VALS)        
-    def test_add_new_mode(self,alpha):
+
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    def test_add_new_mode(self, alpha):
         """Tests adding a new mode in a program context."""
         prog = sf.Program(1)
         with prog.context as q:
@@ -516,45 +522,45 @@ class TestBosonicPrograms:
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()
-        #Check output shapes
+        # Check output shapes
         if alpha != 0:
             assert state.weights().shape == (4,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (4,4)
-            assert state.covs().shape == (4,4,4)
-        
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (4, 4)
+            assert state.covs().shape == (4, 4, 4)
+
         else:
             assert state.weights().shape == (1,)
-            assert np.allclose(sum(state.weights()),1)
-            assert state.means().shape == (1,4)
-            assert state.covs().shape == (1,4,4)
-        
+            assert np.allclose(sum(state.weights()), 1)
+            assert state.means().shape == (1, 4)
+            assert state.covs().shape == (1, 4, 4)
+
     def test_raised_errors(self):
         """Runs programs with operations that are not applicable
         or have not been implemented."""
         from strawberryfields.backends.base import NotApplicableError
-        
+
         with pytest.raises(NotApplicableError):
             prog = sf.Program(1)
             with prog.context as q:
                 sf.ops.Kgate(1) | q[0]
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)
-            
+
         with pytest.raises(NotImplementedError):
             prog = sf.Program(1)
             with prog.context as q:
                 sf.ops.MeasureThreshold() | q[0]
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)
-    
+
     def test_non_initial_prep_error(self):
         """Tests that more than one non-Gaussian state preparations in the same mode
         raises an error."""
         with pytest.raises(NotImplementedError):
             prog = sf.Program(1)
             with prog.context as q:
-                sf.ops.Catstate()|q[0]
+                sf.ops.Catstate() | q[0]
                 sf.ops.GKP() | q[0]
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -66,7 +66,7 @@ class TestBosonicCatStates:
             covs_compare = np.tile(np.eye(2) * sf.hbar / 2, (4, 1, 1))
             assert np.allclose(state.covs(), covs_compare)
 
-            # Weights not real if phi != 0 or 1
+            # Weights should be real if phi is an integer
             if phi % 1 == 0:
                 assert np.allclose(state.weights().real, state.weights())
             else:

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -90,7 +90,7 @@ class TestBosonicCatStates:
         # Check that low cutoff and low D produce fewer weights when alpha !=0
         prog = sf.Program(1)
         with prog.context as q:
-            sf.ops.Catstate(alpha, phi, cutoff=1e-6, desc="real", D=1) | q[0]
+            sf.ops.Catstate(alpha, phi, representation="real", cutoff=1e-6, D=1) | q[0]
 
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
@@ -108,7 +108,7 @@ class TestBosonicCatStates:
 
         prog = sf.Program(1)
         with prog.context as q:
-            sf.ops.Catstate(alpha, phi, cutoff=1e-12, desc="real", D=10) | q[0]
+            sf.ops.Catstate(alpha, phi, representation="real", cutoff=1e-6, D=10) | q[0]
 
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
@@ -139,7 +139,7 @@ class TestBosonicCatStates:
 
         prog_real_cat = sf.Program(1)
         with prog_real_cat.context as qr:
-            sf.ops.Catstate(alpha, phi, desc="real", D=10) | qr[0]
+            sf.ops.Catstate(alpha, phi, representation="real", D=10) | qr[0]
 
         backend_complex = bosonic.BosonicBackend()
         backend_complex.run_prog(prog_complex_cat)
@@ -174,7 +174,7 @@ class TestBosonicCatStates:
 
         prog_real_cat = sf.Program(1)
         with prog_real_cat.context as qr:
-            sf.ops.Catstate(alpha, desc="real") | qr[0]
+            sf.ops.Catstate(alpha, representation="real") | qr[0]
 
         backend_complex = bosonic.BosonicBackend()
         backend_complex.run_prog(prog_complex_cat)
@@ -197,7 +197,7 @@ class TestBosonicCatStates:
 
             prog_real_cat = sf.Program(1)
             with prog_real_cat.context as qr:
-                sf.ops.Catstate(alpha, 1, desc="real") | qr[0]
+                sf.ops.Catstate(alpha, 1, representation="real") | qr[0]
 
             backend_complex = bosonic.BosonicBackend()
             backend_complex.run_prog(prog_complex_cat)
@@ -387,7 +387,7 @@ class TestBosonicUserSpecifiedState:
         dummy_backend = bosonic.BosonicBackend()
         dummy_backend.begin_circuit(1)
         # Get weights, means and covs for a cat state
-        weights, means, covs = dummy_backend.prepare_cat(alpha, 0, 0, "complex", 0)
+        weights, means, covs = dummy_backend.prepare_cat(alpha, 0, "complex", 0, 0)
 
         # Initiate the state, but use Bosonic method
         backend = bosonic.BosonicBackend()

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 r"""
-Unit tests for backends.bosonicbackend.bosoniccircuit.py.
+Unit tests for backends.bosonicbackend.backend.py.
 """
 
 import numpy as np
@@ -279,11 +279,11 @@ class TestBosonicFockStates:
 
 @pytest.mark.backends("bosonic")
 class TestBosonicGKPStates:
-    r"""Tests gkp method of the BosonicBackend class."""
+    r"""Tests the gkp method of the BosonicBackend class."""
     
     @pytest.mark.parametrize("eps", EPS_VALS)
     def test_gkp(self,eps):
-        r"""Checks the complex cat state representation."""
+        r"""Checks the GKP state weights, means and covariances are correct."""
         prog = sf.Program(1)
         with prog.context as q:
             sf.ops.GKP(epsilon=eps) | q[0]
@@ -358,7 +358,10 @@ class TestBosonicGKPStates:
     
     def test_gkp_complex(self):
         r"""Checks that trying to call a complex representation
-        raises an error."""   
+        raises an error.
+        
+        This test can be updated once the complex representation is
+        implemented."""   
         with pytest.raises(NotImplementedError):
             prog = sf.Program(1)
             with prog.context as q:

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -242,7 +242,7 @@ class TestBosonicFockStates:
         assert np.allclose(state.covs().real, state.covs())
         
         if n == 0:
-            covs_compare = np.tile(np.eye(2),(1,1,1))
+            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(1,1,1))
             assert np.allclose(state.covs(), covs_compare)
             assert np.allclose(state.fidelity_vacuum(),1)
     

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -31,7 +31,7 @@ R_VALS = np.linspace(-1,1,5)
 @pytest.mark.backends("bosonic")
 class TestKronList():
     """Test kron_list function from the bosonic backend."""
-    def test_kron_list():
+    def test_kron_list(self):
         l1 = [1,2]
         l2 = [3,4,5]
         list_compare = [3,4,5,6,8,10]

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -315,6 +315,7 @@ class TestBosonicGKPStates:
         # Means should be integer multiples of sqrt(pi*hbar)/2 times a damping
         damping = 2 * np.exp(-eps) / (1 + np.exp(-2 * eps))
         mean_ints = state.means() / (damping * np.sqrt(np.pi * sf.hbar) / 2)
+
         # Round to make sure numerical errors are washed out
         mean_ints = np.round(np.real_if_close(mean_ints), 10)
         assert np.allclose(mean_ints % 1, np.zeros(mean_ints.shape))
@@ -324,7 +325,7 @@ class TestBosonicGKPStates:
         r"""Checks that logically equivalent GKP states have
         Wigner functions that agree."""
         x = np.linspace(-3 * np.sqrt(np.pi), 3 * np.sqrt(np.pi), 40)
-        p = np.linspace(-3 * np.sqrt(np.pi), 3 * np.sqrt(np.pi), 40)
+        p = np.copy(x)
 
         # Prepare GKP 0 and apply Hadamard
         prog_0H = sf.Program(1)
@@ -421,6 +422,7 @@ class TestBosonicPrograms:
             # this line should be ignored since it is a Gaussian prep
             # that would be picked up in run_prog, but not init_circuit
             sf.ops.Squeezed(r) | q[1]
+
         backend = bosonic.BosonicBackend()
         backend.init_circuit(prog)
         state = backend.state()
@@ -441,9 +443,11 @@ class TestBosonicPrograms:
     def test_different_preparations(self, alpha, r):
         """Runs a program with non-Gaussian and Gaussian preparations."""
         prog = sf.Program(3)
+
         with prog.context as q:
             sf.ops.Catstate(alpha) | q[0]
             sf.ops.Squeezed(r) | q[1]
+
         backend = bosonic.BosonicBackend()
         backend.run_prog(prog)
         state = backend.state()

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -21,6 +21,8 @@ import strawberryfields as sf
 import strawberryfields.backends.bosonicbackend.backend as bosonic
 import pytest
 
+pytestmark = pytest.mark.bosonic
+
 ALPHA_VALS = np.linspace(-1,1,5)
 PHI_VALS = np.linspace(0,1,3)
 FOCK_VALS = np.arange(5,dtype=int)
@@ -28,7 +30,6 @@ r_fock = 0.05
 EPS_VALS = np.array([0.01,0.05,0.1,0.5])
 R_VALS = np.linspace(-1,1,5)
 
-@pytest.mark.backends("bosonic")
 class TestKronList():
     """Test kron_list function from the bosonic backend."""
     def test_kron_list(self):
@@ -37,7 +38,6 @@ class TestKronList():
         list_compare = [3,4,5,6,8,10]
         assert np.allclose(list_compare, bosonic.kron_list([l1,l2]))
 
-@pytest.mark.backends("bosonic")
 class TestBosonicCatStates:
     r"""Tests cat state method of the BosonicBackend class."""
     
@@ -210,7 +210,6 @@ class TestBosonicCatStates:
             assert np.allclose(parity_complex, -1)
             assert np.allclose(parity_real, -1)
 
-@pytest.mark.backends("bosonic")  
 class TestBosonicFockStates:
     r"""Tests fock state method of the BosonicBackend class."""
     
@@ -280,7 +279,6 @@ class TestBosonicFockStates:
         state = backend.state()
         assert np.allclose(state.parity_expectation([0]),(-1.0)**n,atol=r_fock)
 
-@pytest.mark.backends("bosonic")
 class TestBosonicGKPStates:
     r"""Tests the gkp method of the BosonicBackend class."""
     
@@ -373,7 +371,6 @@ class TestBosonicGKPStates:
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)
 
-@pytest.mark.backends("bosonic")
 class TestBosonicUserSpecifiedState():
     """Checks the Bosonic preparation method."""
     
@@ -405,7 +402,6 @@ class TestBosonicUserSpecifiedState():
         #Check the two states are equal
         assert state.__eq__(state2)
         
-@pytest.mark.backends("bosonic")     
 class TestBosonicPrograms():
     """Tests that small programs run and return the correct output."""
 

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -55,7 +55,7 @@ class TestBosonicCatStates:
         
        
         if alpha != 0:
-            #Check shapes
+            # Check shapes
             assert state.num_weights == 4
             assert state.weights().shape == (4,)
             assert np.allclose(sum(state.weights()),1)
@@ -64,7 +64,7 @@ class TestBosonicCatStates:
             covs_compare = np.tile(np.eye(2)*sf.hbar/2,(4,1,1))
             assert np.allclose(state.covs(), covs_compare)
             
-            #Weights not real if phi != 0 or 1
+            # Weights not real if phi != 0 or 1
             if phi % 1 == 0:
                 assert np.allclose(state.weights().real, state.weights())
             else:
@@ -157,9 +157,9 @@ class TestBosonicCatStates:
         results = eng.run(prog_cat_fock)
         wigner_fock = results.state.wigner(0,x,p)
         
-        assert np.allclose(wigner_complex,wigner_real,rtol=1e-3,atol=1e-6)
-        assert np.allclose(wigner_complex,wigner_fock,rtol=1e-3,atol=1e-6)
-        assert np.allclose(wigner_fock,wigner_real,rtol=1e-3,atol=1e-6)
+        assert np.allclose(wigner_complex, wigner_real, rtol=1e-3, atol=1e-6)
+        assert np.allclose(wigner_complex, wigner_fock, rtol=1e-3, atol=1e-6)
+        assert np.allclose(wigner_fock, wigner_real, rtol=1e-3, atol=1e-6)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     def test_cat_state_parity(self,alpha):
@@ -224,17 +224,17 @@ class TestBosonicFockStates:
         backend.run_prog(prog)
         state = backend.state()
         
-        #Check shapes
+        # check shapes
         assert state.num_weights == n+1
         assert state.weights().shape == (n+1,)
         assert np.allclose(sum(state.weights()),1)
         assert state.means().shape == (n+1,2)
         assert state.covs().shape == (n+1,2,2)
         
-        #Check mean photon is close to n
+        # check mean photon is close to n
         mean,var = state.mean_photon(0)
-        assert np.allclose(mean,n,atol=r_fock)
-        assert np.allclose(var,0,atol=r_fock)
+        assert np.allclose(mean, n, atol=r_fock)
+        assert np.allclose(var, 0, atol=r_fock)
         
         # Weights, means and covs should be real
         assert np.allclose(state.weights().real, state.weights())
@@ -371,7 +371,7 @@ class TestBosonicGKPStates:
             backend = bosonic.BosonicBackend()
             backend.run_prog(prog)
 
-class TestBosonicUserSpecifiedState():
+class TestBosonicUserSpecifiedState:
     """Checks the Bosonic preparation method."""
     
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
@@ -402,7 +402,7 @@ class TestBosonicUserSpecifiedState():
         #Check the two states are equal
         assert state.__eq__(state2)
         
-class TestBosonicPrograms():
+class TestBosonicPrograms:
     """Tests that small programs run and return the correct output."""
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
@@ -412,8 +412,8 @@ class TestBosonicPrograms():
         prog = sf.Program(3)
         with prog.context as q:
             sf.ops.Catstate(alpha) | q[0]
-            #This line should be ignored since it is a Gaussian prep
-            #that would be picked up in run_prog, but not init_circuit
+            # this line should be ignored since it is a Gaussian prep
+            # that would be picked up in run_prog, but not init_circuit
             sf.ops.Squeezed(r) | q[1]
         backend = bosonic.BosonicBackend()
         backend.init_circuit(prog)

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -1,0 +1,523 @@
+# Copyright 2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Unit tests for backends.bosonicbackend.bosoniccircuit.py.
+"""
+
+import numpy as np
+import strawberryfields as sf
+import strawberryfields.backends.bosonicbackend.backend as bosonic
+import pytest
+
+ALPHA_VALS = np.linspace(-1,1,5)
+PHI_VALS = np.linspace(0,1,3)
+FOCK_VALS = np.arange(5,dtype=int)
+r_fock = 0.05  
+EPS_VALS = np.array([0.01,0.05,0.1,0.5])
+R_VALS = np.linspace(-1,1,5)
+
+def test_kron_list():
+    l1 = [1,2]
+    l2 = [3,4,5]
+    list_compare = [3,4,5,6,8,10]
+    assert np.allclose(list_compare, bosonic.kron_list([l1,l2]))
+
+@pytest.mark.backends("bosonic")
+class TestBosonicCatStates:
+    r"""Tests cat state method of the BosonicBackend class."""
+    
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("phi", PHI_VALS)
+    def test_cat_complex(self,alpha,phi):
+        r"""Checks the complex cat state representation."""
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.Catstate(alpha,phi) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        
+       
+        if alpha != 0:
+            #Check shapes
+            assert state.num_weights == 4
+            assert state.weights().shape == (4,)
+            assert np.allclose(sum(state.weights()),1)
+            assert state.means().shape == (4,2)
+            assert state.covs().shape == (4,2,2)
+            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(4,1,1))
+            assert np.allclose(state.covs(), covs_compare)
+            
+            #Weights not real if phi != 0 or 1
+            if phi % 1 == 0:
+                assert np.allclose(state.weights().real, state.weights())
+            else:
+                assert not np.allclose(state.weights().real, state.weights())
+            # Covs should be real, means complex
+            assert not np.allclose(state.means().real, state.means())
+            assert np.allclose(state.covs().real, state.covs())
+        else:
+            assert state.num_weights == 1
+            assert state.weights().shape == (1,)
+            assert np.allclose(sum(state.weights()),1)
+            assert state.means().shape == (1,2)
+            assert state.covs().shape == (1,2,2)
+            covs_compare = np.tile(np.eye(2)*sf.hbar/2,(1,1,1))
+            assert np.allclose(state.covs(), covs_compare)
+    
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("phi", PHI_VALS)
+    def test_cat_real(self,alpha,phi):
+        r"""Checks the real cat state representation."""
+        # Check that low cutoff and low D produce fewer weights when alpha !=0
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.Catstate(alpha,phi,cutoff=1e-6,desc="real",D=1) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        num_weights_low = state.num_weights
+        
+        assert np.allclose(sum(state.weights()),1)
+        assert state.means().shape == (num_weights_low,2)
+        assert state.covs().shape == (num_weights_low,2,2)
+        
+        # Weights, means and covs should be real
+        assert np.allclose(state.weights().real, state.weights())
+        assert np.allclose(state.means().real, state.means())
+        assert np.allclose(state.covs().real, state.covs())
+        
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.Catstate(alpha,phi,cutoff=1e-12,desc="real",D=10) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        num_weights_high = state.num_weights
+        
+        assert np.allclose(sum(state.weights()),1)
+        assert state.means().shape == (num_weights_high,2)
+        assert state.covs().shape == (num_weights_high,2,2)
+        
+        if alpha != 0:
+            assert num_weights_low < num_weights_high
+        else:
+            assert num_weights_low == num_weights_high
+    
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("phi", PHI_VALS)
+    def test_cat_state_wigners(self,alpha,phi):
+        r"""Checks that the real and complex cat state representations
+        have the same Wigner functions as the cat state from the Fock 
+        backend."""
+        x = np.linspace(-2*alpha,2*alpha,100)
+        p = np.linspace(-2*alpha,2*alpha,100)
+        
+        prog_complex_cat = sf.Program(1)
+        with prog_complex_cat.context as qc:
+            sf.ops.Catstate(alpha,phi) | qc[0]
+        
+        prog_real_cat = sf.Program(1)
+        with prog_real_cat.context as qr:
+            sf.ops.Catstate(alpha,phi,desc="real",D=10) | qr[0]
+        
+        backend_complex = bosonic.BosonicBackend()
+        backend_complex.run_prog(prog_complex_cat)
+        wigner_complex = backend_complex.state().wigner(0,x,p)
+        
+        backend_real = bosonic.BosonicBackend()
+        backend_real.run_prog(prog_real_cat)
+        wigner_real = backend_real.state().wigner(0,x,p)
+        
+        prog_cat_fock = sf.Program(1)
+        with prog_cat_fock.context as qf:
+            if alpha != 0:
+                sf.ops.Catstate(alpha,phi) | qf[0]
+            else:
+                sf.ops.Vacuum() | qf[0]
+        eng = sf.Engine("fock", backend_options={"cutoff_dim": 20})
+        results = eng.run(prog_cat_fock)
+        wigner_fock = results.state.wigner(0,x,p)
+        
+        assert np.allclose(wigner_complex,wigner_real,rtol=1e-3,atol=1e-6)
+        assert np.allclose(wigner_complex,wigner_fock,rtol=1e-3,atol=1e-6)
+        assert np.allclose(wigner_fock,wigner_real,rtol=1e-3,atol=1e-6)
+
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    def test_cat_state_parity(self,alpha):
+        r"""Checks that the real and complex cat state representations
+        yield the correct parity."""    
+        # for phi = 0, should yield parity of 1
+        prog_complex_cat = sf.Program(1)
+        with prog_complex_cat.context as qc:
+            sf.ops.Catstate(alpha) | qc[0]
+        
+        prog_real_cat = sf.Program(1)
+        with prog_real_cat.context as qr:
+            sf.ops.Catstate(alpha,desc="real") | qr[0]
+        
+        backend_complex = bosonic.BosonicBackend()
+        backend_complex.run_prog(prog_complex_cat)
+        state_complex = backend_complex.state()
+        parity_complex = state_complex.parity_expectation([0])
+        
+        backend_real = bosonic.BosonicBackend()
+        backend_real.run_prog(prog_real_cat)
+        state_real = backend_real.state()
+        parity_real = state_real.parity_expectation([0])
+               
+        assert np.allclose(parity_complex, 1)
+        assert np.allclose(parity_real, 1)
+        
+        # for phi = 1, should yield parity of -1 unless alpha == 0
+        if alpha != 0:
+            prog_complex_cat = sf.Program(1)
+            with prog_complex_cat.context as qc:
+                sf.ops.Catstate(alpha,1) | qc[0]
+            
+            prog_real_cat = sf.Program(1)
+            with prog_real_cat.context as qr:
+                sf.ops.Catstate(alpha,1,desc="real") | qr[0]
+            
+            backend_complex = bosonic.BosonicBackend()
+            backend_complex.run_prog(prog_complex_cat)
+            state_complex = backend_complex.state()
+            parity_complex = state_complex.parity_expectation([0])
+            
+            backend_real = bosonic.BosonicBackend()
+            backend_real.run_prog(prog_real_cat)
+            state_real = backend_real.state()
+            parity_real = state_real.parity_expectation([0])
+                   
+            assert np.allclose(parity_complex, -1)
+            assert np.allclose(parity_real, -1)
+
+@pytest.mark.backends("bosonic")  
+class TestBosonicFockStates:
+    r"""Tests fock state method of the BosonicBackend class."""
+    
+    @pytest.mark.parametrize("n", FOCK_VALS)
+    def test_fock(self,n):
+        r"""Checks fock states in the bosonic representation."""
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.Fock(n) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        
+        #Check shapes
+        assert state.num_weights == n+1
+        assert state.weights().shape == (n+1,)
+        assert np.allclose(sum(state.weights()),1)
+        assert state.means().shape == (n+1,2)
+        assert state.covs().shape == (n+1,2,2)
+        
+        #Check mean photon is close to n
+        mean,var = state.mean_photon(0)
+        assert np.allclose(mean,n,atol=r_fock)
+        assert np.allclose(var,0,atol=r_fock)
+        
+        # Weights, means and covs should be real
+        assert np.allclose(state.weights().real, state.weights())
+        assert np.allclose(state.means().real, state.means())
+        assert np.allclose(state.covs().real, state.covs())
+        
+        if n == 0:
+            covs_compare = np.tile(np.eye(2),(1,1,1))
+            assert np.allclose(state.covs(), covs_compare)
+            assert np.allclose(state.fidelity_vacuum(),1)
+    
+    @pytest.mark.parametrize("n", FOCK_VALS)
+    def test_fock_state_wigners(self,n):
+        r"""Checks that fock state Wigner functions in the bosonic and Fock
+        backends match."""
+        x = np.linspace(-n,n,100)
+        p = np.linspace(-n,n,100)
+        
+        prog = sf.Program(1)
+        with prog as q:
+            sf.ops.Fock(n) | q[0]
+        
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        wigner_bosonic = backend.state().wigner(0,x,p)
+        
+        eng = sf.Engine("fock", backend_options={"cutoff_dim": int(n+1)})
+        results = eng.run(prog)
+        wigner_fock = results.state.wigner(0,x,p)
+        
+        assert np.allclose(wigner_fock,wigner_bosonic,atol=r_fock)
+
+    @pytest.mark.parametrize("n", FOCK_VALS)
+    def test_fock_state_parity(self,n):
+        r"""Checks that fock states have the right parity."""    
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.Fock(n) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        assert np.allclose(state.parity_expectation([0]),(-1.0)**n,atol=r_fock)
+
+@pytest.mark.backends("bosonic")
+class TestBosonicGKPStates:
+    r"""Tests gkp method of the BosonicBackend class."""
+    
+    @pytest.mark.parametrize("eps", EPS_VALS)
+    def test_gkp(self,eps):
+        r"""Checks the complex cat state representation."""
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.GKP(epsilon=eps) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        num_weights = state.num_weights
+        assert state.weights().shape == (num_weights,)
+        assert np.allclose(sum(state.weights()),1)
+        assert state.means().shape == (num_weights,2)
+        assert state.covs().shape == (num_weights,2,2)
+        
+        # Weights, means and covs should be real
+        assert np.allclose(state.weights().real, state.weights())
+        assert np.allclose(state.means().real, state.means())
+        assert np.allclose(state.covs().real, state.covs())
+        
+        # Covariance should be diagonal with these entries
+        cov_val = (1 - np.exp(-2 * eps))/ (1 + np.exp(-2 * eps))*sf.hbar/2
+        covs_compare = np.tile(cov_val*np.eye(2),(num_weights,1,1))
+        assert np.allclose(state.covs(),covs_compare)
+        
+        # Means should be integer multiples of sqrt(pi*hbar)/2 times a damping
+        damping = 2 * np.exp(-eps) / (1 + np.exp(-2 * eps))
+        mean_ints = state.means()/(damping*np.sqrt(np.pi*sf.hbar)/2)
+        # Round to make sure numerical errors are washed out
+        mean_ints = np.round(np.real_if_close(mean_ints),10)
+        assert np.allclose(mean_ints % 1, np.zeros(mean_ints.shape))
+    
+    @pytest.mark.parametrize("eps", EPS_VALS)
+    def test_gkp_logical(self,eps):
+        r"""Checks that logically equivalent GKP states have
+        Wigner functions that agree."""
+        x = np.linspace(-3*np.sqrt(np.pi),3*np.sqrt(np.pi),40)
+        p = np.linspace(-3*np.sqrt(np.pi),3*np.sqrt(np.pi),40)
+        
+        # Prepare GKP 0 and apply Hadamard
+        prog_0H = sf.Program(1)
+        with prog_0H.context as q0:
+            sf.ops.GKP(epsilon=eps) | q0[0]
+            sf.ops.Rgate(np.pi/2) | q0[0]
+              
+        backend_0H = bosonic.BosonicBackend()
+        backend_0H.run_prog(prog_0H)
+        state_0H = backend_0H.state()
+        wigner_0H = state_0H.wigner(0,x,p)
+        
+        # Prepare GKP +
+        prog_plus = sf.Program(1)
+        with prog_plus.context as qp:
+            sf.ops.GKP(state=[np.pi/2,0],epsilon=eps) | qp[0]
+              
+        backend_plus = bosonic.BosonicBackend()
+        backend_plus.run_prog(prog_plus)
+        state_plus = backend_plus.state()
+        wigner_plus = state_plus.wigner(0,x,p)
+        
+        assert np.allclose(wigner_0H,wigner_plus)
+    
+    @pytest.mark.parametrize("eps", EPS_VALS)
+    def test_gkp_state_parity(self,eps):
+        r"""Checks that GKP states yield the right parity."""    
+        prog = sf.Program(1)
+        with prog.context as q:
+            sf.ops.GKP(epsilon=eps) | q[0]
+              
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        assert np.allclose(state.parity_expectation([0]),1,atol=r_fock)
+    
+    def test_gkp_complex(self):
+        r"""Checks that trying to call a complex representation
+        raises an error."""   
+        with pytest.raises(NotImplementedError):
+            prog = sf.Program(1)
+            with prog.context as q:
+                sf.ops.GKP(desc="complex") | q[0]
+                  
+            backend = bosonic.BosonicBackend()
+            backend.run_prog(prog)
+
+@pytest.mark.backends("bosonic")
+class TestBosonicUserSpecifiedState():
+    """Checks the Bosonic preparation method."""
+    
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    def test_complex_weight(self, alpha):
+        r"""Checks that Bosonic creates a state with user-specifed weights, means
+        and covariances."""
+        dummy_backend = bosonic.BosonicBackend()
+        dummy_backend.begin_circuit(1)
+        # Get weights, means and covs for a cat state
+        weights, means, covs = dummy_backend.prepare_cat(alpha,0,0,'complex',0)
+        
+        # Initiate the state, but use Bosonic method
+        backend = bosonic.BosonicBackend()
+        prog = sf.Program(1)
+        with prog.context as q1:
+            sf.ops.Bosonic(weights,means,covs) | q1[0]
+        backend.run_prog(prog)
+        state = backend.state()
+        
+        #Prepare using the Catstate method
+        backend2 = bosonic.BosonicBackend()
+        prog2 = sf.Program(1)
+        with prog2.context as q2:
+            sf.ops.Catstate(alpha) | q2[0]
+        backend2.run_prog(prog2)
+        state2 = backend2.state()
+        
+        #Check the two states are equal
+        assert state.__eq__(state2)
+        
+@pytest.mark.backends("bosonic")     
+class TestBosonicPrograms():
+    """Tests that small programs run and return the correct output."""
+
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("r", R_VALS)
+    def test_init_circuit(self,alpha,r):
+        """Checks init_circuit only prepares non-Gaussian states and vacuum."""
+        prog = sf.Program(3)
+        with prog.context as q:
+            sf.ops.Catstate(alpha) | q[0]
+            #This line should be ignored since it is a Gaussian prep
+            #that would be picked up in run_prog, but not init_circuit
+            sf.ops.Squeezed(r) | q[1]
+        backend = bosonic.BosonicBackend()
+        backend.init_circuit(prog)
+        state = backend.state()
+                
+        #Check that second and third mode are still in vacuum
+        weights,means,covs = state.reduced_bosonic([1,2])
+        
+        mean_compare = np.zeros(4)
+        means_compare = np.tile(mean_compare,(4,1))
+        assert np.allclose(means,means_compare) 
+        
+        cov_compare = np.diag([1,1,1,1])
+        covs_compare = np.tile(cov_compare*sf.hbar/2,(4,1,1))
+        assert np.allclose(covs,covs_compare)    
+
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("r", R_VALS)
+    def test_different_preparations(self,alpha,r):
+        """Runs a program with non-Gaussian and Gaussian preparations."""
+        prog = sf.Program(3)
+        with prog.context as q:
+            sf.ops.Catstate(alpha) | q[0]
+            sf.ops.Squeezed(r) | q[1]
+        backend = bosonic.BosonicBackend()
+        backend.run_prog(prog)
+        state = backend.state()
+        
+        #Check output shapes
+        if alpha != 0:
+            assert state.weights().shape == (4,)
+            assert np.allclose(sum(state.weights()),1)
+            assert state.means().shape == (4,6)
+            assert state.covs().shape == (4,6,6)
+        
+        else:
+            assert state.weights().shape == (1,)
+            assert np.allclose(sum(state.weights()),1)
+            assert state.means().shape == (1,6)
+            assert state.covs().shape == (1,6,6)
+        
+        #Check covariance is correct
+        cov_compare = np.diag([1,1,np.exp(-2*r),np.exp(2*r),1,1])
+        covs_compare = np.tile(cov_compare*sf.hbar/2,(4,1,1))
+        assert np.allclose(state.covs(),covs_compare)
+        
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("r", R_VALS)
+    def test_measurement(self,alpha,r):
+        """Runs a program with measurements."""
+        prog = sf.Program(2)
+        with prog.context as q:
+            sf.ops.Catstate(alpha) | q[0]
+            sf.ops.Squeezed(r) | q[1]
+            sf.ops.MeasureX | q[0]
+            sf.ops.MeasureX | q[1]
+        backend = bosonic.BosonicBackend()
+        applied, samples, all_samples = backend.run_prog(prog)
+        state = backend.state()
+        
+        #Check output is vacuum since everything was measured
+        assert np.allclose(state.fidelity_vacuum(),1)
+        
+        #Check samples
+        for i in range(2):
+            assert i in samples.keys()
+            assert samples[i].shape == (1,)
+            
+    @pytest.mark.parametrize("alpha", ALPHA_VALS)
+    @pytest.mark.parametrize("r", R_VALS)
+    def test_mb_gates(self,alpha,r):
+        """Runs a program with measurement-based gates."""
+        prog = sf.Program(2)
+        with prog.context as q:
+            sf.ops.MbSgate(1,0,1,1,avg=True) | q[0]
+            sf.ops.MbSgate(1,0,1,1,avg=False) | q[1]
+            sf.ops.MbSgate(1,0,1,1,avg=False) | q[1]
+        backend = bosonic.BosonicBackend()
+        applied, samples, all_samples = backend.run_prog(prog)
+        
+        #Check number of active modes did not change
+        assert backend.get_modes() == [0,1]
+        
+        #Check samples for the data modes are empty
+        assert samples == {}
+        
+        #Check ancilla samples exist for the second mode
+        ancilla_samples = backend.ancillae_samples_dict
+        assert 1 in ancilla_samples.keys()
+        assert len(ancilla_samples[1]) == 2
+        
+    def test_raised_errors(self):
+        """Runs programs with operations that are not applicable
+        or have not been implemented."""
+        from strawberryfields.backends.base import NotApplicableError
+        
+        with pytest.raises(NotApplicableError):
+            prog = sf.Program(1)
+            with prog.context as q:
+                sf.ops.Kgate(1) | q[0]
+            backend = bosonic.BosonicBackend()
+            backend.run_prog(prog)
+            
+        with pytest.raises(NotImplementedError):
+            prog = sf.Program(1)
+            with prog.context as q:
+                sf.ops.MeasureThreshold() | q[0]
+            backend = bosonic.BosonicBackend()
+            backend.run_prog(prog)

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -433,7 +433,7 @@ class TestBosonicPrograms:
         prog = sf.Program(3)
         with prog.context as q:
             sf.ops.Catstate(alpha) | q[0]
-            # this line should be ignored since it is a Gaussian prep
+            # this line should have no effect since it is a Gaussian prep
             # that would be picked up in run_prog, but not init_circuit
             sf.ops.Squeezed(r) | q[1]
 

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -28,11 +28,14 @@ r_fock = 0.05
 EPS_VALS = np.array([0.01,0.05,0.1,0.5])
 R_VALS = np.linspace(-1,1,5)
 
-def test_kron_list():
-    l1 = [1,2]
-    l2 = [3,4,5]
-    list_compare = [3,4,5,6,8,10]
-    assert np.allclose(list_compare, bosonic.kron_list([l1,l2]))
+@pytest.mark.backends("bosonic")
+class TestKronList():
+    """Test kron_list function from the bosonic backend."""
+    def test_kron_list():
+        l1 = [1,2]
+        l2 = [3,4,5]
+        list_compare = [3,4,5,6,8,10]
+        assert np.allclose(list_compare, bosonic.kron_list([l1,l2]))
 
 @pytest.mark.backends("bosonic")
 class TestBosonicCatStates:

--- a/tests/backend/test_mbsqueeze_operation.py
+++ b/tests/backend/test_mbsqueeze_operation.py
@@ -36,7 +36,7 @@ class TestBosonicRepresentation:
         """Tests average map of mbsqueezing operation for no squeezing,
         where the result should be a vacuum state."""
         backend = setup_backend(2)
-        backend.mb_squeeze(0, 0, 0, r_anc, eta, True)
+        backend.mb_squeeze_avg(0, 0, 0, r_anc, eta)
         backend.squeeze(0, 0, 1)
         assert np.allclose(backend.circuit.covs[0, :2, :2], backend.circuit.covs[0, 2:, 2:], atol=tol)
 
@@ -46,7 +46,7 @@ class TestBosonicRepresentation:
         """Tests average map of mbsqueezing operation with a high squeezed ancilla,
         where the result should be an ideal state."""
         backend = setup_backend(2)
-        backend.mb_squeeze(0, r, phi, 9, 1.0, True)
+        backend.mb_squeeze_avg(0, r, phi, 9, 1.0)
         backend.squeeze(r, phi, 1)
         assert np.allclose(backend.circuit.covs[0, :2, :2], backend.circuit.covs[0, 2:, 2:], atol=tol)
 
@@ -56,7 +56,7 @@ class TestBosonicRepresentation:
         """Tests single shot map of mbsqueezing operation for no squeezing,
         where the result should be a vacuum state."""
         backend = setup_backend(2)
-        backend.mb_squeeze(0, 0, 0, r_anc, eta, False)
+        backend.mb_squeeze_single_shot(0, 0, 0, r_anc, eta)
         backend.squeeze(0, 0, 1)
         assert np.allclose(backend.circuit.covs[0, :2, :2], backend.circuit.covs[0, 2:, 2:], atol=tol)
 
@@ -66,6 +66,6 @@ class TestBosonicRepresentation:
         """Tests single shot map of mbsqueezing operation with a high squeezed ancilla,
         where the result should be an ideal state."""
         backend = setup_backend(2)
-        backend.mb_squeeze(0, r, phi, 9, 1.0, False)
+        backend.mb_squeeze_single_shot(0, r, phi, 9, 1.0)
         backend.squeeze(r, phi, 1)
         assert np.allclose(backend.circuit.covs[0, :2, :2], backend.circuit.covs[0, 2:, 2:], atol=tol)


### PR DESCRIPTION
**Context:** The bosonic backend simulates states as linear combinations of Gaussians in phase space

**Description of the Change:**
- Adds preparation backend and frontend methods for GKP, cat and Fock states to the bosonic backend
- Adds the run_prog and init_circuit methods to bosonic/backend.py which are the engines for running sf Programs in the bosonic backend
- Adds the bosonic compiler
- Adds tests for these new backend methods

**Benefits:**
- Simulation of bosonic qubits

**Possible Drawbacks:**

**Related GitHub Issues:**
