### PR TITLE
Docs cleanup for contribution

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -81,7 +81,8 @@
 
 <h3>Documentation</h3>
 
-* Cleanup docs [(TBD)]
+* Cleanup docs to make contribution easier.
+  [(#561)](https://github.com/XanaduAI/strawberryfields/pull/561)
 
 <h3>Contributors</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -81,13 +81,15 @@
 
 <h3>Documentation</h3>
 
+* Cleanup docs [(TBD)]
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 J. Eli Bourassa, Guillaume Dauphinais, Ish Dhand, Theodor Isacsson, Josh Izaac, 
-Nicolás Quesada, Krishna Kumar Sabapathy, Jeremy Swinarton, Antal Száva, Ilan 
-Tzitrin.
+Nicolás Quesada, Aaron Robertson, Krishna Kumar Sabapathy, Jeremy Swinarton, Antal Száva,
+Ilan Tzitrin.
 
 # Release 0.17.0 (current release)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ It's up to you!
   as a base. Ask us if you have any questions, and send a link to your application to support@xanadu.ai so we can highlight it in
   our documentation!
 
-For some inspiration, you can also check out some preprepared [contribution challenges](/CHALLENGES.md).
+For some inspiration, you can also check out some preprepared [contribution challenges](./CHALLENGES.md).
 
 Appetite whetted? Keep reading below for all the nitty-gritty on reporting bugs, contributing to the documentation,
 and submitting pull requests.
@@ -72,7 +72,7 @@ To submit a bug report, please work your way through the following checklist:
   `#sf_bug` channel.
 
 * **Fill out the issue template**. If you cannot find an existing issue addressing the problem, create a new
-  issue by filling out the [issue template](/ISSUE_TEMPLATE.md). This template is added automatically to the comment
+  issue by filling out the [issue template](./ISSUE_TEMPLATE.md). This template is added automatically to the comment
   box when you create a new issue. Please try and add as many details as possible!
 
 * Try and make your issue as **clear, concise, and descriptive** as possible. Include a clear and descriptive title,
@@ -128,7 +128,7 @@ Before submitting a pull request, please make sure the following is done:
 
 ### Submitting the pull request
 * When ready, submit your fork as a [pull request](https://help.github.com/articles/about-pull-requests) to the Strawberry
-  Fields repository, filling out the [pull request template](/PULL_REQUEST_TEMPLATE.md). This template is added automatically
+  Fields repository, filling out the [pull request template](./PULL_REQUEST_TEMPLATE.md). This template is added automatically
   to the comment box when you create a new issue.
 
 * When describing the pull request, please include as much detail as possible regarding the changes made/new features

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,14 +21,6 @@ To chat directly with the team designing and building Strawberry Fields, as well
 community - ranging from professors of quantum physics, to students, to those just interested in being a
 part of a rapidly growing industry - you can join our [Slack channel](https://u.strawberryfields.ai/slack).
 
-Available channels:
-
-* `#strawberryfields`: For general discussion regarding Strawberry Fields
-* `#sf_projects`: For discussion of research ideas and projects built on Strawberry Fields
-* `#sf_bugs`: For discussion of any bugs and issues you run into using Strawberry Fields
-* `#sf_interactive`: For discussion relating to the [Strawberry Fields Interactive](https://strawberryfields.ai) web application
-* `#sf_docs`: For discussion of the Strawberry Fields [documentation](https://strawberryfields.readthedocs.io)
-
 Sometimes, it might take us a couple of hours to reply - please be patient!
 
 ## How can I contribute?
@@ -62,7 +54,7 @@ It's up to you!
   as a base. Ask us if you have any questions, and send a link to your application to support@xanadu.ai so we can highlight it in
   our documentation!
 
-For some inspiration, you can also check out some preprepared [contribution challenges](.github/CHALLENGES.md).
+For some inspiration, you can also check out some preprepared [contribution challenges](/CHALLENGES.md).
 
 Appetite whetted? Keep reading below for all the nitty-gritty on reporting bugs, contributing to the documentation,
 and submitting pull requests.
@@ -80,7 +72,7 @@ To submit a bug report, please work your way through the following checklist:
   `#sf_bug` channel.
 
 * **Fill out the issue template**. If you cannot find an existing issue addressing the problem, create a new
-  issue by filling out the [issue template](.github/ISSUE_TEMPLATE.md). This template is added automatically to the comment
+  issue by filling out the [issue template](/ISSUE_TEMPLATE.md). This template is added automatically to the comment
   box when you create a new issue. Please try and add as many details as possible!
 
 * Try and make your issue as **clear, concise, and descriptive** as possible. Include a clear and descriptive title,
@@ -136,7 +128,7 @@ Before submitting a pull request, please make sure the following is done:
 
 ### Submitting the pull request
 * When ready, submit your fork as a [pull request](https://help.github.com/articles/about-pull-requests) to the Strawberry
-  Fields repository, filling out the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). This template is added automatically
+  Fields repository, filling out the [pull request template](/PULL_REQUEST_TEMPLATE.md). This template is added automatically
   to the comment box when you create a new issue.
 
 * When describing the pull request, please include as much detail as possible regarding the changes made/new features

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ We welcome contributions—simply fork the Strawberry Fields repository, and the
 
 We also encourage bug reports, suggestions for new features and enhancements, and even links to cool projects or applications built on Strawberry Fields.
 
-See our `contributions page <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CONTRIBUTING.md>`_ and `changelog <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CHANGELOG.md>
+See our `contributions page <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CONTRIBUTING.md>`_ and `changelog <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CHANGELOG.md>`_
 for more details, and then check out some of the Strawberry Fields `challenges <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CHALLENGES.md>`_ for some inspiration.
 
 Authors

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ We welcome contributions—simply fork the Strawberry Fields repository, and the
 
 We also encourage bug reports, suggestions for new features and enhancements, and even links to cool projects or applications built on Strawberry Fields.
 
-See our `contributions page <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CONTRIBUTING.md>`_
+See our `contributions page <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CONTRIBUTING.md>`_ and `changelog <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CHANGELOG.md>
 for more details, and then check out some of the Strawberry Fields `challenges <https://github.com/XanaduAI/strawberryfields/blob/master/.github/CHALLENGES.md>`_ for some inspiration.
 
 Authors

--- a/TESTS.rst
+++ b/TESTS.rst
@@ -1,7 +1,7 @@
 Software tests
 ==============
 
-The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_, `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_, `pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_, and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports. These can both be installed via ``pip``:
+The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_, `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_, `pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_, and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports. These can be installed via ``pip``:
 ::
 
     $ pip install pytest pytest-cov pytest-randomly pytest-mock

--- a/TESTS.rst
+++ b/TESTS.rst
@@ -1,10 +1,10 @@
 Software tests
 ==============
 
-The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_ and `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ for coverage reports. These can both be installed via ``pip``:
+The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_, `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_, `pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_, and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports. These can both be installed via ``pip``:
 ::
 
-    $ pip install pytest pytest-cov
+    $ pip install pytest pytest-cov pytest-randomly pytest-mock
 
 
 To ensure that Strawberry Fields is working correctly after installation, the test suite can be run by navigating to the source code folder and running

--- a/doc/development/development_guide.rst
+++ b/doc/development/development_guide.rst
@@ -64,7 +64,7 @@ The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/la
 `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_,
 `pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_,
 and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports.
-These can both be installed via ``pip``:
+These can be installed via ``pip``:
 
 .. code-block:: bash
 

--- a/doc/development/development_guide.rst
+++ b/doc/development/development_guide.rst
@@ -60,13 +60,15 @@ Or, to install Strawberry Fields and TensorFlow with GPU and CUDA support:
 Software tests
 --------------
 
-The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_
-and `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ for coverage reports.
+The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_,
+`pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_,
+`pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_,
+and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports.
 These can both be installed via ``pip``:
 
 .. code-block:: bash
 
-    pip install pytest pytest-cov
+    pip install pytest pytest-cov pytest-randomly pytest-mock
 
 
 To ensure that Strawberry Fields is working correctly after installation, the test suite


### PR DESCRIPTION
**Context:**

Cleanup documentation for ease of contribution based on this [slack conversation](https://xanadu-quantum.slack.com/archives/CA2U56VDE/p1616180499012000).

**Description of the Change:**

- [x] Fix outdated contributing link
- [x] Development guide test section includes pytest-randomly and pytest-mock
- [x] Contribution challenges, PR template, and issue template links are not dead

**Benefits:**

Makes it easier for new contributors.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**

N/A