### PR TITLE
Development requirements and formatting

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -83,6 +83,8 @@
 
 * Cleanup docs to make contribution easier.
   [(#561)](https://github.com/XanaduAI/strawberryfields/pull/561)
+* Add development requirements and format script to make contribution easier.
+  [(#563)](https://github.com/XanaduAI/strawberryfields/pull/563)
 
 <h3>Contributors</h3>
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,8 @@ Please complete the following checklist when submitting a PR:
 - [ ] Ensure that the test suite passes, by running `make test`.
 
 - [ ] Ensure that code is properly formatted, by running `make format` or `black -l 100
-      strawberryfields`.
-      You will need to have the Black code format installed: `pip install black`
+      strawberryfields`. You will need to have the Black code format installed: `pip install
+      black`.
 
 - [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
       change, and including a link back to the PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@ Please complete the following checklist when submitting a PR:
 
 - [ ] Ensure that the test suite passes, by running `make test`.
 
+- [ ] Ensure that code is properly formatted, by running `make format`.
+
 - [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
       change, and including a link back to the PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,9 @@ Please complete the following checklist when submitting a PR:
 
 - [ ] Ensure that the test suite passes, by running `make test`.
 
-- [ ] Ensure that code is properly formatted, by running `make format`.
+- [ ] Ensure that code is properly formatted, by running `make format` or `black -l 100
+      strawberryfields`.
+      You will need to have the Black code format installed: `pip install black`
 
 - [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
       change, and including a link back to the PR.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@echo "  dist               to package the source distribution"
 	@echo "  clean              to delete all temporary, cache, and build files"
 	@echo "  clean-docs         to delete all built documentation"
+	@echo "  format             to run black formatting"
 	@echo "  test               to run the test suite for entire codebase"
 	@echo "  test-[component]   to run the test suite for frontend, fock, tf, gaussian or apps"
 	@echo "  coverage           to generate a coverage report for entire codebase"
@@ -53,6 +54,10 @@ docs:
 clean-docs:
 	make -C doc clean
 	rm -rf doc/code/api
+
+.PHONY : format
+format: 
+	black -l 100 --check --diff strawberryfields
 
 test: test-frontend test-gaussian test-fock test-tf batch-test-tf test-apps test-api
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean-docs:
 
 .PHONY : format
 format: 
-	black -l 100 --check --diff strawberryfields
+	black -l 100 strawberryfields
 
 test: test-frontend test-gaussian test-fock test-tf batch-test-tf test-apps test-api
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,5 @@
+pytest>=6.2.2
+pytest-cov>=2.11.1
+pytest-mock>=3.5.1
+pytest-randomly>=3.5.0
+black>=20.8b1

--- a/doc/development/development_guide.rst
+++ b/doc/development/development_guide.rst
@@ -56,20 +56,23 @@ Or, to install Strawberry Fields and TensorFlow with GPU and CUDA support:
 
     pip install strawberryfields tensorflow-gpu
 
+Development environment
+-----------------------
+
+Strawberry fields uses a ``pytest`` suite for testing and ``black`` for formatting. These
+dependencies can be installed via ``pip``:
+
+.. code-block:: bash
+
+    pip install -r dev_requirements.txt
 
 Software tests
 --------------
 
-The Strawberry Fields test suite requires `pytest <https://docs.pytest.org/en/latest/>`_,
-`pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_,
+The Strawberry Fields test suite includes `pytest <https://docs.pytest.org/en/latest/>`_,
+`pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_, 
 `pytest-randomly <https://github.com/pytest-dev/pytest-randomly>`_,
-and `pytest-mocks <https://github.com/pytest-dev/pytest-mock/>`_ for coverage reports.
-These can be installed via ``pip``:
-
-.. code-block:: bash
-
-    pip install pytest pytest-cov pytest-randomly pytest-mock
-
+and `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ for coverage reports.
 
 To ensure that Strawberry Fields is working correctly after installation, the test suite
 can be run by navigating to the source code folder and running
@@ -214,6 +217,16 @@ filtering out certain tests:
 
 Passing the ``--cov`` option without any modules specified will generate a
 coverage report for all modules of Strawberry Fields.
+
+Format
+------
+
+Contributions are checked for format alignment in the pipeline. With ``black``
+installed, changes can be checked for format locally using:
+
+.. code-block:: bash
+
+    make format
 
 Documentation
 -------------

--- a/doc/development/development_guide.rst
+++ b/doc/development/development_guide.rst
@@ -222,11 +222,17 @@ Format
 ------
 
 Contributions are checked for format alignment in the pipeline. With ``black``
-installed, changes can be checked for format locally using:
+installed, changes can be formatted locally using:
 
 .. code-block:: bash
 
     make format
+
+Contributors without ``make`` installed can run ``black`` directly using:
+
+.. code-block:: bash
+
+    black -l 100 strawberryfields
 
 Documentation
 -------------


### PR DESCRIPTION
**Context:**

Discussed on #561 

**Description of the Change:**

Adds a development environment section to development docs, and an associated `dev_requirements.txt` for installation. Includes a `black` format script run by `make format` with associated instructions in development docs and PR template.

**Benefits:**

Makes contribution easier.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**

N/A