### PR TITLE
Tf engine dtype

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -80,16 +80,16 @@
   prog = sf.Program(2)
   eng  = sf.Engine("tf", backend_options={"cutoff_dim": 50, "dtype": tf.complex128})
   with prog.context as q:
-      Sgate(0.8)         | q[0]
-      Sgate(0.8)         | q[1]
-      BSgate(0.5,0.5)  | (q[0], q[1])
-      BSgate(0.5,0.5)  | (q[0], q[1])
-  state    = eng.run(prog).state
-  N0,N0var = state.mean_photon(0)
-  N1,N1var = state.mean_photon(1)
+      Sgate(0.8) | q[0]
+      Sgate(0.8) | q[1]
+      BSgate(0.5,0.5) | (q[0], q[1])
+      BSgate(0.5,0.5) | (q[0], q[1])
+  state = eng.run(prog).state
+  N0, N0var = state.mean_photon(0)
+  N1, N1var = state.mean_photon(1)
   print(N0)
   print(N1)
-  print('analytical:',np.sinh(0.8)**2)
+  print("analytical:" ,np.sinh(0.8)**2)
   ```
 
 <h3>Breaking Changes</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -68,8 +68,29 @@
   plt.contourf(xvec, pvec, wigner)
   plt.show()
   ```
+
 * The `fock` backend now supports the `GKP` preparation [(#553)](https://github.com/XanaduAI/strawberryfields/pull/553)
 
+* The `tf` backend now accepts the Tensor DType as argument.
+  [(#562)](https://github.com/XanaduAI/strawberryfields/pull/562)
+
+  Allows high cutoff dimension to give numerically correct calculations:
+
+  ```python
+  prog = sf.Program(2)
+  eng  = sf.Engine("tf", backend_options={"cutoff_dim": 50, "dtype": tf.complex128})
+  with prog.context as q:
+      Sgate(0.8)         | q[0]
+      Sgate(0.8)         | q[1]
+      BSgate(0.5,0.5)  | (q[0], q[1])
+      BSgate(0.5,0.5)  | (q[0], q[1])
+  state    = eng.run(prog).state
+  N0,N0var = state.mean_photon(0)
+  N1,N1var = state.mean_photon(1)
+  print(N0)
+  print(N1)
+  print('analytical:',np.sinh(0.8)**2)
+  ```
 
 <h3>Breaking Changes</h3>
 

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -40,6 +40,7 @@ A number of factors determine the shape and dimensionality of the state tensor:
 * the number of modes :math:`n` actively being simulated
 * the cutoff dimension :math:`D` for the Fock basis
 * whether the circuit is operating in *batched mode* (with batch size :math:`B`)
+* the Tensor DType passed to the circuit
 
 When not operating in batched mode, the state tensor corresponds to a single multimode quantum system. If the
 representation is a pure state, the state tensor has shape
@@ -127,6 +128,7 @@ is that it returns TensorFlow ``Tensor`` objects
    mean_photon
    batched
    cutoff_dim
+   dtype
 
 
 Code details

--- a/strawberryfields/backends/tfbackend/__init__.py
+++ b/strawberryfields/backends/tfbackend/__init__.py
@@ -169,4 +169,3 @@ if not (tf_available and tf_version[:2] == "2."):
 
 
 from .backend import TFBackend
-from .ops import def_type as tf_complex_type

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -278,7 +278,13 @@ class TFBackend(BaseFock):
 
             modenames = ["q[{}]".format(i) for i in np.array(self.get_modes())[modes]]
             state_ = FockStateTF(
-                s, len(modes), pure, self.circuit.cutoff_dim, batched=batched, mode_names=modenames, dtype=dtype
+                s,
+                len(modes),
+                pure,
+                self.circuit.cutoff_dim,
+                batched=batched,
+                mode_names=modenames,
+                dtype=dtype,
             )
         return state_
 

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -21,7 +21,7 @@ TensorFlow backend interface
 import numpy as np
 import tensorflow as tf
 
-from tensorflow import DType
+# from tensorflow import DType
 from strawberryfields.backends import BaseFock, ModeMap
 from .circuit import Circuit
 from .ops import mixed, partial_trace, reorder_modes
@@ -83,7 +83,8 @@ class TFBackend(BaseFock):
                 For each mode, the simulator can represent the Fock states :math:`\ket{0}, \ket{1}, \ldots, \ket{\text{cutoff_dim}-1}`.
             pure (bool): If True (default), use a pure state representation (otherwise will use a mixed state representation).
             batch_size (None or int): Size of the batch-axis dimension. If None, no batch-axis will be used.
-            dtype (DType): Tensorflow element types in a tensor.
+            dtype (DType): Complex Tensorflow Tensor type representation, either complex64 (default) or complex128.
+                Note, complex128 will increase memory usage substantially.
         """
         cutoff_dim = kwargs.get("cutoff_dim", None)
         pure = kwargs.get("pure", True)
@@ -99,8 +100,8 @@ class TFBackend(BaseFock):
             raise ValueError("Argument 'cutoff_dim' must be a positive integer")
         if not isinstance(pure, bool):
             raise ValueError("Argument 'pure' must be either True or False")
-        if not isinstance(dtype, DType):
-            raise ValueError("Argument 'dtype' must be a Tensorflow DType")
+        if not (dtype == tf.complex64 or dtype == tf.complex128):
+            raise ValueError("Argument 'dtype' must be a complex Tensorflow DType")
         if batch_size == 1:
             raise ValueError(
                 "batch_size of 1 not supported, please use different batch_size or set batch_size=None"
@@ -236,6 +237,7 @@ class TFBackend(BaseFock):
             pure = self.circuit.state_is_pure
             num_modes = self.circuit.num_modes
             batched = self.circuit.batched
+            dtype = self.circuit.dtype
 
             # reduce rho down to specified subsystems
             if modes is None:
@@ -276,7 +278,7 @@ class TFBackend(BaseFock):
 
             modenames = ["q[{}]".format(i) for i in np.array(self.get_modes())[modes]]
             state_ = FockStateTF(
-                s, len(modes), pure, self.circuit.cutoff_dim, batched=batched, mode_names=modenames
+                s, len(modes), pure, self.circuit.cutoff_dim, batched=batched, mode_names=modenames, dtype=dtype
             )
         return state_
 

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -83,7 +83,7 @@ class TFBackend(BaseFock):
                 For each mode, the simulator can represent the Fock states :math:`\ket{0}, \ket{1}, \ldots, \ket{\text{cutoff_dim}-1}`.
             pure (bool): If True (default), use a pure state representation (otherwise will use a mixed state representation).
             batch_size (None or int): Size of the batch-axis dimension. If None, no batch-axis will be used.
-            dtype (DType): Tensorflow element types in a tensor. 
+            dtype (DType): Tensorflow element types in a tensor.
         """
         cutoff_dim = kwargs.get("cutoff_dim", None)
         pure = kwargs.get("pure", True)

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -83,6 +83,7 @@ class TFBackend(BaseFock):
                 For each mode, the simulator can represent the Fock states :math:`\ket{0}, \ket{1}, \ldots, \ket{\text{cutoff_dim}-1}`.
             pure (bool): If True (default), use a pure state representation (otherwise will use a mixed state representation).
             batch_size (None or int): Size of the batch-axis dimension. If None, no batch-axis will be used.
+            dtype (DType): Tensorflow element types in a tensor. 
         """
         cutoff_dim = kwargs.get("cutoff_dim", None)
         pure = kwargs.get("pure", True)
@@ -99,7 +100,7 @@ class TFBackend(BaseFock):
         if not isinstance(pure, bool):
             raise ValueError("Argument 'pure' must be either True or False")
         if not isinstance(dtype, DType):
-            raise ValueError("Argument 'dtype' must be a positive integer")
+            raise ValueError("Argument 'dtype' must be a Tensorflow DType")
         if batch_size == 1:
             raise ValueError(
                 "batch_size of 1 not supported, please use different batch_size or set batch_size=None"
@@ -107,7 +108,7 @@ class TFBackend(BaseFock):
 
         with tf.name_scope("Begin_circuit"):
             self._modemap = ModeMap(num_subsystems)
-            circuit = Circuit(num_subsystems, cutoff_dim, pure, batch_size)
+            circuit = Circuit(num_subsystems, cutoff_dim, pure, batch_size, dtype)
 
         self._init_modes = num_subsystems
         self.circuit = circuit

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -82,8 +82,8 @@ class TFBackend(BaseFock):
                 For each mode, the simulator can represent the Fock states :math:`\ket{0}, \ket{1}, \ldots, \ket{\text{cutoff_dim}-1}`.
             pure (bool): If True (default), use a pure state representation (otherwise will use a mixed state representation).
             batch_size (None or int): Size of the batch-axis dimension. If None, no batch-axis will be used.
-            dtype (DType): Complex Tensorflow Tensor type representation, either complex64 (default) or complex128.
-                Note, complex128 will increase memory usage substantially.
+            dtype (tf.DType): Complex Tensorflow Tensor type representation, either ``tf.complex64`` (default) or ``tf.complex128``.
+                Note, ``tf.complex128`` will increase memory usage substantially.
         """
         cutoff_dim = kwargs.get("cutoff_dim", None)
         pure = kwargs.get("pure", True)

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -21,6 +21,7 @@ TensorFlow backend interface
 import numpy as np
 import tensorflow as tf
 
+from tensorflow import DType
 from strawberryfields.backends import BaseFock, ModeMap
 from .circuit import Circuit
 from .ops import mixed, partial_trace, reorder_modes
@@ -86,6 +87,7 @@ class TFBackend(BaseFock):
         cutoff_dim = kwargs.get("cutoff_dim", None)
         pure = kwargs.get("pure", True)
         batch_size = kwargs.get("batch_size", None)
+        dtype = kwargs.get("dtype", tf.complex64)
 
         if cutoff_dim is None:
             raise ValueError("Argument 'cutoff_dim' must be passed to the TensorFlow backend")
@@ -96,6 +98,8 @@ class TFBackend(BaseFock):
             raise ValueError("Argument 'cutoff_dim' must be a positive integer")
         if not isinstance(pure, bool):
             raise ValueError("Argument 'pure' must be either True or False")
+        if not isinstance(dtype, DType):
+            raise ValueError("Argument 'dtype' must be a positive integer")
         if batch_size == 1:
             raise ValueError(
                 "batch_size of 1 not supported, please use different batch_size or set batch_size=None"

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -21,7 +21,6 @@ TensorFlow backend interface
 import numpy as np
 import tensorflow as tf
 
-# from tensorflow import DType
 from strawberryfields.backends import BaseFock, ModeMap
 from .circuit import Circuit
 from .ops import mixed, partial_trace, reorder_modes

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -100,7 +100,7 @@ class TFBackend(BaseFock):
             raise ValueError("Argument 'cutoff_dim' must be a positive integer")
         if not isinstance(pure, bool):
             raise ValueError("Argument 'pure' must be either True or False")
-        if not (dtype == tf.complex64 or dtype == tf.complex128):
+        if not dtype in (tf.complex64, tf.complex128):
             raise ValueError("Argument 'dtype' must be a complex Tensorflow DType")
         if batch_size == 1:
             raise ValueError(

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -74,7 +74,7 @@ class Circuit:
 
     def _make_vac_states(self, cutoff_dim):
         """Make vacuum state tensors for the underlying graph"""
-        one = tf.cast([1.0], dtype=self._dtype)
+        one = tf.cast([1.0], self._dtype)
         v = tf.scatter_nd([[0]], one, [cutoff_dim])
         self._single_mode_pure_vac = v
         self._single_mode_mixed_vac = tf.einsum("i,j->ij", v, v)
@@ -257,7 +257,7 @@ class Circuit:
         if "dtype" in kwargs:
             dtype = kwargs["dtype"]
             if dtype is not None:
-                if not (dtype == tf.complex64 or dtype == tf.complex128):
+                if not dtype in (tf.complex64, tf.complex128):
                     raise ValueError("Argument 'dtype' must be a complex Tensorflow DType")
             self._dtype = dtype
 
@@ -410,7 +410,7 @@ class Circuit:
             elif state.shape == mixed_shape_as_matrix:
                 state = tf.reshape(state, mixed_shape)
 
-            state = tf.cast(tf.convert_to_tensor(state), dtype=self._dtype)
+            state = tf.cast(tf.convert_to_tensor(state), self._dtype)
             # batch state now if not already batched and self._batched
             if self._batched and not input_is_batched:
                 state = tf.stack([state] * self._batch_size)
@@ -997,7 +997,7 @@ class Circuit:
         # `meas_result` will always be a single value since multiple shots is not supported
         if self.batched:
             return tf.reshape(meas_result, (len(meas_result), 1, 1))
-        return tf.cast([[meas_result]], dtype=self._dtype)
+        return tf.cast([[meas_result]], self._dtype)
 
     @property
     def num_modes(self):

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -74,7 +74,7 @@ class Circuit:
 
     def _make_vac_states(self, cutoff_dim):
         """Make vacuum state tensors for the underlying graph"""
-        one = tf.cast([1.0], self._dtype)
+        one = tf.cast([1.0], dtype=self._dtype)
         v = tf.scatter_nd([[0]], one, [cutoff_dim])
         self._single_mode_pure_vac = v
         self._single_mode_mixed_vac = tf.einsum("i,j->ij", v, v)
@@ -396,7 +396,7 @@ class Circuit:
             elif state.shape == mixed_shape_as_matrix:
                 state = tf.reshape(state, mixed_shape)
 
-            state = tf.cast(tf.convert_to_tensor(state), self._dtype)
+            state = tf.cast(tf.convert_to_tensor(state), dtype=self._dtype)
             # batch state now if not already batched and self._batched
             if self._batched and not input_is_batched:
                 state = tf.stack([state] * self._batch_size)
@@ -417,7 +417,7 @@ class Circuit:
         """
         theta = self._maybe_batch(theta)
         new_state = ops.phase_shifter(
-            theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, self._dtype
+            theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
         )
         self._update_state(new_state)
 
@@ -428,7 +428,7 @@ class Circuit:
         r = self._maybe_batch(r)
         phi = self._maybe_batch(phi)
         new_state = ops.displacement(
-            r, phi, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, self._dtype
+            r, phi, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
         )
         self._update_state(new_state)
 
@@ -440,7 +440,7 @@ class Circuit:
         theta = self._maybe_batch(theta)
         self._check_incompatible_batches(r, theta)
         new_state = ops.squeezer(
-            r, theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, self._dtype
+            r, theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
         )
         self._update_state(new_state)
 
@@ -460,7 +460,7 @@ class Circuit:
             self._cutoff_dim,
             self._state_is_pure,
             self._batched,
-            self._dtype,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -480,7 +480,7 @@ class Circuit:
             self._cutoff_dim,
             self._state_is_pure,
             self._batched,
-            self._dtype,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -513,7 +513,7 @@ class Circuit:
         g = tf.cast(gamma, self._dtype)
         g = self._maybe_batch(g)
         new_state = ops.cubic_phase(
-            g, mode, self._state, self._cutoff_dim, self._hbar, self._state_is_pure, self._batched, self._dtype
+            g, mode, self._state, self._cutoff_dim, self._hbar, self._state_is_pure, self._batched, dtype=self._dtype
         )
         self._update_state(new_state)
 
@@ -524,7 +524,7 @@ class Circuit:
         T = tf.cast(T, self._dtype)
         T = self._maybe_batch(T)
         new_state = ops.loss_channel(
-            T, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, self._dtype
+            T, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
         )
         self._update_state(new_state)
         self._state_is_pure = False  # loss output always in mixed state representation

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -225,7 +225,7 @@ class Circuit:
             pure (bool): if True, the reset circuit will represent its state as a pure state. If False, the representation will be mixed.
             cutoff_dim (int): new Fock space cutoff dimension to use.
             batch_size (None, int): None means no batching. An integer value >= 2 sets the batch size to use.
-            dtype (tf.DType): Complex Tensorflow Tensor type representation, either ``tf.complex64`` (default) or ``tf.complex128``.
+            dtype (tf.DType): (optional) complex Tensorflow Tensor type representation, either ``tf.complex64`` (default) or ``tf.complex128``.
         """
         if "pure" in kwargs:
             pure = kwargs["pure"]
@@ -245,11 +245,13 @@ class Circuit:
                 raise ValueError("Argument 'cutoff_dim' must be a positive integer")
             self._cutoff_dim = cutoff_dim
 
-        self._batch_size = kwargs.get("batch_size", None)
-        if self._batch_size is not None:
-            if not isinstance(self._batch_size, int) or self._batch_size < 2:
-                raise ValueError("Argument 'batch_size' must be either None or an integer > 1")
-        self._batched = self._batch_size is not None
+        if "batch_size" in kwargs:
+            batch_size = kwargs["batch_size"]
+            if batch_size is not None:
+                if not isinstance(batch_size, int) or batch_size < 2:
+                    raise ValueError("Argument 'batch_size' must be either None or an integer > 1")
+            self._batch_size = batch_size
+            self._batched = batch_size is not None
 
         self._dtype = kwargs.get("dtype", tf.complex64)
         if self._dtype not in (tf.complex64, tf.complex128):

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -291,7 +291,11 @@ class Circuit:
         if self._valid_modes(mode):
             n = self._maybe_batch(n, convert_to_tensor=False)
             fock_state = ops.fock_state(
-                n, cutoff=self._cutoff_dim, pure=self._state_is_pure, batched=self._batched, dtype=self._dtype
+                n,
+                cutoff=self._cutoff_dim,
+                pure=self._state_is_pure,
+                batched=self._batched,
+                dtype=self._dtype,
             )
             self._replace_and_update(fock_state, mode)
 
@@ -303,7 +307,12 @@ class Circuit:
             r = self._maybe_batch(r)
             phi = self._maybe_batch(phi)
             coherent_state = ops.coherent_state(
-                r, phi, cutoff=self._cutoff_dim, pure=self._state_is_pure, batched=self._batched, dtype=self._dtype
+                r,
+                phi,
+                cutoff=self._cutoff_dim,
+                pure=self._state_is_pure,
+                batched=self._batched,
+                dtype=self._dtype,
             )
             self._replace_and_update(coherent_state, mode)
 
@@ -316,7 +325,12 @@ class Circuit:
             theta = self._maybe_batch(theta)
             self._check_incompatible_batches(r, theta)
             squeezed_state = ops.squeezed_vacuum(
-                r, theta, cutoff=self._cutoff_dim, pure=self._state_is_pure, batched=self._batched, dtype=self._dtype
+                r,
+                theta,
+                cutoff=self._cutoff_dim,
+                pure=self._state_is_pure,
+                batched=self._batched,
+                dtype=self._dtype,
             )
             self._replace_and_update(squeezed_state, mode)
 
@@ -417,7 +431,13 @@ class Circuit:
         """
         theta = self._maybe_batch(theta)
         new_state = ops.phase_shifter(
-            theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
+            theta,
+            mode,
+            self._state,
+            self._cutoff_dim,
+            self._state_is_pure,
+            self._batched,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -428,7 +448,14 @@ class Circuit:
         r = self._maybe_batch(r)
         phi = self._maybe_batch(phi)
         new_state = ops.displacement(
-            r, phi, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
+            r,
+            phi,
+            mode,
+            self._state,
+            self._cutoff_dim,
+            self._state_is_pure,
+            self._batched,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -440,7 +467,14 @@ class Circuit:
         theta = self._maybe_batch(theta)
         self._check_incompatible_batches(r, theta)
         new_state = ops.squeezer(
-            r, theta, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
+            r,
+            theta,
+            mode,
+            self._state,
+            self._cutoff_dim,
+            self._state_is_pure,
+            self._batched,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -513,7 +547,14 @@ class Circuit:
         g = tf.cast(gamma, self._dtype)
         g = self._maybe_batch(g)
         new_state = ops.cubic_phase(
-            g, mode, self._state, self._cutoff_dim, self._hbar, self._state_is_pure, self._batched, dtype=self._dtype
+            g,
+            mode,
+            self._state,
+            self._cutoff_dim,
+            self._hbar,
+            self._state_is_pure,
+            self._batched,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
 
@@ -524,7 +565,13 @@ class Circuit:
         T = tf.cast(T, self._dtype)
         T = self._maybe_batch(T)
         new_state = ops.loss_channel(
-            T, mode, self._state, self._cutoff_dim, self._state_is_pure, self._batched, dtype=self._dtype
+            T,
+            mode,
+            self._state,
+            self._cutoff_dim,
+            self._state_is_pure,
+            self._batched,
+            dtype=self._dtype,
         )
         self._update_state(new_state)
         self._state_is_pure = False  # loss output always in mixed state representation

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -225,7 +225,7 @@ class Circuit:
             pure (bool): if True, the reset circuit will represent its state as a pure state. If False, the representation will be mixed.
             cutoff_dim (int): new Fock space cutoff dimension to use.
             batch_size (None, int): None means no batching. An integer value >= 2 sets the batch size to use.
-            dtype (DType): Complex Tensorflow Tensor type representation, either complex64 (default) or complex128.
+            dtype (tf.DType): Complex Tensorflow Tensor type representation, either ``tf.complex64`` (default) or ``tf.complex128``.
         """
         if "pure" in kwargs:
             pure = kwargs["pure"]
@@ -245,20 +245,15 @@ class Circuit:
                 raise ValueError("Argument 'cutoff_dim' must be a positive integer")
             self._cutoff_dim = cutoff_dim
 
-        if "batch_size" in kwargs:
-            batch_size = kwargs["batch_size"]
-            if batch_size is not None:
-                if not isinstance(batch_size, int) or batch_size < 2:
-                    raise ValueError("Argument 'batch_size' must be either None or an integer > 1")
-            self._batch_size = batch_size
-            self._batched = batch_size is not None
+        self._batch_size = kwargs.get("batch_size", None)
+        if self._batch_size is not None:
+            if not isinstance(self._batch_size, int) or self._batch_size < 2:
+                raise ValueError("Argument 'batch_size' must be either None or an integer > 1")
+        self._batched = self._batch_size is not None
 
-        if "dtype" in kwargs:
-            dtype = kwargs["dtype"]
-            if dtype is not None:
-                if not dtype in (tf.complex64, tf.complex128):
-                    raise ValueError("Argument 'dtype' must be a complex Tensorflow DType")
-            self._dtype = dtype
+        self._dtype = kwargs.get("dtype", tf.complex64)
+        if self._dtype not in (tf.complex64, tf.complex128):
+            raise ValueError("Argument 'dtype' must be a complex Tensorflow DType")
 
         self._state_history = []
         self._cache = {}

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -38,6 +38,7 @@ import numpy as np
 from scipy.special import factorial
 import tensorflow as tf
 from tensorflow import DType
+
 # With TF 2.1+, the legacy tf.einsum was renamed to _einsum_v1, while
 # the replacement tf.einsum introduced the bug. This try-except block
 # will dynamically patch TensorFlow versions where _einsum_v1 exists, to make it the
@@ -65,7 +66,11 @@ class Circuit:
     def __init__(self, num_modes, cutoff_dim, pure, batch_size, dtype):
         self._hbar = 2
         self.reset(
-            num_subsystems=num_modes, pure=pure, cutoff_dim=cutoff_dim, batch_size=batch_size, dtype=dtype
+            num_subsystems=num_modes,
+            pure=pure,
+            cutoff_dim=cutoff_dim,
+            batch_size=batch_size,
+            dtype=dtype,
         )
 
     def _make_vac_states(self, cutoff_dim):
@@ -222,7 +227,7 @@ class Circuit:
             pure (bool): if True, the reset circuit will represent its state as a pure state. If False, the representation will be mixed.
             cutoff_dim (int): new Fock space cutoff dimension to use.
             batch_size (None, int): None means no batching. An integer value >= 2 sets the batch size to use.
-            dtype (DType): Default is tf.complex64. 
+            dtype (DType): Default is tf.complex64.
         """
         if "pure" in kwargs:
             pure = kwargs["pure"]

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -98,7 +98,7 @@ class Circuit:
         for mode in modes:
             if mode < 0:
                 raise ValueError("Specified mode number(s) cannot be negative.")
-            elif mode >= self._num_modes:
+            if mode >= self._num_modes:
                 raise ValueError(
                     "Specified mode number(s) are not compatible with number of modes."
                 )
@@ -182,8 +182,7 @@ class Circuit:
                     self._batch_size
                 )
             )
-        else:
-            return broadcast_p
+        return broadcast_p
 
     def _check_incompatible_batches(self, *params):
         """Helper function for verifying that all the params from a list have the same batch size. Only does something
@@ -809,9 +808,8 @@ class Circuit:
 
         if not isinstance(mode, int):
             raise ValueError("Specified modes are not valid.")
-        else:
-            if mode < 0 or mode >= self._num_modes:
-                raise ValueError("Specified modes are not valid.")
+        if mode < 0 or mode >= self._num_modes:
+            raise ValueError("Specified modes are not valid.")
 
         m_omega_over_hbar = 1 / self._hbar
         if self._state_is_pure:
@@ -879,7 +877,7 @@ class Circuit:
                     Hn = Hn_p1
                 self._cache["hermite_polys"] = hermite_polys
 
-            number_state_indices = [k for k in product(range(self._cutoff_dim), repeat=2)]
+            number_state_indices = list(product(range(self._cutoff_dim), repeat=2))
             terms = [
                 1
                 / np.sqrt(2 ** n * factorial(n) * 2 ** m * factorial(m))

--- a/strawberryfields/backends/tfbackend/circuit.py
+++ b/strawberryfields/backends/tfbackend/circuit.py
@@ -37,7 +37,7 @@ from string import ascii_lowercase as indices
 import numpy as np
 from scipy.special import factorial
 import tensorflow as tf
-
+from tensorflow import DType
 # With TF 2.1+, the legacy tf.einsum was renamed to _einsum_v1, while
 # the replacement tf.einsum introduced the bug. This try-except block
 # will dynamically patch TensorFlow versions where _einsum_v1 exists, to make it the
@@ -62,10 +62,10 @@ class Circuit:
     The state of the modes is manipulated by calling the various methods."""
 
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
-    def __init__(self, num_modes, cutoff_dim, pure, batch_size):
+    def __init__(self, num_modes, cutoff_dim, pure, batch_size, dtype):
         self._hbar = 2
         self.reset(
-            num_subsystems=num_modes, pure=pure, cutoff_dim=cutoff_dim, batch_size=batch_size
+            num_subsystems=num_modes, pure=pure, cutoff_dim=cutoff_dim, batch_size=batch_size, dtype=dtype
         )
 
     def _make_vac_states(self, cutoff_dim):
@@ -222,6 +222,7 @@ class Circuit:
             pure (bool): if True, the reset circuit will represent its state as a pure state. If False, the representation will be mixed.
             cutoff_dim (int): new Fock space cutoff dimension to use.
             batch_size (None, int): None means no batching. An integer value >= 2 sets the batch size to use.
+            dtype (DType): Default is tf.complex64. 
         """
         if "pure" in kwargs:
             pure = kwargs["pure"]
@@ -248,6 +249,13 @@ class Circuit:
                     raise ValueError("Argument 'batch_size' must be either None or an integer > 1")
             self._batch_size = batch_size
             self._batched = batch_size is not None
+
+        if "dtype" in kwargs:
+            dtype = kwargs["dtype"]
+            if dtype is not None:
+                if not isinstance(dtype, DType):
+                    raise ValueError("Argument 'dtype' must be a Tensorflow DType")
+            self._dtype = dtype
 
         self._state_history = []
         self._cache = {}

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -182,7 +182,10 @@ def squeezer_matrix(r, phi, cutoff, batched=False, dtype=tf.complex64):
     phi = tf.cast(phi, dtype)
     if batched:
         return tf.stack(
-            [single_squeezing_matrix(r_, phi_, cutoff, dtype=dtype.as_numpy_dtype) for r_, phi_ in tf.transpose([r, phi])]
+            [
+                single_squeezing_matrix(r_, phi_, cutoff, dtype=dtype.as_numpy_dtype)
+                for r_, phi_ in tf.transpose([r, phi])
+            ]
         )
     return single_squeezing_matrix(r, phi, cutoff, dtype=dtype.as_numpy_dtype)
 
@@ -225,7 +228,9 @@ def cross_kerr_interaction_matrix(kappa, cutoff, batched=False):
     return output
 
 
-def cubic_phase_matrix(gamma, cutoff, hbar, batched=False, method="self_adjoint_eig", dtype=tf.complex64):
+def cubic_phase_matrix(
+    gamma, cutoff, hbar, batched=False, method="self_adjoint_eig", dtype=tf.complex64
+):
     """creates the single mode cubic phase matrix"""
     a, ad = ladder_ops(cutoff)
     x = np.sqrt(hbar / 2) * tf.cast(a + ad, dtype)
@@ -305,7 +310,10 @@ def displacement_matrix(r, phi, cutoff, batched=False, dtype=tf.complex64):
     phi = tf.cast(phi, dtype)
     if batched:
         return tf.stack(
-            [single_displacement_matrix(r_, phi_, cutoff, dtype=dtype.as_numpy_dtype) for r_, phi_ in tf.transpose([r, phi])]
+            [
+                single_displacement_matrix(r_, phi_, cutoff, dtype=dtype.as_numpy_dtype)
+                for r_, phi_ in tf.transpose([r, phi])
+            ]
         )
     return single_displacement_matrix(r, phi, cutoff, dtype=dtype.as_numpy_dtype)
 
@@ -341,7 +349,9 @@ def beamsplitter_matrix(theta, phi, cutoff, batched=False, dtype=tf.complex64):
                 for theta_, phi_ in tf.transpose([theta, phi])
             ]
         )
-    return tf.convert_to_tensor(single_beamsplitter_matrix(theta, phi, cutoff, dtype=dtype.as_numpy_dtype))
+    return tf.convert_to_tensor(
+        single_beamsplitter_matrix(theta, phi, cutoff, dtype=dtype.as_numpy_dtype)
+    )
 
 
 @tf.custom_gradient
@@ -375,7 +385,9 @@ def two_mode_squeezer_matrix(theta, phi, cutoff, batched=False, dtype=tf.complex
                 for theta_, phi_ in tf.transpose([theta, phi])
             ]
         )
-    return tf.convert_to_tensor(single_two_mode_squeezing_matrix(theta, phi, cutoff, dtype=dtype.as_numpy_dtype))
+    return tf.convert_to_tensor(
+        single_two_mode_squeezing_matrix(theta, phi, cutoff, dtype=dtype.as_numpy_dtype)
+    )
 
 
 ###################################################################
@@ -429,7 +441,9 @@ def squeezed_vacuum(r, theta, cutoff, pure=True, batched=False, dtype=tf.complex
     return squeezed
 
 
-def displaced_squeezed(r_d, phi_d, r_s, phi_s, cutoff, pure=True, batched=False, eps=1e-12, dtype=tf.complex64):
+def displaced_squeezed(
+    r_d, phi_d, r_s, phi_s, cutoff, pure=True, batched=False, eps=1e-12, dtype=tf.complex64
+):
     """creates a single mode input displaced squeezed state"""
     alpha = tf.cast(r_d, dtype) * tf.exp(1j * tf.cast(phi_d, dtype))
     r_s = (
@@ -457,7 +471,9 @@ def displaced_squeezed(r_d, phi_d, r_s, phi_s, cutoff, pure=True, batched=False,
         ],
         axis=-1,
     )
-    hermite_terms = tf.stack([tf.cast(H(n, hermite_arg, dtype), dtype) for n in range(cutoff)], axis=-1)
+    hermite_terms = tf.stack(
+        [tf.cast(H(n, hermite_arg, dtype), dtype) for n in range(cutoff)], axis=-1
+    )
     squeezed_coh = prefactor * coeff * hermite_terms
 
     if not pure:
@@ -471,7 +487,10 @@ def thermal_state(nbar, cutoff, dtype=tf.complex64):
     """
     nbar = tf.cast(nbar, dtype)
     coeffs = tf.stack(
-        [_numer_safe_power(nbar, n, dtype) / _numer_safe_power(nbar + 1, n + 1, dtype) for n in range(cutoff)],
+        [
+            _numer_safe_power(nbar, n, dtype) / _numer_safe_power(nbar + 1, n + 1, dtype)
+            for n in range(cutoff)
+        ],
         axis=-1,
     )
     thermal = tf.linalg.diag(coeffs)
@@ -750,7 +769,15 @@ def cross_kerr_interaction(kappa, mode1, mode2, in_modes, cutoff, pure=True, bat
 
 
 def cubic_phase(
-    gamma, mode, in_modes, cutoff, hbar=2, pure=True, batched=False, method="self_adjoint_eig", dtype=tf.complex64
+    gamma,
+    mode,
+    in_modes,
+    cutoff,
+    hbar=2,
+    pure=True,
+    batched=False,
+    method="self_adjoint_eig",
+    dtype=tf.complex64,
 ):
     """returns cubic phase unitary matrix on specified input modes"""
     matrix = cubic_phase_matrix(gamma, cutoff, hbar, batched, method=method, dtype=dtype)
@@ -758,7 +785,9 @@ def cubic_phase(
     return output
 
 
-def beamsplitter(theta, phi, mode1, mode2, in_modes, cutoff, pure=True, batched=False, dtype=tf.complex64):
+def beamsplitter(
+    theta, phi, mode1, mode2, in_modes, cutoff, pure=True, batched=False, dtype=tf.complex64
+):
     """returns beamsplitter unitary matrix on specified input modes"""
     theta = tf.cast(theta, dtype)
     phi = tf.cast(phi, dtype)
@@ -767,7 +796,9 @@ def beamsplitter(theta, phi, mode1, mode2, in_modes, cutoff, pure=True, batched=
     return output
 
 
-def two_mode_squeeze(r, theta, mode1, mode2, in_modes, cutoff, pure=True, batched=False, dtype=tf.complex64):
+def two_mode_squeeze(
+    r, theta, mode1, mode2, in_modes, cutoff, pure=True, batched=False, dtype=tf.complex64
+):
     """returns beamsplitter unitary matrix on specified input modes"""
     matrix = two_mode_squeezer_matrix(r, theta, cutoff, batched, dtype)
     output = two_mode_gate(matrix, mode1, mode2, in_modes, pure, batched)

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -57,7 +57,7 @@ try:
 except ImportError:
     pass
 
-def_type = tf.complex64  # NOTE: what if a user wants higher accuracy?
+def_type = tf.float64  # NOTE: what if a user wants higher accuracy?
 max_num_indices = len(indices)
 
 ###################################################################

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -62,10 +62,10 @@ max_num_indices = len(indices)
 ###################################################################
 
 # Helper functions:
-def _numer_safe_power(base, exponent, dtype):
+def _numer_safe_power(base, exponent, dtype=tf.complex64):
     """gives the desired behaviour of 0**0=1"""
     if exponent == 0:
-        return tf.ones_like(base, dtype=dtype)
+        return tf.ones_like(base, dtype)
 
     return base ** exponent
 
@@ -160,7 +160,7 @@ def squeezed_vacuum_vector(r, theta, cutoff, batched=False, eps=1e-32, dtype=tf.
 
 
 @tf.custom_gradient
-def single_squeezing_matrix(r, phi, cutoff, dtype):
+def single_squeezing_matrix(r, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
     """creates a single-mode squeezing matrix"""
     r = r.numpy()
     phi = phi.numpy()
@@ -283,7 +283,7 @@ def loss_superop(T, cutoff, batched=False, dtype=tf.complex64):
 
 
 @tf.custom_gradient
-def single_displacement_matrix(r, phi, cutoff, dtype):
+def single_displacement_matrix(r, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
     """creates a single mode displacement matrix"""
     r = r.numpy()
     phi = phi.numpy()
@@ -311,7 +311,7 @@ def displacement_matrix(r, phi, cutoff, batched=False, dtype=tf.complex64):
 
 
 @tf.custom_gradient
-def single_beamsplitter_matrix(theta, phi, cutoff, dtype):
+def single_beamsplitter_matrix(theta, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
     """creates a single mode beamsplitter matrix"""
     theta = theta.numpy()
     phi = phi.numpy()
@@ -345,7 +345,7 @@ def beamsplitter_matrix(theta, phi, cutoff, batched=False, dtype=tf.complex64):
 
 
 @tf.custom_gradient
-def single_two_mode_squeezing_matrix(theta, phi, cutoff, dtype):
+def single_two_mode_squeezing_matrix(theta, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
     """creates a single mode two-mode squeezing matrix"""
     theta = theta.numpy()
     phi = phi.numpy()
@@ -721,7 +721,7 @@ def displacement(r, phi, mode, in_modes, cutoff, pure=True, batched=False, dtype
     """returns displacement unitary matrix on specified input modes"""
     r = tf.cast(r, dtype)
     phi = tf.cast(phi, dtype)
-    matrix = displacement_matrix(r, phi, cutoff, batched, dtype=dtype)
+    matrix = displacement_matrix(r, phi, cutoff, batched, dtype)
     output = single_mode_gate(matrix, mode, in_modes, pure, batched)
     return output
 
@@ -730,7 +730,7 @@ def squeezer(r, theta, mode, in_modes, cutoff, pure=True, batched=False, dtype=t
     """returns squeezer unitary matrix on specified input modes"""
     r = tf.cast(r, dtype)
     theta = tf.cast(theta, dtype)
-    matrix = squeezer_matrix(r, theta, cutoff, batched, dtype=dtype)
+    matrix = squeezer_matrix(r, theta, cutoff, batched, dtype)
     output = single_mode_gate(matrix, mode, in_modes, pure, batched)
     return output
 
@@ -762,14 +762,14 @@ def beamsplitter(theta, phi, mode1, mode2, in_modes, cutoff, pure=True, batched=
     """returns beamsplitter unitary matrix on specified input modes"""
     theta = tf.cast(theta, dtype)
     phi = tf.cast(phi, dtype)
-    matrix = beamsplitter_matrix(theta, phi, cutoff, batched, dtype=dtype.as_numpy_dtype)
+    matrix = beamsplitter_matrix(theta, phi, cutoff, batched, dtype)
     output = two_mode_gate(matrix, mode1, mode2, in_modes, pure, batched)
     return output
 
 
 def two_mode_squeeze(r, theta, mode1, mode2, in_modes, cutoff, pure=True, batched=False, dtype=tf.complex64):
     """returns beamsplitter unitary matrix on specified input modes"""
-    matrix = two_mode_squeezer_matrix(r, theta, cutoff, batched, dtype=dtype.as_numpy_dtype)
+    matrix = two_mode_squeezer_matrix(r, theta, cutoff, batched, dtype)
     output = two_mode_gate(matrix, mode1, mode2, in_modes, pure, batched)
     return output
 

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -931,24 +931,11 @@ def replace_modes(replacement, modes, system, system_is_pure, batched=False):
         # append mode and insert state (There is also insert_state(), but it seemed unnecessarily complicated to try to generalize this function, which does a lot of manual list comprehension, to the multi mode case than to write the two liner below)
         # todo: insert_state() could be rewritten to take full advantage of the high level functions of tf. Before doing that different implementatinos should be benchmarked to compare speed and memory requirements, as in practice these methods will be perfomance critical.
         if not batched:
-            # todo: remove the hack in the line below and enable the line with axes=0 instead, if ever we change the dependency of SF to tensorflow>=1.6
-            # revised_modes = tf.tensordot(reduced_state, replacement, axes=0)
-            revised_modes = tf.tensordot(
-                tf.expand_dims(reduced_state, 0), tf.expand_dims(replacement, 0), axes=[[0], [0]]
-            )
+            revised_modes = tf.tensordot(reduced_state, replacement, axes=0)
         else:
             batch_size = reduced_state.shape[0]
-            # todo: remove the hack in the line below and enabled the line with axes=0 instead, if ever we change the dependency of SF to tensorflow>=1.6
-            # revised_modes = tf.stack([tf.tensordot(reduced_state[b], replacement[b], axes=0) for b in range(batch_size)])
             revised_modes = tf.stack(
-                [
-                    tf.tensordot(
-                        tf.expand_dims(reduced_state[b], 0),
-                        tf.expand_dims(replacement[b], 0),
-                        axes=[[0], [0]],
-                    )
-                    for b in range(batch_size)
-                ]
+                [tf.tensordot(reduced_state[b], replacement[b], axes=0) for b in range(batch_size)]
             )
         revised_modes_pure = False
 

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -50,7 +50,16 @@ class FockStateTF(BaseFockState):
                     complex64 (default) or complex128
     """
 
-    def __init__(self, state_data, num_modes, pure, cutoff_dim, batched=False, mode_names=None, dtype=tf.complex64):
+    def __init__(
+        self,
+        state_data,
+        num_modes,
+        pure,
+        cutoff_dim,
+        batched=False,
+        mode_names=None,
+        dtype=tf.complex64,
+    ):
         # pylint: disable=too-many-arguments
         state_data = tf.convert_to_tensor(
             state_data, name="state_data"
@@ -58,8 +67,10 @@ class FockStateTF(BaseFockState):
         super().__init__(state_data, num_modes, pure, cutoff_dim, mode_names)
         self._batched = batched
         self._dtype = dtype
-        self._str = "<FockStateTF: num_modes={}, cutoff={}, pure={}, batched={}, hbar={}, dtype={}>".format(
-            self.num_modes, self.cutoff_dim, self._pure, self._batched, self._hbar, self._dtype
+        self._str = (
+            "<FockStateTF: num_modes={}, cutoff={}, pure={}, batched={}, hbar={}, dtype={}>".format(
+                self.num_modes, self.cutoff_dim, self._pure, self._batched, self._hbar, self._dtype
+            )
         )
 
     def trace(self, **kwargs):

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 from strawberryfields.backends.states import BaseFockState
-from .ops import def_type, ladder_ops, phase_shifter_matrix, reduced_density_matrix
+from .ops import ladder_ops, phase_shifter_matrix, reduced_density_matrix
 
 
 class FockStateTF(BaseFockState):
@@ -43,19 +43,23 @@ class FockStateTF(BaseFockState):
             num_modes (int): the number of modes in the state
             pure (bool): True if the state is a pure state, false if the state is mixed
             cutoff_dim (int): the Fock basis truncation size
+            batched (bool): (optional) default False means no batching
             mode_names (Sequence): (optional) this argument contains a list providing mode names
-                    for each mode in the state.
+                    for each mode in the state
+            dtype (DType): (optional) complex Tensorflow Tensor type representation, either
+                    complex64 (default) or complex128
     """
 
-    def __init__(self, state_data, num_modes, pure, cutoff_dim, batched=False, mode_names=None):
+    def __init__(self, state_data, num_modes, pure, cutoff_dim, batched=False, mode_names=None, dtype=tf.complex64):
         # pylint: disable=too-many-arguments
         state_data = tf.convert_to_tensor(
             state_data, name="state_data"
         )  # convert everything to a Tensor so we have the option to do symbolic evaluations
         super().__init__(state_data, num_modes, pure, cutoff_dim, mode_names)
         self._batched = batched
-        self._str = "<FockStateTF: num_modes={}, cutoff={}, pure={}, batched={}, hbar={}>".format(
-            self.num_modes, self.cutoff_dim, self._pure, self._batched, self._hbar
+        self._dtype = dtype
+        self._str = "<FockStateTF: num_modes={}, cutoff={}, pure={}, batched={}, hbar={}, dtype={}>".format(
+            self.num_modes, self.cutoff_dim, self._pure, self._batched, self._hbar, self._dtype
         )
 
     def trace(self, **kwargs):
@@ -180,7 +184,7 @@ class FockStateTF(BaseFockState):
         if len(other_state.shape) == 1:
             other_state = tf.expand_dims(other_state, 0)  # add batch dimension for state
 
-        other_state = tf.cast(other_state, def_type)
+        other_state = tf.cast(other_state, self.dtype)
         state_dm = tf.einsum("bi,bj->bij", tf.math.conj(other_state), other_state)
         flat_state_dm = tf.reshape(state_dm, [1, -1])
         flat_rho = tf.reshape(rho, [-1, self.cutoff_dim ** 2])
@@ -349,7 +353,7 @@ class FockStateTF(BaseFockState):
         if self.batched and len(phi.shape) == 0:  # pylint: disable=len-as-condition
             phi = tf.expand_dims(phi, 0)
         larger_cutoff = self.cutoff_dim + 1  # start one dimension higher to avoid truncation errors
-        R = phase_shifter_matrix(phi, larger_cutoff, batched=self.batched)
+        R = phase_shifter_matrix(phi, larger_cutoff, batched=self.batched, dtype=self.dtype)
         if not self.batched:
             R = tf.expand_dims(R, 0)  # add fake batch dimension
 
@@ -556,3 +560,8 @@ class FockStateTF(BaseFockState):
     def batched(self):
         """The number of batches."""
         return self._batched
+
+    @property
+    def dtype(self):
+        """The circuit dtype"""
+        return self._dtype

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -184,7 +184,7 @@ class FockStateTF(BaseFockState):
         if len(other_state.shape) == 1:
             other_state = tf.expand_dims(other_state, 0)  # add batch dimension for state
 
-        other_state = tf.cast(other_state, self.dtype)
+        other_state = tf.cast(other_state, dtype=self.dtype)
         state_dm = tf.einsum("bi,bj->bij", tf.math.conj(other_state), other_state)
         flat_state_dm = tf.reshape(state_dm, [1, -1])
         flat_rho = tf.reshape(rho, [-1, self.cutoff_dim ** 2])
@@ -259,9 +259,9 @@ class FockStateTF(BaseFockState):
             )
             f = tf.einsum(
                 eqn,
-                tf.convert_to_tensor(np.conj(multi_cohs_vec), dtype=def_type),
+                tf.convert_to_tensor(np.conj(multi_cohs_vec), dtype=self.dtype),
                 s,
-                tf.convert_to_tensor(multi_cohs_vec, def_type),
+                tf.convert_to_tensor(multi_cohs_vec, dtype=self.dtype),
             )
         if not self.batched:
             f = tf.squeeze(f, 0)  # drop fake batch dimension
@@ -359,7 +359,7 @@ class FockStateTF(BaseFockState):
 
         a, ad = ladder_ops(larger_cutoff)
         x = np.sqrt(self._hbar / 2.0) * (a + ad)
-        x = tf.expand_dims(tf.cast(x, def_type), 0)  # add batch dimension to x
+        x = tf.expand_dims(tf.cast(x, dtype=self.dtype), 0)  # add batch dimension to x
         quad = tf.math.conj(R) @ x @ R
         quad2 = (quad @ quad)[:, : self.cutoff_dim, : self.cutoff_dim]
         quad = quad[

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -195,7 +195,7 @@ class FockStateTF(BaseFockState):
         if len(other_state.shape) == 1:
             other_state = tf.expand_dims(other_state, 0)  # add batch dimension for state
 
-        other_state = tf.cast(other_state, dtype=self.dtype)
+        other_state = tf.cast(other_state, self.dtype)
         state_dm = tf.einsum("bi,bj->bij", tf.math.conj(other_state), other_state)
         flat_state_dm = tf.reshape(state_dm, [1, -1])
         flat_rho = tf.reshape(rho, [-1, self.cutoff_dim ** 2])
@@ -370,7 +370,7 @@ class FockStateTF(BaseFockState):
 
         a, ad = ladder_ops(larger_cutoff)
         x = np.sqrt(self._hbar / 2.0) * (a + ad)
-        x = tf.expand_dims(tf.cast(x, dtype=self.dtype), 0)  # add batch dimension to x
+        x = tf.expand_dims(tf.cast(x, self.dtype), 0)  # add batch dimension to x
         quad = tf.math.conj(R) @ x @ R
         quad2 = (quad @ quad)[:, : self.cutoff_dim, : self.cutoff_dim]
         quad = quad[

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -46,8 +46,8 @@ class FockStateTF(BaseFockState):
             batched (bool): (optional) default False means no batching
             mode_names (Sequence): (optional) this argument contains a list providing mode names
                     for each mode in the state
-            dtype (DType): (optional) complex Tensorflow Tensor type representation, either
-                    complex64 (default) or complex128
+            dtype (tf.DType): (optional) complex Tensorflow Tensor type representation, either
+                    ``tf.complex64`` (default) or ``tf.complex128``
     """
 
     def __init__(

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -51,7 +51,7 @@ engines = [
     sf.Engine("gaussian", backend_options={"cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"cutoff_dim": 6}),
-    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.float64}),
+    sf.Engine("tf", backend_options={"cutoff_dim": 6, "dtype": tf.float64}),
 ]
 
 

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -44,14 +44,14 @@ batch_engines = [
     sf.Engine("gaussian", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6}),
-    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.float64}),
+    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.complex64}),
 ]
 
 engines = [
     sf.Engine("gaussian", backend_options={"cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"cutoff_dim": 6}),
-    sf.Engine("tf", backend_options={"cutoff_dim": 6, "dtype": tf.float64}),
+    sf.Engine("tf", backend_options={"cutoff_dim": 6, "dtype": tf.complex128}),
 ]
 
 

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -15,6 +15,7 @@ r"""Unit tests for engine.py"""
 import pytest
 import numpy as np
 
+tf = pytest.importorskip("tensorflow", minversion="2.0")
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends.base import BaseBackend
@@ -43,12 +44,14 @@ batch_engines = [
     sf.Engine("gaussian", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6}),
+    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.float64}),
 ]
 
 engines = [
     sf.Engine("gaussian", backend_options={"cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"cutoff_dim": 6}),
+    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.float64}),
 ]
 
 

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -44,7 +44,7 @@ batch_engines = [
     sf.Engine("gaussian", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("fock", backend_options={"batch_size": 2, "cutoff_dim": 6}),
     sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6}),
-    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.complex64}),
+    sf.Engine("tf", backend_options={"batch_size": 2, "cutoff_dim": 6, "dtype": tf.complex128}),
 ]
 
 engines = [


### PR DESCRIPTION
**Context:**
Resolves #486 

**Description of the Change:**
Make tensorflow dtype adjustable by user by adding a `dtype` optional argument to `backend_options`. Follows existing patterns for optional arguments.

**Benefits:**
User can adjust `dtype`, i.e.:
```
  prog = sf.Program(2)
  eng  = sf.Engine("tf", backend_options={"cutoff_dim": 50, "dtype": tf.complex128})
  with prog.context as q:
      Sgate(0.8)         | q[0]
      Sgate(0.8)         | q[1]
      BSgate(0.5,0.5)  | (q[0], q[1])
      BSgate(0.5,0.5)  | (q[0], q[1])
  state    = eng.run(prog).state
  N0,N0var = state.mean_photon(0)
  N1,N1var = state.mean_photon(1)
  print(N0)
  print(N1)
  print('analytical:',np.sinh(0.8)**2)
```

**Possible Drawbacks:**
N/A?

**Related GitHub Issues:**
#486 