### PR TITLE
Fix validation in TdmProgram.compile

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -150,6 +150,9 @@
   by storing them as `blackbird.RegRefTransforms` in the resulting Blackbird program.
   [(#596)](https://github.com/XanaduAI/strawberryfields/pull/596)
 
+* Fixed a bug in the validation step of `strawberryfields.tdm.TdmProgram.compile` which almost always 
+  used the wrong set of allowed gate parameter ranges to validate the parameters in a program. 
+  [(#605)](https://github.com/XanaduAI/strawberryfields/pull/605)
 
 <h3>Documentation</h3>
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -436,7 +436,6 @@ class TDMProgram(sf.Program):
         """
         if compiler == "gaussian":
             return super().compile(device=device, compiler=compiler)
-
         if device is not None:
             device_layout = bb.loads(device.layout)
 
@@ -471,6 +470,7 @@ class TDMProgram(sf.Program):
             # Third check: the parameters of the gates are valid
             # We will loop over the different operations in the device specification
 
+            num_symbolic_param = 0  # counts the number of symbolic variables, which are labelled consecutively by the context method
             for i, operation in enumerate(device_layout.operations):
                 # We obtain the name of the parameter(s)
                 param_names = operation["args"]
@@ -487,8 +487,6 @@ class TDMProgram(sf.Program):
                                 "due to incompatible parameter.".format(device.target)
                             )
                 # Now we will check explicitly if the parameters in the program match
-                num_symbolic_param = 0  # counts the number of symbolic variables, which are labelled consecutively by the context method
-
                 for k, param_name in enumerate(param_names):
                     # Obtain the value of the corresponding parameter in the program
                     program_param = self.rolled_circuit[i].op.p[k]
@@ -532,6 +530,7 @@ class TDMProgram(sf.Program):
                                     device.target, program_param, param_range
                                 )
                             )
+
             return self
 
         raise CircuitError("TDM programs cannot be compiled without a valid device specification.")

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -471,8 +471,6 @@ class TDMProgram(sf.Program):
             # Third check: the parameters of the gates are valid
             # We will loop over the different operations in the device specification
 
-            num_symbolic_param = 0  # counts the number of symbolic variables, which are labelled consecutively by the context method
-
             for i, operation in enumerate(device_layout.operations):
                 # We obtain the name of the parameter(s)
                 param_names = operation["args"]
@@ -509,7 +507,7 @@ class TDMProgram(sf.Program):
                     param_range = device.gate_parameters[param_name]
                     if sf.parameters.par_is_symbolic(program_param):
                         # If it is a symbolic value go and lookup its corresponding list in self.tdm_params
-                        local_p_vals = self.tdm_params[num_symbolic_param]
+                        local_p_vals = self.parameters.get(program_param.name, [])
 
                         for x in local_p_vals:
                             if not x in param_range:
@@ -520,7 +518,6 @@ class TDMProgram(sf.Program):
                                         device.target, x, param_range
                                     )
                                 )
-                        num_symbolic_param += 1
 
                     else:
                         # If it is a numerical value check directly

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -580,7 +580,7 @@ class TDMProgram(sf.Program):
         q = self.register
 
         sm = []
-        for i, item in enumerate(self.N):
+        for i, _ in enumerate(self.N):
             start = sum(self.N[:i])
             stop = sum(self.N[:i]) + self.N[i]
             sm.append(slice(start, stop))

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -580,7 +580,7 @@ class TDMProgram(sf.Program):
         q = self.register
 
         sm = []
-        for i in range(len(self.N)):
+        for i, item in enumerate(self.N):
             start = sum(self.N[:i])
             stop = sum(self.N[:i]) + self.N[i]
             sm.append(slice(start, stop))

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -471,6 +471,7 @@ class TDMProgram(sf.Program):
             # We will loop over the different operations in the device specification
 
             num_symbolic_param = 0  # counts the number of symbolic variables, which are labelled consecutively by the context method
+            
             for i, operation in enumerate(device_layout.operations):
                 # We obtain the name of the parameter(s)
                 param_names = operation["args"]
@@ -530,7 +531,6 @@ class TDMProgram(sf.Program):
                                     device.target, program_param, param_range
                                 )
                             )
-
             return self
 
         raise CircuitError("TDM programs cannot be compiled without a valid device specification.")

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -436,6 +436,7 @@ class TDMProgram(sf.Program):
         """
         if compiler == "gaussian":
             return super().compile(device=device, compiler=compiler)
+
         if device is not None:
             device_layout = bb.loads(device.layout)
 
@@ -471,7 +472,7 @@ class TDMProgram(sf.Program):
             # We will loop over the different operations in the device specification
 
             num_symbolic_param = 0  # counts the number of symbolic variables, which are labelled consecutively by the context method
-            
+
             for i, operation in enumerate(device_layout.operations):
                 # We obtain the name of the parameter(s)
                 param_names = operation["args"]

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -822,4 +822,3 @@ class TestTDMValidation:
         args[incorrect_index] = -999
         with pytest.raises(CircuitError, match="Parameter has value '-999' while its valid range is "):
             self.compile_test_program(device, args=args)
-    

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -15,6 +15,8 @@ r"""Unit tests for tdmprogram.py"""
 import copy
 from collections.abc import Iterable
 
+import inspect
+from strawberryfields.program_utils import CircuitError
 import pytest
 import numpy as np
 
@@ -555,7 +557,7 @@ class TestTDMcompiler:
             ops.MeasureHomodyne(p[2]) | q[0]
         eng = sf.Engine("gaussian")
         with pytest.raises(
-            sf.program_utils.CircuitError,
+            CircuitError,
             match="The gates or the order of gates used in the Program",
         ):
             prog.compile(device=device, compiler="TD2")
@@ -575,7 +577,7 @@ class TestTDMcompiler:
             ops.MeasureHomodyne(p[2]) | q[0]
         eng = sf.Engine("gaussian")
         with pytest.raises(
-            sf.program_utils.CircuitError, match="due to incompatible mode ordering."
+            CircuitError, match="due to incompatible mode ordering."
         ):
             prog.compile(device=device, compiler="TD2")
 
@@ -587,7 +589,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] + [np.pi / 2, np.pi / 2]
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="due to incompatible parameter."):
+        with pytest.raises(CircuitError, match="due to incompatible parameter."):
             prog.compile(device=device, compiler="TD2")
 
     def test_tdm_wrong_parameters_explicit_in_list(self):
@@ -601,7 +603,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] + [np.pi / 2, np.pi / 2]
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="due to incompatible parameter."):
+        with pytest.raises(CircuitError, match="due to incompatible parameter."):
             prog.compile(device=device, compiler="TD2")
 
     def test_tdm_wrong_parameter_second_argument(self):
