### PR TITLE
faster gaussian compiling

### DIFF
--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -152,7 +152,7 @@ class GaussianUnitary(Compiler):
         nmodes = len(used_modes)
 
         # This is the identity transformation in phase-space, multiply by the identity and add zero
-        Snet = np.identity(2 * nmodes)
+        Snet = identity(2 * nmodes)
         rnet = np.zeros(2 * nmodes)
 
         # Now we will go through each operation in the sequence `seq` and apply it in quadrature space

--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -31,6 +31,7 @@ from .compiler import Compiler
 
 from scipy.sparse import identity, csr_matrix
 
+
 def sparse_expand(S, modes, N):
     r"""Expands a Symplectic matrix S into a CSR spare matrix to act on the entire subsystem.
 
@@ -43,7 +44,7 @@ def sparse_expand(S, modes, N):
         csr_matrix: the resulting sparse :math:`2N\times 2N` Symplectic matrix
     """
     M = len(S) // 2
-    S2 = identity(2 * N, dtype=S.dtype, format='lil')
+    S2 = identity(2 * N, dtype=S.dtype, format="lil")
     w = np.asarray(modes)
 
     S2[w.reshape(-1, 1), w.reshape(1, -1)] = S[:M, :M]  # X
@@ -52,6 +53,7 @@ def sparse_expand(S, modes, N):
     S2[(w + N).reshape(-1, 1), w.reshape(1, -1)] = S[M:, :M]  # PX
 
     return S2.tocsr()
+
 
 class GaussianUnitary(Compiler):
     """Compiler to arrange a Gaussian quantum circuit into the canonical Symplectic form.
@@ -165,7 +167,9 @@ class GaussianUnitary(Compiler):
             modes = [modes_label.ind for modes_label in operations.reg]
             if name == "Dgate":
                 rnet[dict_indices[modes[0]]] += 2 * (params[0] * (np.exp(1j * params[1]))).real
-                rnet[dict_indices[modes[0]]+nmodes] += 2 * (params[0] * (np.exp(1j * params[1]))).imag
+                rnet[dict_indices[modes[0]] + nmodes] += (
+                    2 * (params[0] * (np.exp(1j * params[1]))).imag
+                )
             else:
                 if name == "Rgate":
                     modes = [dict_indices[modes[0]]]

--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -14,12 +14,11 @@
 """This module contains a compiler to arrange a Gaussian quantum circuit into the canonical Symplectic form."""
 
 import numpy as np
+from scipy.sparse import identity, csr_matrix
 from strawberryfields.program_utils import Command
 from strawberryfields import ops
 from strawberryfields.parameters import par_evaluate
 from thewalrus.symplectic import (
-    expand_vector,
-    expand,
     rotation,
     squeezing,
     two_mode_squeezing,
@@ -28,8 +27,6 @@ from thewalrus.symplectic import (
 )
 
 from .compiler import Compiler
-
-from scipy.sparse import identity, csr_matrix
 
 
 def sparse_expand(S, modes, N):
@@ -126,7 +123,7 @@ class GaussianUnitary(Compiler):
         "Zgate": {},
         "Fouriergate": {},
     }
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches, too-many-statements
     def compile(self, seq, registers):
         """Try to arrange a quantum circuit into the canonical Symplectic form.
 
@@ -208,7 +205,6 @@ class GaussianUnitary(Compiler):
                 Snet = csr_matrix(S.dot(Snet))
                 rnet = S.dot(rnet)
 
-        # Snet = Snet.toarray()
         if not isinstance(Snet, np.ndarray):
             Snet = Snet.toarray()
 


### PR DESCRIPTION
to speed up large circuits with a lot of gates, we wish to avoid a full size, dense matrix-matrix multiplication upon application of each gate.

In this PR we will try to avoid this. My first attempt is to use scipy.sparse.csr_matrix to reduce the complexity of the matrix-matrix multiplications. However, we may also look into hardcoding the matrix-matrix multiplication.

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Ensure that code is properly formatted, by running `make format` or `black -l 100
      strawberryfields`. You will need to have the Black code format installed: `pip install
      black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Strawberry Fields source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint strawberryfields/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
