### PR TITLE
Add support for npz results

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <h3>New features since last release</h3>
 
-* Cloud devices can now return dictionaries of numpy arrays, and comporession can be used to reduce the data payload.
+* Xanadu Cloud devices can now return dictionaries of numpy arrays, and compression can be used to reduce the data payload.
   [(#633)](https://github.com/XanaduAI/strawberryfields/pull/633)
 
 <h3>Breaking Changes</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <h3>New features since last release</h3>
 
+* Cloud devices can now return dictionaries of numpy arrays, and comporession can be used to reduce the data payload.
+  [(#633)](https://github.com/XanaduAI/strawberryfields/pull/633)
+
 <h3>Breaking Changes</h3>
 
 <h3>Bug fixes</h3>

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -293,8 +293,7 @@ class Connection:
                 samples = int_to_int64(samples)
 
             # The npz format can be used to compress data. In this case samples is
-            # a dict at this point, but the user might expect a single array. For
-            # this case we use the special key ``single_samples_array``.
+            # a dict with one entry but the user might expect a single array.
             if isinstance(samples, dict) and len(samples) == 1:
                 samples = next(iter(samples.values()))
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -288,7 +288,7 @@ class Connection:
                 return samples
 
             if isinstance(samples, dict):
-                samples = {key: int_to_int64(value) for key, value in samples}
+                samples = {key: int_to_int64(value) for key, value in samples.items()}
             else:
                 samples = int_to_int64(samples)
 

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -282,20 +282,25 @@ class Connection:
             # Samples represent photon numbers.
             # Convert to int64, to avoid unexpected behaviour
             # when users postprocess these samples.
-            def int_to_int64(samples): 
+            def int_to_int64(samples):
                 if np.issubdtype(samples.dtype, np.integer):
                     return samples.astype(np.int64)
                 else:
                     return samples
+
             if isinstance(samples, dict):
                 samples = {key: int_to_int64(value) for key, value in samples}
             else:
                 samples = int_to_int64(samples)
 
-            # The npz format can be used to compress data. In this case samples is 
-            # a dict at this point, but the user might expect a single array. For 
+            # The npz format can be used to compress data. In this case samples is
+            # a dict at this point, but the user might expect a single array. For
             # this case we use the special key ``single_samples_array``.
-            if isinstance(samples, dict) and "_single_samples_array" in samples and len(samples) == 1:
+            if (
+                isinstance(samples, dict)
+                and "_single_samples_array" in samples
+                and len(samples) == 1
+            ):
                 samples = samples["_single_samples_array"]
 
             return Result(samples, is_stateful=False)

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -297,10 +297,9 @@ class Connection:
             # this case we use the special key ``single_samples_array``.
             if (
                 isinstance(samples, dict)
-                and "_single_samples_array" in samples
                 and len(samples) == 1
             ):
-                samples = samples["_single_samples_array"]
+                samples = next(samples.values())
 
             return Result(samples, is_stateful=False)
         raise RequestFailedError(

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -276,12 +276,27 @@ class Connection:
                 buf.seek(0)
 
                 samples = np.load(buf, allow_pickle=False)
+                if isinstance(samples, np.lib.npyio.NpzFile):
+                    samples = dict(samples)  # convert to dict to free buffer
 
+            # Samples represent photon numbers.
+            # Convert to int64, to avoid unexpected behaviour
+            # when users postprocess these samples.
+            def int_to_int64(samples): 
                 if np.issubdtype(samples.dtype, np.integer):
-                    # Samples represent photon numbers.
-                    # Convert to int64, to avoid unexpected behaviour
-                    # when users postprocess these samples.
-                    samples = samples.astype(np.int64)
+                    return samples.astype(np.int64)
+                else:
+                    return samples
+            if isinstance(samples, dict):
+                samples = {key: int_to_int64(value) for key, value in samples}
+            else:
+                samples = int_to_int64(samples)
+
+            # The npz format can be used to compress data. In this case samples is 
+            # a dict at this point, but the user might expect a single array. For 
+            # this case we use the special key ``single_samples_array``.
+            if isinstance(samples, dict) and "_single_samples_array" in samples and len(samples) == 1:
+                samples = samples["_single_samples_array"]
 
             return Result(samples, is_stateful=False)
         raise RequestFailedError(

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -295,11 +295,8 @@ class Connection:
             # The npz format can be used to compress data. In this case samples is
             # a dict at this point, but the user might expect a single array. For
             # this case we use the special key ``single_samples_array``.
-            if (
-                isinstance(samples, dict)
-                and len(samples) == 1
-            ):
-                samples = next(samples.values())
+            if isinstance(samples, dict) and len(samples) == 1:
+                samples = next(iter(samples.values()))
 
             return Result(samples, is_stateful=False)
         raise RequestFailedError(

--- a/strawberryfields/api/connection.py
+++ b/strawberryfields/api/connection.py
@@ -285,8 +285,7 @@ class Connection:
             def int_to_int64(samples):
                 if np.issubdtype(samples.dtype, np.integer):
                     return samples.astype(np.int64)
-                else:
-                    return samples
+                return samples
 
             if isinstance(samples, dict):
                 samples = {key: int_to_int64(value) for key, value in samples}

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -135,6 +135,12 @@ class Result:
 
     def __repr__(self):
         """String representation."""
+        if isinstance(self.samples, dict):
+            # if samples is a dict (of arrays), simply display the available keys
+            return "<Result: keys={}, contains state={}>".format(
+                self.samples.keys(), self._is_stateful
+            )
+
         if self.samples.ndim == 2:
             # if samples has dim 2, assume they're from a standard Program
             shots, modes = self.samples.shape

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -254,7 +254,6 @@ class TestConnection:
 
         assert np.array_equal(result.samples, result_samples)
 
-
     @pytest.mark.parametrize(
         "result_dtype",
         [
@@ -312,7 +311,9 @@ class TestConnection:
         ],
     )
     @pytest.mark.parametrize("compressed", [True, False])
-    def test_get_job_result_dict_single_samples_array(self, connection, result_dtype, compressed, monkeypatch):
+    def test_get_job_result_dict_single_samples_array(
+        self, connection, result_dtype, compressed, monkeypatch
+    ):
         """Tests a successful job result request."""
         array1 = np.array([[1, 2], [3, 4]], dtype=result_dtype)
 
@@ -332,7 +333,6 @@ class TestConnection:
         assert np.array_equal(result.samples, array1)
         if np.issubdtype(result_dtype, np.integer):
             assert result.samples.dtype == np.int64
-
 
     def test_get_job_result_error(self, connection, monkeypatch):
         """Tests a failed job result request."""

--- a/tests/api/test_connection.py
+++ b/tests/api/test_connection.py
@@ -267,6 +267,8 @@ class TestConnection:
             np.uint64,
             np.float32,
             np.float64,
+            np.complex64,
+            np.complex128,
         ],
     )
     @pytest.mark.parametrize("compressed", [True, False])
@@ -308,6 +310,8 @@ class TestConnection:
             np.uint64,
             np.float32,
             np.float64,
+            np.complex64,
+            np.complex128,
         ],
     )
     @pytest.mark.parametrize("compressed", [True, False])
@@ -319,9 +323,9 @@ class TestConnection:
 
         with io.BytesIO() as buf:
             if compressed:
-                np.savez_compressed(buf, _single_samples_array=array1)
+                np.savez_compressed(buf, array1=array1)
             else:
-                np.savez(buf, _single_samples_array=array1)
+                np.savez(buf, array1=array1)
             buf.seek(0)
             monkeypatch.setattr(
                 requests,

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -83,7 +83,7 @@ class TestResult:
     def test_dict_print(self, stateful, capfd):
         """Test that printing a result object with a dict of samples
         provides the correct output."""
-        samples = {"ones": np.ones((2, 3, 4, 5)), "twos": 2*np.ones((2, 3, 4, 5))}
+        samples = {"ones": np.ones((2, 3, 4, 5)), "twos": 2 * np.ones((2, 3, 4, 5))}
         result = Result(samples, is_stateful=stateful)
         print(result)
         out, err = capfd.readouterr()

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -78,3 +78,18 @@ class TestResult:
         assert "shots" not in out
         assert "timebins" not in out
         assert f"contains state={stateful}" in out
+
+    @pytest.mark.parametrize("stateful", [True, False])
+    def test_dict_print(self, stateful, capfd):
+        """Test that printing a result object with a dict of samples
+        provides the correct output."""
+        samples = {"ones": np.ones((2, 3, 4, 5)), "twos": 2*np.ones((2, 3, 4, 5))}
+        result = Result(samples, is_stateful=stateful)
+        print(result)
+        out, err = capfd.readouterr()
+        assert "modes" not in out
+        assert "shots" not in out
+        assert "timebins" not in out
+        assert "ones" in out
+        assert "twos" in out
+        assert f"contains state={stateful}" in out


### PR DESCRIPTION
**Context:**
Some devices on the Xanadu Quantum Cloud need to return multiple arrays of data with different shapes or data types. Furthermore, sometimes the size of a job result is a limiting factor due to limited bandwidth. This PR adds support for compressed result data, and supports returning dictionaries of result arrays instead of a single array per job.

**Description of the Change:**
With this change, job results can be serialized using `numpy.savez` or `numpy.savez_copressed`. In this format, a dictionary of numpy arrays can be transferred, with compression disabled or enabled.

**Benefits:**
Cloud devices can now return dictionaries of numpy arrays, and comporession can be used to reduce the data payload.

**Possible Drawbacks:**
For single result arrays, it is not clear whether the client supports compression or not. 

~**Related GitHub Issues:**~
