### PR TITLE
numpy>=1.19.2 as requirement

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ ipykernel
 sphinx==2.2.2
 m2r
 networkx>=2.0
-numpy>=1.20
+numpy>=1.19.2
 plotly
 quantum-blackbird
 scipy>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20
+numpy>=1.19.2
 scipy
 sympy>=1.5
 tensorflow>=2.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("strawberryfields/_version.py") as f:
 
 
 requirements = [
-    "numpy>=1.17.4",
+    "numpy>=1.19.2",
     "scipy>=1.0.0",
     "sympy>=1.5",
     "networkx>=2.0",


### PR DESCRIPTION
**Context**

The new release of TensorFlow version 2.5 pins `numpy ~= 1.19.2`. As Strawberry Fields pins `numpy>=1.20`, installing SF in a clean environment results in version conflicts between TensorFlow's and SF's `numpy` version requirement.

**Changes**

Pins `numpy>=1.19.2` in `requirements.txt`, `doc/requirements.txt` and `setup.py`.

**Related issues**

Closes #580.