### PR TITLE
Replace `pop` with indexing in `reshape_samples`

### DIFF
--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -193,6 +193,7 @@ def reshape_samples(all_samples, modes, N, timebins):
     # calculate the total number of samples and the order in which they were measured
     num_of_values = len([i for j in all_samples.values() for i in j])
     mode_order = _get_mode_order(num_of_values, modes, N, timebins)
+    idx_tracker = {i: 0 for i in mode_order}
 
     # iterate backwards through all_samples and add them into the correct mode
     new_samples = dict()
@@ -204,7 +205,8 @@ def reshape_samples(all_samples, modes, N, timebins):
             # create an entry for the new mode with a nested list for each timebin
             new_samples[mode_idx] = [[] for _ in range(timebins)]
 
-        sample = all_samples[mode].pop(0)[0]
+        sample = all_samples[mode][idx_tracker[mode]][0]
+        idx_tracker[mode] += 1
         new_samples[mode_idx][timebin_idx].append(sample)
 
         # populate each spatial mode in one timebin before moving on to the next timebin


### PR DESCRIPTION
**Context:**
The `reshape_samples` function in `tdmprogram.py` currently works by popping elements from the `all_samples` dictionary that's being sent in as an argument, and then inserting them into a new dictionary which is then returned. This causes the sent in `all_samples` dictionary to be empty after having reshaped the samples (which might be confusing for the user, since this is nowhere stated).

This is not really an optimal way of handling things, and should probably be fixed. 

**Description of the Change:**
The popping of samples from the input `all_samples` dictionary is changed to indexing, while keeping track of used indices. Thanks to @lneuhaus for [pointing this out](https://github.com/XanaduAI/strawberryfields/pull/542#discussion_r580376229)!

**Benefits:**
This method doesn't change the input `all_samples` and it should be equally fast as before, if not faster.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
