### PR TITLE
Use refactored gaussian gate from The Walrus

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: josh146/sphinx-action@master
+    - uses: XanaduAI/sphinx-action@master
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,5 +15,5 @@ sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.6.1
-http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp37-cp37m-manylinux2014_x86_64.whl#sha256=5e5ebc26d5a4839a7cbcce63bf6b5a4245928f7808a10ceb3e695908db7bc463
+http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp38-cp38-manylinux2014_x86_64.whl#sha256=f8cef1f05a903eec2b563758b7542490681dfc899e57cce1542385546e222306
 toml

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,5 +15,5 @@ sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.6.1
-http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp38-cp38-manylinux2014_x86_64.whl#sha256=f8cef1f05a903eec2b563758b7542490681dfc899e57cce1542385546e222306
+http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp37-cp37m-manylinux2014_x86_64.whl#sha256=5e5ebc26d5a4839a7cbcce63bf6b5a4245928f7808a10ceb3e695908db7bc463
 toml

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,5 +15,5 @@ sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.6.1
-thewalrus>=0.16.0
+http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp38-cp38-manylinux2014_x86_64.whl#sha256=f8cef1f05a903eec2b563758b7542490681dfc899e57cce1542385546e222306
 toml

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ tensorboard
 networkx
 quantum-blackbird
 python-dateutil
-git+https://github.com/XanaduAI/thewalrus.git
+http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211117203611-cp38-cp38-manylinux2014_x86_64.whl#sha256=f8cef1f05a903eec2b563758b7542490681dfc899e57cce1542385546e222306
 toml
 appdirs
 numba

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ tensorboard
 networkx
 quantum-blackbird
 python-dateutil
-thewalrus
+http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211101181237-cp38-cp38-manylinux2010_x86_64.whl
 toml
 appdirs
 numba

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ tensorboard
 networkx
 quantum-blackbird
 python-dateutil
-http://xanadu-wheels.s3-website-us-east-1.amazonaws.com/thewalrus-0.17.0.dev0+20211101181237-cp38-cp38-manylinux2010_x86_64.whl
+https://github.com/XanaduAI/thewalrus/suites/4343041497/artifacts/114559088
 toml
 appdirs
 numba

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ tensorboard
 networkx
 quantum-blackbird
 python-dateutil
-https://github.com/XanaduAI/thewalrus/suites/4343041497/artifacts/114559088
+git+https://github.com/XanaduAI/thewalrus.git
 toml
 appdirs
 numba

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -47,9 +47,9 @@ from thewalrus.fock_gradients import mzgate as mzgate_tw
 from thewalrus.fock_gradients import grad_mzgate as grad_mzgate_tw
 from thewalrus.fock_gradients import two_mode_squeezing as two_mode_squeezing_tw
 from thewalrus.fock_gradients import grad_two_mode_squeezing as grad_two_mode_squeezing_tw
-from thewalrus._hermite_multidimensional import hermite_multidimensional_numba as gaussian_gate_tw
+from thewalrus._hermite_multidimensional import hermite_multidimensional as gaussian_gate_tw
 from thewalrus._hermite_multidimensional import (
-    grad_hermite_multidimensional_numba as grad_gaussian_gate_tw,
+    grad_hermite_multidimensional as grad_gaussian_gate_tw,
 )
 from thewalrus.symplectic import is_symplectic, sympmat
 

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -525,7 +525,7 @@ def choi_trick(S, d, dtype=tf.complex128):
 @tf.custom_gradient
 def single_gaussian_gate_matrix(R, y, C, cutoff, dtype=tf.complex128):
     """creates a N-mode gaussian gate matrix"""
-    gate = tf.numpy_function(gaussian_gate_tw, [R, cutoff, y, C], tf.complex128)
+    gate = tf.numpy_function(gaussian_gate_tw, [R, cutoff, y, C, True, True, True], tf.complex128)
     N = y.shape[-1] // 2
     transpose_list = [x for pair in zip(range(N), range(N, 2 * N)) for x in pair]
 


### PR DESCRIPTION
**Context:** [PR #295](https://github.com/XanaduAI/thewalrus/pull/295) on The Walrus deprecates the C++ implementation of  `gaussian_gate` and `grad_gaussian_gate` in favor of the numba implementation. This in turn modifies the signatures of the imported functions.

**Description of the Change:** This PR will use the new implementation of `gaussian_gate` and `grad_gaussian_gate` on The Walrus

**Benefits:** The Walrus has less C++ dependencies

**Possible Drawbacks:** None

**Related GitHub Issues:** None
