### PR TITLE
Fixes the QNN example to use a safe absolute value function for multiple modes

### DIFF
--- a/examples/quantum_neural_network.py
+++ b/examples/quantum_neural_network.py
@@ -170,11 +170,14 @@ with qnn.context as q:
 
 def safe_abs(x):
     # Helper function to deal with tensor terms near zero
+
+    # Check where we have near zero terms
     EPS = 1e-15
     x = tf.where(tf.abs(x) < EPS, tf.zeros_like(x), x)
     zero = tf.constant(0, dtype=tf.complex64)
     x_ok = tf.not_equal(x, zero)
 
+    # To make sure, swap out the zeros with ones
     safe_x = tf.where(x_ok, x, tf.ones_like(x, dtype=tf.complex64))
     return tf.where(x_ok, tf.abs(safe_x), tf.zeros_like(x, dtype=tf.float32))
 


### PR DESCRIPTION
**Context**

When increasing the number of modes in the `examples/quantum_neural_network.py` file containing the QNN tutorial (e.g., having `modes=2), the gradient contains `nan` values and the optimization will continue using tensors filled with `nan` values.

**Changes**

For computing the fidelity of the difference between the measured ket and the target state, a safe absolute value function is being used. This function allows ensuring that the gradient for getting the absolute value at the `0.0` point will return `0.0`.

**Related issues**

Closes #588 