### PR TITLE
Symbolic parameter support in TDM compiler

### DIFF
--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -170,7 +170,7 @@ def reshape_samples(all_samples, modes, N, timebins):
     idx_tracker = {i: 0 for i in mode_order}
 
     # iterate backwards through all_samples and add them into the correct mode
-    new_samples = dict()
+    new_samples = {}
     timebin_idx = 0
     for i, mode in enumerate(mode_order):
         mode_idx = modes[i % len(N)]
@@ -684,7 +684,7 @@ class TDMProgram(Program):
         for _ in range(shots):
             # save previous mode index of a command to be able to check when modes
             # are looped back to the start (not allowed when space-unrolling)
-            previous_mode_index = dict()
+            previous_mode_index = {}
 
             for cmd in self.rolled_circuit:
                 previous_mode_index[cmd] = 0

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -513,7 +513,7 @@ class TDMProgram(Program):
                     program_param = self.rolled_circuit[i].op.p[k]
 
                     # make sure that hardcoded parameters in the device layout are correct
-                    if not isinstance(param_name, str):
+                    if not isinstance(param_name, str) and not par_is_symbolic(param_name):
                         if not program_param == param_name:
                             raise CircuitError(
                                 "Program cannot be used with the device '{}' "
@@ -525,8 +525,8 @@ class TDMProgram(Program):
                         continue
 
                     # Obtain the relevant parameter range from the device
-                    param_range = device.gate_parameters[param_name]
-                    if par_is_symbolic(program_param):
+                    param_range = device.gate_parameters.get(str(param_name))
+                    if param_range and par_is_symbolic(program_param):
                         # If it is a symbolic value go and lookup its corresponding list in self.tdm_params
                         local_p_vals = self.parameters.get(program_param.name, [])
 
@@ -540,7 +540,7 @@ class TDMProgram(Program):
                                     )
                                 )
 
-                    else:
+                    elif param_range:
                         # If it is a numerical value check directly
                         if not program_param in param_range:
                             raise CircuitError(

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -526,7 +526,14 @@ class TDMProgram(Program):
 
                     # Obtain the relevant parameter range from the device
                     param_range = device.gate_parameters.get(str(param_name))
-                    if param_range and par_is_symbolic(program_param):
+                    if param_range is None:
+                        raise CircuitError(
+                            "Program cannot be used with the device '{}' "
+                            "due to parameter '{}' not found in device specification.".format(
+                                device.target, param_name
+                            )
+                        )
+                    if par_is_symbolic(program_param):
                         # If it is a symbolic value go and lookup its corresponding list in self.tdm_params
                         local_p_vals = self.parameters.get(program_param.name, [])
 
@@ -540,7 +547,7 @@ class TDMProgram(Program):
                                     )
                                 )
 
-                    elif param_range:
+                    else:
                         # If it is a numerical value check directly
                         if not program_param in param_range:
                             raise CircuitError(

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -601,6 +601,20 @@ class TestTDMcompiler:
         with pytest.raises(CircuitError, match="due to incompatible parameter."):
             prog.compile(device=device, compiler="TD2")
 
+    def test_tdm_parameters_not_in_devicespec(self):
+        """Test the correct error is raised when the tdm circuit symbolic parameters are not found
+        in the device specification"""
+        spec = copy.deepcopy(device_spec)
+        # "p1" removed from device spec, but is still used in layout
+        del spec["gate_parameters"]["p1"]
+
+        c = 2
+        prog = singleloop_program(
+            0.5643, [np.pi / 4, 0] * c, [0, np.pi / 2] * c, [0, 0, np.pi / 2, np.pi / 2]
+        )
+        with pytest.raises(CircuitError, match="not found in device specification"):
+            prog.compile(device=DeviceSpec("TDM", spec, connection=None), compiler="TDM")
+
     def test_tdm_inconsistent_temporal_modes(self):
         """Test the correct error is raised when the tdm circuit has too many temporal modes"""
         sq_r = 0.5643


### PR DESCRIPTION
**Context:**
The TDM compiler is failing when attempting to compile TDM program using device specs with symbolic template parameters in operations. This is due to the compiler seeing anything that is not a string (e.g., a value _or_ a symbolic parameter) as a hard-coded parameter, which a template parameter is not, and concludes that the values in the spec differ from the values in the program.

**Description of the Change:**
* Template parameters are no longer seen as a hard-coded parameter type.
* If a template parameter is used instead of a p-type parameter, it can still be used to validate the parameter values in the device spec if it's named the same there.

**Example:** The following works, with all `{s}` values being validated using the gate parameter range `'s': [[0.0, 99999999.]]`. Also works as before with non-template p-types (e.g. `p0`) using the _same name as in the device spec_.
```python
bbt = """\
name template_td3_fake
version 1.0
target TD3_fake (shots=1)
type tdm (temporal_modes=259, copies=1)

float array p0[1, 259] =
    {s}

Sgate({s}, 0.0) | 43
"""

device_spec = {
    'layout': bbt,
    'modes': 
    {
        'spatial': 1, 
        'concurrent': 44, 
        'temporal_max': 259
    }, 
    'compiler': ['TD3_fake'], 
    'gate_parameters': 
    {
        's': [[0.0, 99999999.]], 
    }
}
```

**Benefits:**
TDM and QKD programs can be be more easily run through the compiler.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
