### PR TITLE
Fix TDM "modes" validation to match XQC API

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -101,6 +101,7 @@
   [(#540)](https://github.com/XanaduAI/strawberryfields/pull/540)
 * TDM programs now expect a flat (not nested) dictionary of `modes` in device 
   specifications obtained from the XQC platform API.
+  [(#566)](https://github.com/XanaduAI/strawberryfields/pull/566)
 
 <h3>Documentation</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -99,6 +99,8 @@
 * `Connection` objects now send requests to the platform API at version `0.2.0`
   instead of the incorrect version number `1.0.0`.
   [(#540)](https://github.com/XanaduAI/strawberryfields/pull/540)
+* TDM programs now expect a flat (not nested) dictionary of `modes` in device 
+  specifications obtained from the XQC platform API.
 
 <h3>Documentation</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -99,6 +99,7 @@
 * `Connection` objects now send requests to the platform API at version `0.2.0`
   instead of the incorrect version number `1.0.0`.
   [(#540)](https://github.com/XanaduAI/strawberryfields/pull/540)
+
 * TDM programs now expect a flat (not nested) dictionary of `modes` in device 
   specifications obtained from the XQC platform API.
   [(#566)](https://github.com/XanaduAI/strawberryfields/pull/566)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -115,9 +115,9 @@
 
 This release contains contributions from (in alphabetical order):
 
-J. Eli Bourassa, Guillaume Dauphinais, Ish Dhand, Theodor Isacsson, Josh Izaac, 
-Nicolás Quesada, Aaron Robertson, Krishna Kumar Sabapathy, Jeremy Swinarton, Antal Száva,
-Ilan Tzitrin.
+J. Eli Bourassa, Guillaume Dauphinais, Ish Dhand, Theodor Isacsson, Josh Izaac,
+Leonhard Neuhaus, Nicolás Quesada, Aaron Robertson, Krishna Kumar Sabapathy, 
+Jeremy Swinarton, Antal Száva, Ilan Tzitrin.
 
 # Release 0.17.0 (current release)
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -643,7 +643,6 @@ class TDMProgram(sf.Program):
         self.append(cmd.op.__class__(*params), get_modes(cmd, q))
 
     def assert_number_of_modes(self, device):
-        return
         if self.timebins > device.modes["temporal_max"]:
             raise CircuitError(
                 f"This program contains {self.timebins} temporal modes, but the device '{device.target}' "

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -644,7 +644,7 @@ class TDMProgram(sf.Program):
 
     def assert_number_of_modes(self, device):
         return
-        if self.timebins > device.modes["temporal"]["max"]:
+        if self.timebins > device.modes["temporal_max"]:
             raise CircuitError(
                 f"This program contains {self.timebins} temporal modes, but the device '{device.target}' "
                 f"only supports up to {device.modes['temporal']['max']} modes."

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -646,7 +646,7 @@ class TDMProgram(sf.Program):
         if self.timebins > device.modes["temporal_max"]:
             raise CircuitError(
                 f"This program contains {self.timebins} temporal modes, but the device '{device.target}' "
-                f"only supports up to {device.modes['temporal']['max']} modes."
+                f"only supports up to {device.modes['temporal_max']} modes."
             )
         if self.concurr_modes != device.modes["concurrent"]:
             raise CircuitError(

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -643,6 +643,7 @@ class TDMProgram(sf.Program):
         self.append(cmd.op.__class__(*params), get_modes(cmd, q))
 
     def assert_number_of_modes(self, device):
+        return
         if self.timebins > device.modes["temporal"]["max"]:
             raise CircuitError(
                 f"This program contains {self.timebins} temporal modes, but the device '{device.target}' "

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -525,7 +525,7 @@ target = "TD2"
 tm = 4
 device_spec = {
     "layout": "name template_tdm\nversion 1.0\ntarget {target} (shots=1)\ntype tdm (temporal_modes={tm})\nfloat array p1[1, {tm}] =\n    {{bs_array}}\nfloat array p2[1, {tm}] =\n    {{r_array}}\nfloat array p3[1, {tm}] =\n    {{m_array}}\n\nSgate(0.5643) | 1\nBSgate(p1) | (1, 0)\nRgate(p2) | 1\nMeasureHomodyne(p3) | 0\n",
-    "modes": {"concurrent": 2, "spatial": 1, "temporal": {"max": 100}},
+    "modes": {"concurrent": 2, "spatial": 1, "temporal_max": 100},
     "compiler": ["TD2"],
     "gate_parameters": {
         "p1": [0, [0, 6.283185307179586]],


### PR DESCRIPTION
**Context:**
Device specifications for TDM programs that are exposed by Xanadu's device API used to include a field `modes` with data like
```
{
    "concurrent": 2,
    "spatial": 1,
    "max": {"temporal": 100},
}
```
This format was recently changed into (ex generis):
```
{
    "concurrent": 2,
    "spatial": 1,
    "temporal_max": 100
}
```

**Description of the Change:**
This PR brings Strawberry Fields up to date with the new format.

**Benefits:**
TDM programs can run on Xanadu hardware.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
