### PR TITLE
Pin docutils to version v0.16

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.16
 appdirs
 ipykernel
 sphinx==2.2.2


### PR DESCRIPTION
[Docutils version 0.17](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-17-2021-04-03), released on April 3rd, contains a new HTML5 writer that uses HTML5 semantic tags (`<main>`, `<section>`, `<header>`, `<footer>`, `<aside>`, `<figure>`, and `<figcaption>`) rather than `<div>`. This breaks the CSS on the website.

This PR pins docutils to version 0.16.