### PR TITLE
Switch measurements kwargs to args in `io.to_blackbird`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -140,7 +140,7 @@
 
 * `measure_threshold` in the `gaussian` backend now supports displaced Gaussian states.
   [(#615)](https://github.com/XanaduAI/strawberryfields/pull/615)
-  
+
 * Speed improvements to ``gaussian_unitary`` compiler
   [(#603)](https://github.com/XanaduAI/strawberryfields/pull/603)
 
@@ -166,6 +166,10 @@
 * The correct samples are now returned when running a TDMProgram with several shots, where
   `timebins % concurrent_modes != 0`.
   [(#611)](https://github.com/XanaduAI/strawberryfields/pull/611)
+
+* Measurement arguments are now stored as non-keyword arguments, instead of keyword arguments, in
+  the resulting Blackbird program when using the `io.to_blackbird()` converter function.
+  [(#622)](https://github.com/XanaduAI/strawberryfields/pull/622)
 
 <h3>Documentation</h3>
 

--- a/strawberryfields/io.py
+++ b/strawberryfields/io.py
@@ -75,7 +75,7 @@ def to_blackbird(prog, version="1.0"):
 
             if cmd.op.p:
                 # argument is quadrature phase
-                op["kwargs"]["phi"] = cmd.op.p[0]
+                op["args"] = cmd.op.p
 
             if op["op"] == "MeasureFock":
                 # special case to take into account 'dark_counts' keyword argument

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -66,7 +66,7 @@ def prog():
         # measurement
         ops.MeasureX | q[0]
         ops.MeasureHomodyne(0.43, select=0.32) | q[2]
-        ops.MeasureHomodyne(phi=0.43, select=0.32) | q[2]
+        ops.MeasureHomodyne(0.43, select=0.32) | q[2]
 
     return prog
 
@@ -87,9 +87,9 @@ Sgate(1, 0.0) | 0
 Dgate(0.735934779718964, 0.7469555733762603) | 1
 S2gate(0.543, -0.12) | [0, 3]
 Interferometer(A0) | [0, 1, 2, 3]
-MeasureHomodyne(phi=0) | 0
-MeasureHomodyne(select=0.32, phi=0.43) | 2
-MeasureHomodyne(select=0.32, phi=0.43) | 2
+MeasureHomodyne(0) | 0
+MeasureHomodyne(0.43, select=0.32) | 2
+MeasureHomodyne(0.43, select=0.32) | 2
 """
 
 
@@ -280,8 +280,8 @@ class TestSFToBlackbirdConversion:
         expected = {
             "op": "MeasureHomodyne",
             "modes": [0],
-            "args": [],
-            "kwargs": {"phi": 0.43},
+            "args": [0.43],
+            "kwargs": {},
         }
 
         assert bb.operations[0] == expected
@@ -298,8 +298,8 @@ class TestSFToBlackbirdConversion:
         expected = {
             "op": "MeasureHomodyne",
             "modes": [0],
-            "args": [],
-            "kwargs": {"phi": 0.43, "select": 0.543},
+            "args": [0.43],
+            "kwargs": {"select": 0.543},
         }
 
         assert bb.operations[0] == expected
@@ -358,7 +358,7 @@ class TestSFToBlackbirdConversion:
         assert bb.operations[0] == {'kwargs': {}, 'args': [0.7, 0], 'op': 'Sgate', 'modes': [1]}
         assert bb.operations[1] == {'kwargs': {}, 'args': ['p0', 0.0], 'op': 'BSgate', 'modes': [0, 1]}
         assert bb.operations[2] == {'kwargs': {}, 'args': ['p1'], 'op': 'Rgate', 'modes': [1]}
-        assert bb.operations[3] == {'kwargs': {'phi': 'p2'}, 'args': [], 'op': 'MeasureHomodyne', 'modes': [0]}
+        assert bb.operations[3] == {'kwargs': {}, 'args': ['p2'], 'op': 'MeasureHomodyne', 'modes': [0]}
 
         assert bb.programtype == {'name': 'tdm', 'options': {'temporal_modes': 2}}
         assert list(bb._var.keys()) == ["p0", "p1", "p2"]

--- a/tests/frontend/test_io.py
+++ b/tests/frontend/test_io.py
@@ -66,7 +66,7 @@ def prog():
         # measurement
         ops.MeasureX | q[0]
         ops.MeasureHomodyne(0.43, select=0.32) | q[2]
-        ops.MeasureHomodyne(0.43, select=0.32) | q[2]
+        ops.MeasureHomodyne(phi=0.43, select=0.32) | q[2]
 
     return prog
 


### PR DESCRIPTION
**Context:**
Measurement arguments are _always_ compiled into Blackbird keyword arguments when using `io.to_blackbird`, while all other gate arguments are being stored as non-keyword arguments. This causes some issues when attempting to match templates with parameter values ([specifically for QKD](https://github.com/XanaduAI/xanadu-og-config/pull/143#event-5215091659)).

**Description of the Change:**
Switch measurement arguments from being compiled into keyword arguments in Blackbird to non-keyword arguments, to conform with the rest of the gate arguments.

**Benefits:**
Matching parameter values with measurement arguments works the same as when matching with gate arguments.

**Possible Drawbacks:**
If someone somewhere uses the fact that measurement arguments always are stored as keyword arguments in the resulting Blackbird program, this will no longer work (since the parameters will be found as a non-keyword argument instead).

**Related GitHub Issues:**
None
