### PR TITLE
Generaldyne sampling in gaussian

### DIFF
--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -478,7 +478,7 @@ class GaussianModes:
 
         r = self.smean()
         (va, vc) = ops.chop_in_blocks_vector(r, expind)
-        vm = np.random.multivariate_normal(vc, C, size=shots)
+        vm = np.random.multivariate_normal(vc, C + covmat, size=shots)
         # The next line is a hack in that it only updates conditioned on the first samples value
         # should still work if shots = 1
         va = va + np.dot(np.dot(B, np.linalg.inv(C + covmat)), vm[0] - vc)


### PR DESCRIPTION
**Context:** Generaldyne sampling in the gaussian backend

**Description of the Change:** Fixes the formula used for sampling generaldyne outcomes in the gaussian backend.

The covariance matrix of the sampling distribution needed also to depend on the covariance of the state onto which the target state was begin measured.

Updated the test in test_heterodyne to account for this.

**Benefits:** Correct heterodyne sampling (homodyne unaffected).

**Possible Drawbacks:** None.

**Related GitHub Issues:**