@@ -620,7 +622,7 @@ class TestTDMcompiler:
             ops.Rgate(p[1]) | q[1]
             ops.MeasureHomodyne(p[2]) | q[0]
         eng = sf.Engine("gaussian")
-        with pytest.raises(sf.program_utils.CircuitError, match="due to incompatible parameter."):
+        with pytest.raises(CircuitError, match="due to incompatible parameter."):
             prog.compile(device=device, compiler="TD2")
 
     def test_tdm_wrong_parameters_symbolic(self):
@@ -631,7 +633,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] + [np.pi / 2, np.pi / 2]
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="due to incompatible parameter."):
+        with pytest.raises(CircuitError, match="due to incompatible parameter."):
             prog.compile(device=device, compiler="TD2")
 
     def test_tdm_inconsistent_temporal_modes(self):
@@ -642,7 +644,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] * c
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="temporal modes, but the device"):
+        with pytest.raises(CircuitError, match="temporal modes, but the device"):
             prog.compile(device=device, compiler="TD2")
 
     def test_tdm_inconsistent_concurrent_modes(self):
@@ -658,7 +660,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] * c
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="concurrent modes, but the device"):
+        with pytest.raises(CircuitError, match="concurrent modes, but the device"):
             prog.compile(device=device1, compiler="TD2")
 
     def test_tdm_inconsistent_spatial_modes(self):
@@ -674,7 +676,7 @@ class TestTDMcompiler:
         phi = [0, np.pi / 2] * c
         theta = [0, 0] * c
         prog = singleloop_program(sq_r, alpha, phi, theta)
