### PR TITLE
Change simulon target to simulon_gaussian

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 * References to the ``simulon`` simulator target have been rewritten to
   ``simulon_gaussian`` to reflect changes made on the Xanadu Quantum Cloud. The
-  language has been modified to suggest that multiple simulators could be
-  available.
+  language has been modified to imply that multiple simulators could be
+  available on XQC.
+  [(#576)](https://github.com/XanaduAI/strawberryfields/pull/576)
 
 <h3>Contributors</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,9 +8,16 @@
 
 <h3>Documentation</h3>
 
+* References to the ``simulon`` simulator target have been rewritten to
+  ``simulon_gaussian`` to reflect changes made on the Xanadu Quantum Cloud. The
+  language has been modified to suggest that multiple simulators could be
+  available.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Jeremy Swinarton.
 
 # Release 0.18.0 (current release)
 

--- a/doc/introduction/photonic_hardware.rst
+++ b/doc/introduction/photonic_hardware.rst
@@ -136,13 +136,14 @@ Cloud simulator
 In addition to submitting jobs to be run on quantum hardware, it is also possible to run jobs on
 simulators via the Xanadu Quantum Cloud. The process is very similar to running jobs on hardware. You
 will need to configure your account, as described above, and submit a job via the ``RemoteEngine``,
-using a simulator as the target instead of a specific chip:
+using a simulator (a "simulon") as the target instead of a specific chip:
 
 >>> eng = sf.RemoteEngine("simulon_gaussian")
 >>> result = eng.run(prog)
 
-Simulon jobs can also be submitted asynchronously using ``eng.run_async``, or by submitting a
-Blackbird script with the ``target`` set to a simulator target in the Blackbird header.
+Simulator jobs can also be submitted asynchronously using ``eng.run_async``, or
+by submitting a Blackbird script with the ``target`` set to a simulator target
+in the Blackbird header.
 
 See the `Submitting jobs on hardware`_ section above for more details.
 

--- a/doc/introduction/photonic_hardware.rst
+++ b/doc/introduction/photonic_hardware.rst
@@ -134,25 +134,27 @@ Cloud simulator
 ---------------
 
 In addition to submitting jobs to be run on quantum hardware, it is also possible to run jobs on
-the Xanadu Quantum Cloud simulator Simulon. The process is very similar to running jobs on hardware. You
+simulators via the Xanadu Quantum Cloud. The process is very similar to running jobs on hardware. You
 will need to configure your account, as described above, and submit a job via the ``RemoteEngine``,
-using ``"simulon"`` as the target instead of a specific chip:
+using a simulator as the target instead of a specific chip:
 
->>> eng = sf.RemoteEngine("simulon")
+>>> eng = sf.RemoteEngine("simulon_gaussian")
 >>> result = eng.run(prog)
 
 Simulon jobs can also be submitted asynchronously using ``eng.run_async``, or by submitting a
-Blackbird script with the ``target`` set to ``simulon`` in the Blackbird header.
+Blackbird script with the ``target`` set to a simulator target in the Blackbird header.
 
 See the `Submitting jobs on hardware`_ section above for more details.
 
 .. note::
 
-    Simulon runs on the ``gaussian`` backend (see :ref:`simulating_your_program`) and thus only supports
-    Gaussian operations, including homodyne and heterodyne measurements, as well terminal
-    Fock measurements. Note that there are limits to how many measurements a circuit can have depending
-    on the type of measurement. These can be retrieved by calling ``engine.device_spec.modes`` with
-    ``engine = sf.RemoteEngine("simulon")``.
+    The ``simulon_gaussian`` simulator runs on the ``gaussian`` backend (see
+    :ref:`simulating_your_program`) and thus only supports Gaussian operations,
+    including homodyne and heterodyne measurements, as well terminal Fock
+    measurements. Note that there are limits to how many measurements a circuit
+    can have depending on the type of measurement. These can be retrieved by
+    calling ``engine.device_spec.modes`` with ``engine =
+    sf.RemoteEngine("simulon_gaussian")``.
 
 Tutorials
 ---------

--- a/doc/introduction/photonic_hardware.rst
+++ b/doc/introduction/photonic_hardware.rst
@@ -133,10 +133,12 @@ You can also omit the ``--output`` parameter to print the result to the screen.
 Cloud simulator
 ---------------
 
-In addition to submitting jobs to be run on quantum hardware, it is also possible to run jobs on
-simulators via the Xanadu Quantum Cloud. The process is very similar to running jobs on hardware. You
-will need to configure your account, as described above, and submit a job via the ``RemoteEngine``,
-using a simulator (a "simulon") as the target instead of a specific chip:
+In addition to submitting jobs to be run on quantum hardware, it is also
+possible to run jobs on cloud simulators (which we refer to as "simulons") via
+the Xanadu Quantum Cloud. The process is very similar to running jobs on
+hardware. You will need to configure your account, as described above, and
+submit a job via the ``RemoteEngine``, using a simulator as the target instead
+of a specific chip:
 
 >>> eng = sf.RemoteEngine("simulon_gaussian")
 >>> result = eng.run(prog)

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -77,7 +77,7 @@ class GaussianModes:
         self.nlen = newnlen
 
     def del_mode(self, modes):
-        """ delete mode from the circuit"""
+        """delete mode from the circuit"""
         if isinstance(modes, int):
             modes = [modes]
 
@@ -110,7 +110,7 @@ class GaussianModes:
         return [x for x in self.active if x is not None]
 
     def displace(self, r, phi, i):
-        """ Implements a displacement operation by the complex number `beta = r * np.exp(1j * phi)` in mode i"""
+        """Implements a displacement operation by the complex number `beta = r * np.exp(1j * phi)` in mode i"""
         # Update displacement of mode i by the complex amount bet
         if self.active[i] is None:
             raise ValueError("Cannot displace mode, mode does not exist")
@@ -118,7 +118,7 @@ class GaussianModes:
         self.mean[i] += r * np.exp(1j * phi)
 
     def squeeze(self, r, phi, k):
-        """ Implements a squeezing operation in mode k by the amount z = r*exp(1j*phi)."""
+        """Implements a squeezing operation in mode k by the amount z = r*exp(1j*phi)."""
         if self.active[k] is None:
             raise ValueError("Cannot squeeze mode, mode does not exist")
 
@@ -158,7 +158,7 @@ class GaussianModes:
         self.mmat[:, k] = self.mmat[k]
 
     def phase_shift(self, phi, k):
-        """ Implements a phase shift in mode k by the amount phi."""
+        """Implements a phase shift in mode k by the amount phi."""
         if self.active[k] is None:
             raise ValueError("Cannot phase shift mode, mode does not exist")
 
@@ -181,7 +181,7 @@ class GaussianModes:
         self.mmat[:, k] = self.mmat[k]
 
     def beamsplitter(self, theta, phi, k, l):
-        """ Implements a beam splitter operation between modes k and l by the amount theta, phi"""
+        """Implements a beam splitter operation between modes k and l by the amount theta, phi"""
         if self.active[k] is None or self.active[l] is None:
             raise ValueError("Cannot perform beamsplitter, mode(s) do not exist")
 
@@ -358,7 +358,7 @@ class GaussianModes:
         self.mmat[rows, cols] = 0.25 * (A - C + 1j * (B + Bt))
 
     def qmat(self, modes=None):
-        """ Construct the covariance matrix for the Q function"""
+        """Construct the covariance matrix for the Q function"""
         if modes is None:
             modes = list(range(self.nlen))
 
@@ -382,7 +382,7 @@ class GaussianModes:
         return sigmaq
 
     def fidelity_coherent(self, alpha, modes=None):
-        """ Returns a function that evaluates the Q function of the given state """
+        """Returns a function that evaluates the Q function of the given state"""
         if modes is None:
             modes = list(range(self.nlen))
 
@@ -404,7 +404,7 @@ class GaussianModes:
         return self.fidelity_coherent(alpha)
 
     def Amat(self):
-        """ Constructs the A matrix from Hamilton's paper"""
+        """Constructs the A matrix from Hamilton's paper"""
         ######### this needs to be conjugated
         sigmaq = (
             np.concatenate(
@@ -446,12 +446,12 @@ class GaussianModes:
         self.nmat += (1 - T) * nbar
 
     def init_thermal(self, population, mode):
-        """ Initializes a state of mode in a thermal state with the given population"""
+        """Initializes a state of mode in a thermal state with the given population"""
         self.loss(0.0, mode)
         self.nmat[mode][mode] = population
 
     def is_vacuum(self, tol=0.0):
-        """ Checks if the state is vacuum by calculating its fidelity with vacuum """
+        """Checks if the state is vacuum by calculating its fidelity with vacuum"""
         fid = self.fidelity_vacuum()
         return np.abs(fid - 1) <= tol
 
@@ -495,7 +495,7 @@ class GaussianModes:
         return res
 
     def post_select_homodyne(self, n, val, eps=0.0002):
-        """ Performs a homodyne measurement but postelecting on the value vals for mode n """
+        """Performs a homodyne measurement but postelecting on the value vals for mode n"""
         if self.active[n] is None:
             raise ValueError("Cannot apply homodyne measurement, mode does not exist")
         covmat = np.diag(np.array([eps ** 2, 1.0 / eps ** 2]))
@@ -517,7 +517,7 @@ class GaussianModes:
         return val
 
     def post_select_heterodyne(self, n, alpha_val):
-        """ Performs a homodyne measurement but postelecting on the value vals for mode n """
+        """Performs a homodyne measurement but postelecting on the value vals for mode n"""
         if self.active[n] is None:
             raise ValueError("Cannot apply heterodyne measurement, mode does not exist")
 
@@ -539,7 +539,7 @@ class GaussianModes:
         return alpha_val
 
     def apply_u(self, U):
-        """ Transforms the state according to the linear optical unitary that maps a[i] \to U[i, j]^*a[j]"""
+        """Transforms the state according to the linear optical unitary that maps a[i] \to U[i, j]^*a[j]"""
         self.mean = np.dot(np.conj(U), self.mean)
         self.nmat = np.dot(np.dot(U, self.nmat), np.conj(np.transpose(U)))
         self.mmat = np.dot(np.dot(np.conj(U), self.mmat), np.conj(np.transpose(U)))

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -240,7 +240,7 @@ class TestProgram:
             },
             "layout": None, "gate_parameters": {}, "compiler": [None]
         }
-        spec = sf.api.DeviceSpec(target="simulon", connection=None, spec=device_dict)
+        spec = sf.api.DeviceSpec(target="simulon_gaussian", connection=None, spec=device_dict)
 
         prog = sf.Program(3)
         with prog.context as q:
@@ -256,7 +256,7 @@ class TestProgram:
         """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
         with the incorrect type of device spec mode entry."""
         device_dict = {"modes": 2, "layout": None, "gate_parameters": None, "compiler": [None]}
-        spec = sf.api.DeviceSpec(target="simulon", connection=None, spec=device_dict)
+        spec = sf.api.DeviceSpec(target="simulon_gaussian", connection=None, spec=device_dict)
 
         prog = sf.Program(3)
         with prog.context as q:
@@ -547,7 +547,7 @@ class TestValidation:
             },
             "layout": None, "gate_parameters": {}, "compiler": [None]
         }
-        spec = sf.api.DeviceSpec(target="simulon", connection=None, spec=device_dict)
+        spec = sf.api.DeviceSpec(target="simulon_gaussian", connection=None, spec=device_dict)
 
         prog = sf.Program(3)
         with prog.context as q:


### PR DESCRIPTION
**Context:**
The Xanadu Quantum Cloud simulator, formerly called `simulon`, now has the target name `simulon_gaussian`. This change was made to support many different simulon types in the future.

**Description of the Change:**
- References to `simulon` in documentation and tests have been changed to `simulon_gaussian`.
- A formatting change is made in `strawberryfields/backends/gaussianbackend/gaussiancircuit.py`. It appears that the black version on CI has been upgraded since the last commit, which now checks new elements in docstrings. This change has been made here instead of in a separate PR.

**Benefits:**
People reading the docs will not try to submit jobs to a simulator that doesn't exist :slightly_smiling_face: 

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
n/a