### PR TITLE
Keep symbolic expressions for Blackbird programs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,16 +6,16 @@
  (``rectangular_compact`` and ``triangular_compact``) are now available in
  the ``sf.decompositions`` module, and as options in the ``Interferometer`` operation.
  [(#584)](https://github.com/XanaduAI/strawberryfields/pull/584)
- 
- This decomposition allows for lower depth photonic circuits in physical devices by applying two 
+
+ This decomposition allows for lower depth photonic circuits in physical devices by applying two
  independent phase shifts in parallel inside each Mach-Zehnder interferometer.
- ``rectangular_compact`` reduces the layers of phase shifters from 2N+1 to N+2 
+ ``rectangular_compact`` reduces the layers of phase shifters from 2N+1 to N+2
  for an N mode interferometer when compared to e.g. ``rectangular_MZ``.
 
  Example:
 
- ```python 
-  import numpy as np 
+ ```python
+  import numpy as np
   from strawberryfields import Program
   from strawberryfields.ops import Interferometer
   from scipy.stats import unitary_group
@@ -30,7 +30,7 @@
   with prog.context as q:
       Interferometer(U, mesh='rectangular_compact') | q
 
-  # check that applied unitary is correct 
+  # check that applied unitary is correct
   compiled_circuit = prog.compile(compiler="gaussian_unitary")
   commands = compiled_circuit.circuit
   S = commands[0].op.p[0] # symplectic transformation
@@ -43,21 +43,21 @@
   overhead for non-Gaussian circuits by minimizing the amount of Gaussian operations
   in a circuit, while retaining the same functionality.
   [(#591)](https://github.com/XanaduAI/strawberryfields/pull/591)
-   
+
   ``GaussianMerge`` merges Gaussian operations, where allowed, into ``GaussianTransform``
   and ``Dgate`` operations. It utilizes the existing ``GaussianUnitary`` compiler to
   merge operations and Directed Acyclic Graphs to determine which operations can be merged.
 
-  ```python 
+  ```python
   modes = 4
   cutoff_dim = 6
-  
+
   # prepare an intial state with 4 photons in as many modes
   initial_state = np.zeros([cutoff_dim] * modes, dtype=complex)
   initial_state[1, 1, 1, 1] = 1
-  
+
   prog = sf.Program(4)
-  
+
   with prog.context as q:
       ops.Ket(initial_state) | q  # Initial state preparation
       # Gaussian Layer
@@ -75,7 +75,7 @@
       ops.Sgate(0.01, 0.01) | q[1]
       # Non-Gaussian Layer
       ops.Vgate(0.5) | q[2]
-  
+
   prog_merged = prog.compile(compiler="gaussian_merge")
   ```
 
@@ -95,6 +95,11 @@
   to ``sympy.lambdify`` caching too much data using ``linecache``.
   [(#579)](https://github.com/XanaduAI/strawberryfields/pull/579)
 
+* Keep symbolic expressions when converting a Strawberry Fields circuit to a Blackbird program
+  by storing them as `blackbird.RegRefTransforms` in the resulting Blackbird program.
+  [(#596)](https://github.com/XanaduAI/strawberryfields/pull/596)
+
+
 <h3>Documentation</h3>
 
 * References to the ``simulon`` simulator target have been rewritten to
@@ -107,7 +112,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jake Bulmer, Aaron Robertson, Jeremy Swinarton, Antal Száva, Federico Rueda, Yuan Yao.
+Jake Bulmer, Theodor Isacsson, Aaron Robertson, Jeremy Swinarton, Antal Száva, Federico Rueda, Yuan Yao.
 
 # Release 0.18.0 (current release)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,4 +14,5 @@ sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.5.0
+thewalrus>=0.15.0
 toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sympy>=1.5
 tensorflow>=2.0
 tensorboard>=2.0
 networkx>=2.0
-git+https://github.com/XanaduAI/blackbird@master#egg=blackbird
+git+https://github.com/XanaduAI/blackbird@master#egg=quantum-blackbird
 python-dateutil==2.8.0
 thewalrus>=0.15.0
 toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sympy>=1.5
 tensorflow>=2.0
 tensorboard>=2.0
 networkx>=2.0
-git+git:github.com/XanaduAI/blackbird@master#egg=blackbird
+git+https://github.com/XanaduAI/blackbird@master#egg=blackbird
 python-dateutil==2.8.0
 thewalrus>=0.15.0
 toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sympy>=1.5
 tensorflow>=2.0
 tensorboard>=2.0
 networkx>=2.0
-quantum-blackbird>=0.3.0
+git+git:github.com/XanaduAI/blackbird@master#egg=blackbird
 python-dateutil==2.8.0
 thewalrus>=0.15.0
 toml

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -18,9 +18,9 @@ code.
 """
 # pylint: disable=protected-access,too-many-nested-blocks
 import os
-import regex as re
 from numbers import Number
 
+import re
 import numpy as np
 
 import blackbird

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -20,7 +20,6 @@ code.
 import os
 from numbers import Number
 
-import re
 import numpy as np
 
 import blackbird
@@ -84,8 +83,9 @@ def to_blackbird(prog, version="1.0"):
             for a in cmd.op.p:
                 if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string
-                    if re.search(r"(?<!\w)q\d*(?!\w)", str(a)):
-                        # check if there are any regref statements (e.g. q0, q1)
+                    isMeasuredParameter = lambda x : isinstance(x, sfpar.MeasuredParameter)
+                    if any(map(isMeasuredParameter, a.free_symbols)):
+                        # check if there are any measured parameters in `a`
                         a = blackbird.RegRefTransform(a)
                     else:
                         a = str(a)

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -18,6 +18,7 @@ code.
 """
 # pylint: disable=protected-access,too-many-nested-blocks
 import os
+import regex as re
 from numbers import Number
 
 import numpy as np
@@ -26,7 +27,6 @@ import blackbird
 import strawberryfields.program as sfp
 import strawberryfields.parameters as sfpar
 from . import ops
-import regex as re
 
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -46,6 +46,8 @@ def to_blackbird(prog, version="1.0"):
     bb = blackbird.BlackbirdProgram(name=prog.name, version=version)
     bb._modes = list(prog.reg_refs.keys())
 
+    isMeasuredParameter = lambda x: isinstance(x, sfpar.MeasuredParameter)
+
     # TODO not sure if this makes sense: the program has *already been* compiled using this target
     if prog.target is not None:
         # set the target
@@ -80,7 +82,6 @@ def to_blackbird(prog, version="1.0"):
                     op["kwargs"]["dark_counts"] = cmd.op.dark_counts
 
         else:
-            isMeasuredParameter = lambda x: isinstance(x, sfpar.MeasuredParameter)
             for a in cmd.op.p:
                 if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -80,7 +80,7 @@ def to_blackbird(prog, version="1.0"):
                     op["kwargs"]["dark_counts"] = cmd.op.dark_counts
 
         else:
-            isMeasuredParameter = lambda x : isinstance(x, sfpar.MeasuredParameter)
+            isMeasuredParameter = lambda x: isinstance(x, sfpar.MeasuredParameter)
             for a in cmd.op.p:
                 if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -26,6 +26,7 @@ import blackbird
 import strawberryfields.program as sfp
 import strawberryfields.parameters as sfpar
 from . import ops
+import regex as re
 
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
@@ -83,7 +84,11 @@ def to_blackbird(prog, version="1.0"):
             for a in cmd.op.p:
                 if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string
-                    a = str(a)
+                    if re.search(r"(?<!\w)q\d*(?!\w)", str(a)):
+                        # check if there are any regref statements (e.g. q0, q1)
+                        a = blackbird.RegRefTransform(a)
+                    else:
+                        a = str(a)
                 op["args"].append(a)
 
         # If program type is "tdm" then add the looped-over arrays to the

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -80,10 +80,10 @@ def to_blackbird(prog, version="1.0"):
                     op["kwargs"]["dark_counts"] = cmd.op.dark_counts
 
         else:
+            isMeasuredParameter = lambda x : isinstance(x, sfpar.MeasuredParameter)
             for a in cmd.op.p:
                 if sfpar.par_is_symbolic(a):
                     # SymPy object, convert to string
-                    isMeasuredParameter = lambda x : isinstance(x, sfpar.MeasuredParameter)
                     if any(map(isMeasuredParameter, a.free_symbols)):
                         # check if there are any measured parameters in `a`
                         a = blackbird.RegRefTransform(a)

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -97,6 +97,7 @@ import collections.abc
 import functools
 import types
 import linecache
+import blackbird
 
 import numpy as np
 import sympy
@@ -257,6 +258,8 @@ def par_convert(args, prog):
     """
 
     def do_convert(a):
+        if isinstance(a, blackbird.RegRefTransform):
+            a = a.expr
         if isinstance(a, sympy.Basic):
             # substitute SF symbolic parameter objects for Blackbird ones
             s = {}

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -322,8 +322,15 @@ class TestSFToBlackbirdConversion:
             ops.Zgate(2 * pf.sin(q[0].par)) | q[1]
 
         bb = io.to_blackbird(prog)
-        expected = {"op": "Zgate", "modes": [1], "args": ["2*sin(q0)"], "kwargs": {}}
-        assert bb.operations[-1] == expected
+        assert bb.operations[-1]["op"] == "Zgate"
+        assert bb.operations[-1]["modes"] == [1]
+
+        assert isinstance(bb.operations[-1]["args"][0], blackbird.RegRefTransform)
+        assert bb.operations[-1]["args"][0].func_str == "2*sin(q0)"
+        assert bb.operations[-1]["args"][0].regrefs == [0]
+
+        assert bb.operations[-1]["kwargs"] == {}
+
 
     def test_free_par_str(self):
         """Test a FreeParameter with some transformations converts properly"""

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -467,7 +467,6 @@ class TestBlackbirdToSFConversion:
         assert prog.circuit[0].op.p[0] == 0.54
         assert prog.circuit[0].reg[0].ind == 0
 
-    @pytest.mark.skip("FIXME enable when blackbird.program.RegRefTransform is replaced with sympy.Symbol.")
     def test_gate_measured_par(self):
         """Test a gate with a MeasuredParameter argument."""
 


### PR DESCRIPTION
**Context:**
There are a few issues when attempting to convert an SF circuit with feed-forwarding to Blackbird. If any parameter is found to be symbolic, it's cast as a string rather than keeping it as a `blackbird.RegRefTransform` as it would be if loaded directly from a script to Blackbird. For example, the following SF circuit

```python
with prog.context as q:
    Coherent(math.sqrt(5/4), math.atan(1/2)) | q[0]
    Sgate(2, 0) | q[2]
    Sgate(-2, 0) | q[1]
    BSgate(0.7854, 0) | (q[1], q[2])
    BSgate(0.7854, 0) | (q[0], q[1])
    MeasureP | q[1]
    MeasureX | q[0]
    Xgate(q[0].par*1.41421356237000) | q[2]
    Zgate(q[1].par*1.41421356237000) | q[2]
```
will, when transformed into a Blackbird program, converting `q[0].par*1.41421356237000` and `q[1].par*1.41421356237000` into the strings `"1.41421356237000*q0"` and `"1.41421356237000*q1"`, rather than, as it should, into `blackbird.RegRefTransform` objects.

If attempting to load the following blackbird script

```
name Teleportation
version 1.0
target gaussian

Coherent(1.118033988749895, 0.4636476090008061) | 0
Sgate(2, 0) | 2
Sgate(-2, 0) | 1
BSgate(0.7854, 0) | [1, 2]
BSgate(0.7854, 0) | [0, 1]
MeasureHomodyne(phi=1.5707963267948966) | 1
MeasureHomodyne(phi=0) | 0
Xgate(1.41421356237*q0) | 2
Zgate(1.41421356237*q1) | 2
```

both `1.41421356237*q0` and `1.41421356237*q0` will be stored as `blackbird.RegRefTransform` objects.

**Description of the Change:**
The `strawberryfields.to_blackbird` function is changed so that if an SF parameter contains a regref (e.g. `q0` or `q1`, as in the string representation of the symbolic expression in SF) it stores it as a `blackbird.RegRefTransform` instead of as a string.

When converting from a Blackbird program to an SF program, the symbolic expression needs to be extracted from the `RegRefTransform`, so that SF can understand it. This is being added in [this Blackbird PR #46](https://github.com/XanaduAI/blackbird/pull/46).

**Benefits:**
SF circuits with feed-forwarding can now be transformed and serialized into Blackbird and back, without any issues or loss of information.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
Closes #595 
