### PR TITLE
Reduce the use of SymPy lambdify

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixed an unexpected behaviour that can result in increasing memory usage due
+  to ``sympy.lambdify`` caching too much data using ``linecache``.
+  [(#579)](https://github.com/XanaduAI/strawberryfields/pull/579)
+
 <h3>Documentation</h3>
 
 * References to the ``simulon`` simulator target have been rewritten to
@@ -25,7 +29,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Aaron Robertson, Jeremy Swinarton.
+Aaron Robertson, Jeremy Swinarton, Antal Száva.
 
 # Release 0.18.0 (current release)
 

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -96,6 +96,7 @@ What we cannot do at the moment:
 import collections.abc
 import functools
 import types
+import linecache
 
 import numpy as np
 import sympy
@@ -209,8 +210,6 @@ def par_evaluate(params, dtype=None):
         # sympy.lambdify caches data using linecache, if called many times this
         # can make up for a lot of memory used. We clear the cache here to
         # avoid that.
-        import linecache
-
         linecache.clearcache()
 
         if dtype is not None:

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -210,6 +210,7 @@ def par_evaluate(params, dtype=None):
         # can make up for a lot of memory used. We clear the cache here to
         # avoid that.
         import linecache
+
         linecache.clearcache()
 
         if dtype is not None:

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -191,12 +191,17 @@ def par_evaluate(params, dtype=None):
 
         # using lambdify we can also substitute np.ndarrays and tf.Tensors for the atoms
         atoms = list(p.atoms(MeasuredParameter, FreeParameter))
+
+        if not atoms:
+            return float(p) if p.is_real else complex(p)
+
         # evaluate the atoms of the expression
         vals = [k._eval_evalf(None) for k in atoms]
         # use the tensorflow printer if any of the symbolic parameter values are TF objects
         # (we do it like this to avoid importing tensorflow if it's not needed)
         is_tf = (type(v).__module__.startswith("tensorflow") for v in vals)
         printer = "tensorflow" if any(is_tf) else "numpy"
+
         func = sympy.lambdify(atoms, p, printer)
 
         if dtype is not None:

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -216,7 +216,9 @@ def par_evaluate(params, dtype=None):
 
         return func(*vals)
 
+    import linecache
     ret = list(map(do_evaluate, params))
+    linecache.clearcache()
     if scalar:
         return ret[0]
     return ret


### PR DESCRIPTION
**Context:**
Some optimization tasks using Strawberry Fields were showing increased memory allocation, although no state was being left (i.e., the engine was reset, state objects recreated, etc.).

Parameters in Strawberry Fields might be numeric or symbolic. To represent both, SymPy is used. When using gate parameters that are internally created, Strawberry Fields evaluates the parameter to get the numeric value using SymPy.

Evaluating the parameters depends on the `sympy.lambdify` function, which [internally caches data using `linecache`](https://github.com/sympy/sympy/blob/aa96b23bb98f00542101c08d8ea02ef83949310b/sympy/utilities/lambdify.py#L876). The memory increase was found to be due to this caching.

**Description of the Change:**
Changes the `par_evaluate` function which does the parameter evaluation such that:
* If the SymPy object can be converted to a numeric Python type (`float` or `complex`), then we perform the conversion without using `sympy.lambdify`
* Otherwise, when using `sympy.lambdify` we also clear the cache using `linecache`.

**Benefits:**
* Significantly faster parameter evaluation in cases when the use of `sympy.lambdify` can be avoided
* No memory increase over time

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

[See profiling data here.](https://github.com/XanaduAI/strawberryfields/pull/579#issuecomment-840109642)