### PR TITLE
Update docstring for `reshape_samples`

### DIFF
--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -135,6 +135,12 @@ def _get_mode_order(num_of_values, modes, N, timebins):
 
 def reshape_samples(all_samples, modes, N, timebins):
     """Reshapes the samples dict so that they have the expected correct shape.
+    
+    .. note::
+
+        This function will empty the ``all_samples`` dictionary that's being sent in,
+        which will thus contain no samples after the reshaped samples dictionary has been
+        constructed. The samples will instead be returned, reshaped, in a new dictionary.
 
     Corrects the :attr:`~.Results.all_samples` dictionary so that the measured modes are
     the ones defined to be measured in the circuit, instead of being spread over a larger
@@ -204,6 +210,7 @@ def reshape_samples(all_samples, modes, N, timebins):
             # create an entry for the new mode with a nested list for each timebin
             new_samples[mode_idx] = [[] for _ in range(timebins)]
 
+        # pops samples, thus emptying all_samples for memory conservation
         sample = all_samples[mode].pop(0)[0]
         new_samples[mode_idx][timebin_idx].append(sample)
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -138,7 +138,7 @@ def reshape_samples(all_samples, modes, N, timebins):
 
     .. note::
 
-        This function will empty the ``all_samples`` dictionary that's being sent in,
+        This function will empty the input ``all_samples`` dictionary,
         which will thus contain no samples after the reshaped samples dictionary has been
         constructed. The samples will instead be returned, reshaped, in a new dictionary.
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -135,7 +135,7 @@ def _get_mode_order(num_of_values, modes, N, timebins):
 
 def reshape_samples(all_samples, modes, N, timebins):
     """Reshapes the samples dict so that they have the expected correct shape.
-    
+
     .. note::
 
         This function will empty the ``all_samples`` dictionary that's being sent in,


### PR DESCRIPTION
**Context:**
The `reshape_samples` function in `tdmprogram.py` currently works by popping elements from the `all_samples` dictionary that's being sent in as an argument, and then inserting them into a new dictionary which is then returned. This causes the sent in `all_samples` dictionary to be empty after having reshaped the samples (which might be confusing for the user, since this is nowhere stated).

This is not really an optimal way of handling things, and should probably be fixed. There are two different alternatives, that are not being addressed directly in this PR, but might be good to note:

* Create a copy of `all_samples` at the start. This is a simple solution, but has the downside that a copy needs to be made of a potentially very large dictionary. (Could this become an issue? Memory-wise?)

* Avoid returning anything and just update the old `all_samples` directly.

This PR simply updates the docstring to make it clear to the user what's happening.

**Description of the Change:**
Adds a note to the docstring of `reshape_samples` stating that `all_samples` will be empty after the function is called.

**Benefits:**
The functionality of `reshape_samples` is clearer.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