-        with pytest.raises(sf.program_utils.CircuitError, match="spatial modes, but the device"):
+        with pytest.raises(CircuitError, match="spatial modes, but the device"):
             prog.compile(device=device1, compiler="TD2")
 
 class TestTDMProgramFunctions:
@@ -756,3 +758,68 @@ class TestEngineTDMProgramInteraction:
         results = eng.run(prog, shots=2)
         assert results.samples.shape[0] == 2
         assert prog.run_options["shots"] == 5
+
+
+class TestTDMValidation:
+    """Test the validation of TDMProgram against the device specs"""
+    @pytest.fixture(scope="class")
+    def device(self):
+        target = "TD2"
+        tm = 4
+        layout = f"""
+            name template_tdm
+            version 1.0
+            target {target} (shots=1)
+            type tdm (temporal_modes=2)
+            float array p0[1, {tm}] =
+                {{rs_array}}
+            float array p1[1, {tm}] =
+                {{r_array}}
+            float array p2[1, {tm}] =
+                {{bs_array}}
+            float array p3[1, {tm}] =
+                {{m_array}}
+            Sgate(p0) | 1
+            Rgate(p1) | 0
+            BSgate(p2, 0) | (0, 1)
+            MeasureHomodyne(p3) | 0
+        """
+        device_spec = {
+            "layout": inspect.cleandoc(layout),
+            "modes": {"concurrent": 2, "spatial": 1, "temporal_max": 100},
+            "compiler": [target],
+            "gate_parameters": {
+                "p0": [-1],
+                "p1": [1],
+                "p2": [2],
+                "p3": [3],
+            },
+        }
+        return DeviceSpec("TD2", device_spec, connection=None)
+    
+    @staticmethod
+    def compile_test_program(device, args=(-1, 1, 2, 3)):
+        """Compiles a test program with the given gate arguments."""
+        alpha = [args[1]]
+        beta = [args[2]]
+        gamma = [args[3]]
+        prog = tdmprogram.TDMProgram(N=2)
+        with prog.context(alpha, beta, gamma) as (p, q):
+            ops.Sgate(args[0]) | q[1]  # Note that the Sgate has a second parameter that is non-zero
+            ops.Rgate(p[0]) | q[0]
+            ops.BSgate(p[1]) | (q[0], q[1])
+            ops.MeasureHomodyne(p[2]) | q[0]
+        prog.compile(device=device, compiler=device.compiler)
+
+    def test_validation_correct_args(self, device):
+        """Test that no error is raised when the tdm circuit explicit parameters within the allowed ranges"""
+        self.compile_test_program(device, args=(-1, 1, 2, 3))
+
+    @pytest.mark.parametrize("incorrect_index", list(range(4)))
+    def test_validation_incorrect_args(self, device, incorrect_index):
+        """Test the correct error is raised when the tdm circuit explicit parameters are not within the allowed ranges"""
+        args = [-1, 1, 2, 3]
+        args[incorrect_index] = -999
+        with pytest.raises(CircuitError, match="Parameter has value '-999' while its valid range is "):
+            self.compile_test_program(device, args=args)
+    


### PR DESCRIPTION
**Context:**
We recently changed the allowed gate parameters for `TD2`. The `Rgate` phase can now be both positive and negative. With this change, requested programs did not pass the validation step in the program validation any more when negative phases were set. The reason was that when the code was supposed to validate the phases of the `BSgate` (where only positive values are allowed), it used the values set for the `Rgate` phases, which were occasionally negative. 

**Description of the Change:**
The proposed solution now uses the correct values in the above described validation step for each parameter.

**Benefits:**
Fixed a bug. Code behavior should be closer to what one expects now.

**Possible Drawbacks:**
I did not fully understand the logic. In particular, it seems to me that the current way of updating a counter for the index that is used to grab the relevant parameter values is highly error-prone. I could imagine there are edge cases where this still leads to unexpected behavior. A more thorough logic cleanup would maybe be a better solution, but take more time. I also did not dig too far into why the tests did not uncover this problem. I'd be happy to add a new test case in case it's worth it and we don't want to do the full cleanup now.

**Related GitHub Issues:**
None