### PR TITLE
Update Result class to work with XCC

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -189,9 +189,9 @@
 * The `sf.api.Result` class has been updated to support the Xanadu Cloud Client integration.
   [(#651)](https://github.com/XanaduAI/strawberryfields/pull/651)
 
-  While `Result.samples` should return the same type and shape as before, a `Result.samples_dict`
-  property has been added, returning the samples as a dictionary with corresponding measured modes
-  as keys.
+  While `Result.samples` should return the same type and shape as before, the `Result.all_samples`
+  property has been renamed to `Result.samples_dict`, which returns the samples as a dictionary with
+  corresponding measured modes as keys.
 
   ```pycon
   >>> res = eng.run(prog, shots=3)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,7 +26,7 @@
   state_out = eng.run(prog).state.ket()
   ```
 
-  Note that in order to update the parameter `S` by using its gradient, you cannot use gradient 
+  Note that in order to update the parameter `S` by using its gradient, you cannot use gradient
   descent directly (as the unitary would not be symplectic after the update). Please use the
   function `sf.backends.tfbackend.update_symplectic` which is designed specifically for this purpose.
 
@@ -185,6 +185,31 @@
   )
   engine = sf.RemoteEngine("X8", connection=connection)
   ```
+
+* The `sf.api.Result` class has been updated to support the Xanadu Cloud Client integration.
+  [(#651)](https://github.com/XanaduAI/strawberryfields/pull/651)
+
+  While `Result.samples` should return the same type and shape as before, a `Result.samples_dict`
+  property has been added, returning the samples as a dictionary with corresponding measured modes
+  as keys.
+
+  ```pycon
+  >>> res = eng.run(prog, shots=3)
+  >>> res.samples
+  array([[1, 0], [0, 1], [1, 1]])
+  >>> res.samples_dict
+  {0: [np.array([1, 0, 1])], 1: [np.array([0, 1, 1])]}
+  ```
+
+  The samples dictionary is only accessible for simulators.
+
+* The `sf.api.DeviceSpec` class has been updated to support the Xanadu Cloud Client integration.
+  [(#644)](https://github.com/XanaduAI/strawberryfields/pull/644)
+
+  It now works as a container for a device specification dictionary. There are no more API
+  connection usages, and `DeviceSpec.target` is retrieved from the device specification rather than
+  passed at initialization.
+
 
 <h3>Bug fixes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -190,7 +190,7 @@
   [(#651)](https://github.com/XanaduAI/strawberryfields/pull/651)
 
   While `Result.samples` should return the same type and shape as before, the `Result.all_samples`
-  property has been renamed to `Result.samples_dict`, which returns the samples as a dictionary with
+  property has been renamed to `Result.samples_dict` and returns the samples as a dictionary with
   corresponding measured modes as keys.
 
   ```pycon

--- a/doc/development/migration_guides.rst
+++ b/doc/development/migration_guides.rst
@@ -61,3 +61,51 @@ The (semantically) equivalent code in Strawberry Fields v0.20.0 is
         port=443,
         tls=True,                                        # See "token" argument above.
     )
+
+Result
+^^^^^^
+
+When running local or remote jobs, a ``strawberryfields.api.Result`` object will be returned. This
+object will function slightly differently in Strawberry Fields v0.20.0.
+
+While ``Result.samples`` should return the same type and shape as before, the `Result.all_samples`
+property has been renamed to `Result.samples_dict`. This property returns the samples as a
+dictionary with corresponding measured modes as keys.
+
+.. code-block:: pycon
+
+    >>> res = eng.run(prog, shots=3)
+    >>> res.samples
+    array([[1, 0], [0, 1], [1, 1]])
+    >>> res.samples_dict
+    {0: [np.array([1, 0, 1])], 1: [np.array([0, 1, 1])]}
+
+Any use of `Result.all_samples` must be renamed `Result.samples_dict` in Strawberry Fields v0.20.0.
+
+Device Specification
+^^^^^^^^^^^^^^^^^^^^
+
+The ``DeviceSpec`` no longer has a connection object, and is simply a container for a remote device
+specification. The target argument has been removed in favour of using the target entry in the
+device specification dictionary.
+
+Creating a ``DeviceSpec`` object in Strawberry Fields v0.19.0:
+
+.. code-block:: python
+
+    connection = sf.api.Connection()
+    spec = {"target": "X8", "layout": "", "modes": 8, "gate_parameters": {}}
+    device_spec = sf.api.DeviceSpec(target="X8", spec=spec, connection=connection)
+
+The (semantically) equivalent code in Strawberry Fields v0.20.0 is
+
+.. code-block:: python
+
+    spec = {"target": "X8", "layout": "", "modes": 8, "gate_parameters": {}}
+    device_spec = sf.api.DeviceSpec(spec=spec)
+
+.. note::
+
+    Rhe remote specification dictionary keys "target", "layout", "modes" and "gate_parameters" are
+    mandatory in Strawberry Fields v0.20.0. If one or more are missing, a ``DeviceSpec`` object
+    cannot be created.

--- a/doc/development/migration_guides.rst
+++ b/doc/development/migration_guides.rst
@@ -80,7 +80,7 @@ dictionary with corresponding measured modes as keys.
     >>> res.samples_dict
     {0: [np.array([1, 0, 1])], 1: [np.array([0, 1, 1])]}
 
-Any use of `Result.all_samples` must be renamed `Result.samples_dict` in Strawberry Fields v0.20.0.
+All instances of ``Result.all_samples`` must be replaced with ``Result.samples_dict`` in Strawberry Fields v0.20.0.
 
 Device Specification
 ^^^^^^^^^^^^^^^^^^^^
@@ -106,6 +106,6 @@ The (semantically) equivalent code in Strawberry Fields v0.20.0 is
 
 .. note::
 
-    Rhe remote specification dictionary keys "target", "layout", "modes" and "gate_parameters" are
+    The remote specification dictionary keys "target", "layout", "modes" and "gate_parameters" are
     mandatory in Strawberry Fields v0.20.0. If one or more are missing, a ``DeviceSpec`` object
     cannot be created.

--- a/doc/development/migration_guides.rst
+++ b/doc/development/migration_guides.rst
@@ -68,8 +68,8 @@ Result
 When running local or remote jobs, a ``strawberryfields.api.Result`` object will be returned. This
 object will function slightly differently in Strawberry Fields v0.20.0.
 
-While ``Result.samples`` should return the same type and shape as before, the `Result.all_samples`
-property has been renamed to `Result.samples_dict`. This property returns the samples as a
+While ``Result.samples`` should return the same type and shape as before, the ``Result.all_samples``
+property has been renamed to ``Result.samples_dict``. This property returns the samples as a
 dictionary with corresponding measured modes as keys.
 
 .. code-block:: pycon

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -162,7 +162,7 @@ for accessing the results of your program execution:
   for manipulation of the final circuit state. Not available for remote
   backends.
 
-  .. code-block:: python
+  .. code-block:: pycon
 
       >>> print(result.state)
       <FockState: num_modes=3, cutoff=5, pure=True, hbar=2.0>

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -74,7 +74,7 @@ class Result:
         self._ancilla_samples = ancilla_samples
 
     @property
-    def samples(self) -> np.ndarray:
+    def samples(self) -> Optional[np.ndarray]:
         """Measurement samples.
 
         Returned measurement samples will have shape ``(shots, modes)``.
@@ -83,12 +83,12 @@ class Result:
             array[array[float, int]]: measurement samples returned from
             program execution
         """
-        if len(self._result) > 1:
+        if len(self._result["output"]) > 1:
             warnings.warn(
                 f"Result dictionary has {len(self._result)} entries; "
-                "returning only the primary entry."
+                "returning only the 'output' entry."
             )
-        return list(self._result.values())[0]
+        return self._result.get("output", [None])[0]
 
     @property
     def samples_dict(self) -> Mapping:

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -18,6 +18,7 @@ This module provides a class that represents the result of a quantum computation
 import warnings
 import numpy as np
 
+
 class Result:
     """Result of a quantum computation.
 
@@ -100,7 +101,9 @@ class Result:
         Raises:
             AttributeError: if samples dictionary is access for a stateless computation
         """
-        samples_dict = {key: np.array(val) for key, val in self._result.items() if isinstance(key, int)}
+        samples_dict = {
+            key: np.array(val) for key, val in self._result.items() if isinstance(key, int)
+        }
         return samples_dict
 
     @property

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -16,7 +16,11 @@ This module provides a class that represents the result of a quantum computation
 """
 
 import warnings
+from typing import Mapping, Optional
+
 import numpy as np
+
+from strawberryfields.backends import BaseState
 
 
 class Result:
@@ -64,13 +68,17 @@ class Result:
         but the return value of ``Result.state`` will be ``None``.
     """
 
-    def __init__(self, result, ancilla_samples=None):
+    def __init__(
+        self,
+        result: Mapping,
+        ancilla_samples: Mapping = None
+    ) -> None:
         self._state = None
         self._result = result
         self._ancilla_samples = ancilla_samples
 
     @property
-    def samples(self):
+    def samples(self) -> np.ndarray:
         """Measurement samples.
 
         Returned measurement samples will have shape ``(shots, modes)``.
@@ -84,10 +92,10 @@ class Result:
                 f"Result dictionary has {len(self._result)} entries; "
                 "returning only the primary entry."
             )
-        return np.array(list(self._result.values())[0])
+        return list(self._result.values())[0]
 
     @property
-    def samples_dict(self):
+    def samples_dict(self) -> Mapping:
         """All measurement samples as a dictionary. Only available on simulators.
 
         Returns a dictionary which associates each mode (keys) with the list of
@@ -97,17 +105,14 @@ class Result:
 
         Returns:
             dict[int, list]: mode index associated with the list of measurement outcomes
-
-        Raises:
-            AttributeError: if samples dictionary is access for a stateless computation
         """
         samples_dict = {
-            key: np.array(val) for key, val in self._result.items() if isinstance(key, int)
+            key: val for key, val in self._result.items() if isinstance(key, int)
         }
         return samples_dict
 
     @property
-    def ancilla_samples(self):
+    def ancilla_samples(self) -> Optional[Mapping]:
         """All measurement samples from ancillary modes used for measurement-based
         gates.
 
@@ -122,7 +127,7 @@ class Result:
         return self._ancilla_samples
 
     @property
-    def state(self):
+    def state(self) -> Optional[BaseState]:
         """The quantum state object.
 
         The quantum state object contains details and methods
@@ -140,15 +145,10 @@ class Result:
 
         Returns:
             BaseState: quantum state returned from program execution
-
-        Raises:
-            AttributeError: if samples dictionary is access for a stateless computation
         """
-        if self._state is None:
-            raise AttributeError("The state is undefined for a stateless computation.")
         return self._state
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation."""
         if self.samples.ndim == 2:
             # if samples has dim 2, assume they're from a standard Program

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -96,7 +96,7 @@ class Result:
 
         Returns a dictionary which associates each mode (keys) with the list of
         measurements outcomes (values), including modes that are being measured
-        several times. For multiple shots or batched execution arrays and
+        several times. For multiple shots or batched execution, arrays and
         tensors are stored.
 
         Returns:

--- a/strawberryfields/api/result.py
+++ b/strawberryfields/api/result.py
@@ -68,11 +68,7 @@ class Result:
         but the return value of ``Result.state`` will be ``None``.
     """
 
-    def __init__(
-        self,
-        result: Mapping,
-        ancilla_samples: Mapping = None
-    ) -> None:
+    def __init__(self, result: Mapping, ancilla_samples: Mapping = None) -> None:
         self._state = None
         self._result = result
         self._ancilla_samples = ancilla_samples
@@ -106,9 +102,7 @@ class Result:
         Returns:
             dict[int, list]: mode index associated with the list of measurement outcomes
         """
-        samples_dict = {
-            key: val for key, val in self._result.items() if isinstance(key, int)
-        }
+        samples_dict = {key: val for key, val in self._result.items() if isinstance(key, int)}
         return samples_dict
 
     @property

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -96,8 +96,7 @@ class BosonicBackend(BaseBosonic):
             prog (object): sf.Program instance
 
         Returns:
-            tuple: a tuple of the list of applied commands, the dictionary of measurement samples,
-            and the dictionary of ancilla measurement samples
+            tuple: a tuple of the list of applied commands and the dictionary of measurement samples
 
         Raises:
             NotApplicableError: if an op in the program does not apply to the bosonic backend

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -158,8 +158,8 @@ class BosonicBackend(BaseBosonic):
                         for i, r in enumerate(cmd.reg):
                             # Internally also store all the measurement outcomes
                             if r.ind not in samples_dict:
-                                samples_dict[r.ind] = np.array([])
-                            samples_dict[r.ind] = np.append(samples_dict[r.ind], val[:, i])
+                                samples_dict[r.ind] = []
+                            samples_dict[r.ind].append(val[:, i])
 
                     applied.append(cmd)
 
@@ -176,7 +176,7 @@ class BosonicBackend(BaseBosonic):
                             cmd.op, kwargs
                         )
                     ) from e
-
+        samples_dict = {k: np.array(v) for k, v in samples_dict.items()}
         return applied, samples_dict
 
     # pylint: disable=import-outside-toplevel

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -123,7 +123,6 @@ class BosonicBackend(BaseBosonic):
         # TODO: Deal with Preparation classes in the middle of a circuit.
         applied = []
         samples_dict = {}
-        all_samples = {}
 
         non_gauss_preps = (
             Bosonic,
@@ -157,12 +156,10 @@ class BosonicBackend(BaseBosonic):
                     val = cmd.op.apply(cmd.reg, self, **kwargs)
                     if val is not None:
                         for i, r in enumerate(cmd.reg):
-                            samples_dict[r.ind] = val[:, i]
-
                             # Internally also store all the measurement outcomes
-                            if r.ind not in all_samples:
-                                all_samples[r.ind] = []
-                            all_samples[r.ind].append(val[:, i])
+                            if r.ind not in samples_dict:
+                                samples_dict[r.ind] = []
+                            samples_dict[r.ind].append(val[:, i])
 
                     applied.append(cmd)
 
@@ -180,7 +177,7 @@ class BosonicBackend(BaseBosonic):
                         )
                     ) from e
 
-        return applied, samples_dict, all_samples
+        return applied, samples_dict
 
     # pylint: disable=import-outside-toplevel
     def init_circuit(self, prog):

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -176,7 +176,6 @@ class BosonicBackend(BaseBosonic):
                             cmd.op, kwargs
                         )
                     ) from e
-        samples_dict = {k: np.array(v) for k, v in samples_dict.items()}
         return applied, samples_dict
 
     # pylint: disable=import-outside-toplevel

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -158,8 +158,8 @@ class BosonicBackend(BaseBosonic):
                         for i, r in enumerate(cmd.reg):
                             # Internally also store all the measurement outcomes
                             if r.ind not in samples_dict:
-                                samples_dict[r.ind] = []
-                            samples_dict[r.ind].append(val[:, i])
+                                samples_dict[r.ind] = np.array([])
+                            samples_dict[r.ind] = np.append(samples_dict[r.ind], val[:, i])
 
                     applied.append(cmd)
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -281,8 +281,7 @@ class BaseEngine(abc.ABC):
 
             prev = p
 
-        samples = {"samples": self.samples}
-        samples.update(self.samples_dict)
+        samples = {"output": [self.samples], **self.samples_dict}
         return Result(samples)
 
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -406,7 +406,7 @@ class LocalEngine(BaseEngine):
             samples_dict = {k: [convert_to_tensor(i) for i in v] for k, v in samples_dict.items()}
             return convert_to_tensor(samples), samples_dict
 
-        samples_dict = {k: np.array(v) for k, v in samples_dict.items()}
+        samples_dict = {k: [np.array(i) for i in v] for k, v in samples_dict.items()}
         return samples, samples_dict
 
     # pylint:disable=too-many-branches

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -281,7 +281,7 @@ class BaseEngine(abc.ABC):
 
             prev = p
 
-        samples = {"output": self.samples, **self.samples_dict}
+        samples = {"output": [self.samples], **self.samples_dict}
         return Result(samples)
 
 
@@ -503,7 +503,7 @@ class LocalEngine(BaseEngine):
                 )
                 # transpose the samples so that they have shape `(shots, spatial modes, timebins)`
                 result._result = {
-                    "samples": np.array(list(samples_dict.values())).transpose(1, 0, 2)
+                    "output": [np.array(list(samples_dict.values())).transpose(1, 0, 2)]
                 }
                 result._result.update(samples_dict)
             if received_rolled_circuit:

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -281,7 +281,7 @@ class BaseEngine(abc.ABC):
 
             prev = p
 
-        samples = {"output": [self.samples], **self.samples_dict}
+        samples = {"output": self.samples, **self.samples_dict}
         return Result(samples)
 
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -60,7 +60,6 @@ class BaseEngine(abc.ABC):
         self.run_progs = []
         #: List[List[Number]]: latest measurement results, shape == (modes, shots)
         self.samples = None
-        self.all_samples = None
 
         if isinstance(backend, str):
             self.backend_name = backend
@@ -128,7 +127,6 @@ class BaseEngine(abc.ABC):
             p._clear_regrefs()
         self.run_progs.clear()
         self.samples = None
-        self.all_samples = None
 
     def print_applied(self, print_fn=print):
         """Print all the Programs run since the backend was initialized.
@@ -278,12 +276,14 @@ class BaseEngine(abc.ABC):
                 p = p.compile(compiler=target, **compile_options)
             p.lock()
 
-            _, self.samples, self.all_samples = self._run_program(p, **kwargs)
+            _, self.samples, self.samples_dict = self._run_program(p, **kwargs)
             self.run_progs.append(p)
 
             prev = p
 
-        return Result(self.samples, all_samples=self.all_samples)
+        samples = {"samples": self.samples}
+        samples.update(self.samples_dict)
+        return Result(samples)
 
 
 class LocalEngine(BaseEngine):
@@ -344,7 +344,6 @@ class LocalEngine(BaseEngine):
     def _run_program(self, prog, **kwargs):
         applied = []
         samples_dict = {}
-        all_samples = {}
         batches = self.backend_options.get("batch_size", 0)
 
         for cmd in prog.circuit:
@@ -354,19 +353,15 @@ class LocalEngine(BaseEngine):
                 if val is not None:
                     for i, r in enumerate(cmd.reg):
                         if batches:
-                            samples_dict[r.ind] = val[:, :, i]
-
                             # Internally also store all the measurement outcomes
-                            if r.ind not in all_samples:
-                                all_samples[r.ind] = []
-                            all_samples[r.ind].append(val[:, :, i])
+                            if r.ind not in samples_dict:
+                                samples_dict[r.ind] = []
+                            samples_dict[r.ind].append(val[:, :, i])
                         else:
-                            samples_dict[r.ind] = val[:, i]
-
                             # Internally also store all the measurement outcomes
-                            if r.ind not in all_samples:
-                                all_samples[r.ind] = []
-                            all_samples[r.ind].append(val[:, i])
+                            if r.ind not in samples_dict:
+                                samples_dict[r.ind] = []
+                            samples_dict[r.ind].append(val[:, i])
 
                 applied.append(cmd)
 
@@ -386,7 +381,7 @@ class LocalEngine(BaseEngine):
 
         samples = self._combine_and_sort_samples(samples_dict)
 
-        return applied, samples, all_samples
+        return applied, samples, samples_dict
 
     def _combine_and_sort_samples(self, samples_dict):
         """Helper function to combine the values in the samples dictionary sorted by its keys."""
@@ -395,6 +390,7 @@ class LocalEngine(BaseEngine):
         if not samples_dict:
             return np.empty((0, 0))
 
+        samples_dict = {key: val[-1] for key, val in samples_dict.items()}
         samples = np.transpose([i for _, i in sorted(samples_dict.items())])
 
         # pylint: disable=import-outside-toplevel
@@ -500,12 +496,15 @@ class LocalEngine(BaseEngine):
         )
 
         if isinstance(program, TDMProgram):
-            if isinstance(result.all_samples, dict) and len(result.all_samples) > 0:
-                result._all_samples = reshape_samples(
-                    result.all_samples, program.measured_modes, program.N, program.timebins
+            if isinstance(result.samples_dict, dict) and len(result.samples_dict) > 0:
+                samples_dict = reshape_samples(
+                    result.samples_dict, program.measured_modes, program.N, program.timebins
                 )
                 # transpose the samples so that they have shape `(shots, spatial modes, timebins)`
-                result._samples = np.array(list(result.all_samples.values())).transpose(1, 0, 2)
+                result._result = {
+                    "samples": np.array(list(samples_dict.values())).transpose(1, 0, 2)
+                }
+                result._result.update(samples_dict)
             if received_rolled_circuit:
                 # if the tdm circuit is received in a rolled state, and unrolled
                 # for execution, roll it back again
@@ -797,6 +796,6 @@ class BosonicEngine(LocalEngine):
 
     def _run_program(self, prog, **kwargs):
         # Custom Bosonic run code
-        applied, samples_dict, all_samples = self.backend.run_prog(prog, **kwargs)
+        applied, samples_dict = self.backend.run_prog(prog, **kwargs)
         samples = self._combine_and_sort_samples(samples_dict)
-        return applied, samples, all_samples
+        return applied, samples, samples_dict

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -380,6 +380,7 @@ class LocalEngine(BaseEngine):
                 ) from None
 
         samples = self._combine_and_sort_samples(samples_dict)
+        samples_dict = {k: np.array(v) for k, v in samples_dict.items()}
 
         return applied, samples, samples_dict
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -211,8 +211,9 @@ class BaseEngine(abc.ABC):
         Args:
             prog (Program): program to run
         Returns:
-            list[Command]: commands that were applied to the backend
-            list[array, tensor]: samples returned from the backend
+            tuple(list[Command], list[array, tensor], dict[int, list]): tuple containing the
+            commands that were applied to the backend, the samples returned from the backend, and
+            the samples as a dictionary with the measured modes as keys
         """
 
     def _run(self, program, *, args, compile_options, **kwargs):

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -390,7 +390,6 @@ class LocalEngine(BaseEngine):
         if not samples_dict:
             return np.empty((0, 0)), samples_dict
 
-
         single_sample_dict = {key: val[-1] for key, val in samples_dict.items()}
         samples = np.transpose([i for _, i in sorted(single_sample_dict.items())])
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -107,10 +107,10 @@ def _get_mode_order(num_of_values, modes, N):
     return mode_order[:num_of_values]
 
 
-def reshape_samples(all_samples, modes, N, timebins):
+def reshape_samples(samples_dict, modes, N, timebins):
     """Reshapes the samples dict so that they have the expected correct shape.
 
-    Corrects the :attr:`~.Results.all_samples` dictionary so that the measured modes are
+    Corrects the :attr:`~.Results.samples_dict` dictionary so that the measured modes are
     the ones defined to be measured in the circuit, instead of being spread over a larger
     number of modes due to the mode-shifting occurring in :class:`~.TDMProgram`.
 
@@ -155,7 +155,7 @@ def reshape_samples(all_samples, modes, N, timebins):
         }
 
     Args:
-        all_samples (dict[int, list]): the raw measured samples
+        samples_dict (dict[int, list]): the raw measured samples
         modes (Sequence[int]): the modes that are measured in the circuit
         N (Sequence[int]): the number of concurrent modes per belt/spatial modes
         timebins (int): the number of timebins/temporal modes in the program per shot
@@ -165,11 +165,11 @@ def reshape_samples(all_samples, modes, N, timebins):
             mode and the values have shape ``(shots, timebins)``
     """
     # calculate the total number of samples and the order in which they were measured
-    num_of_values = len([i for j in all_samples.values() for i in j])
+    num_of_values = len([i for j in samples_dict.values() for i in j])
     mode_order = _get_mode_order(num_of_values, modes, N)
     idx_tracker = {i: 0 for i in mode_order}
 
-    # iterate backwards through all_samples and add them into the correct mode
+    # iterate backwards through `samples_dict` and add them into the correct mode
     new_samples = {}
     timebin_idx = 0
     for i, mode in enumerate(mode_order):
@@ -179,7 +179,7 @@ def reshape_samples(all_samples, modes, N, timebins):
             # create an entry for the new mode with a nested list for each timebin
             new_samples[mode_idx] = [[] for _ in range(timebins)]
 
-        sample = all_samples[mode][idx_tracker[mode]][0]
+        sample = samples_dict[mode][idx_tracker[mode]][0]
         idx_tracker[mode] += 1
         new_samples[mode_idx][timebin_idx].append(sample)
 
@@ -324,7 +324,7 @@ class TDMProgram(Program):
     The engine automatically takes this mode shifting into account; returned samples
     will always be transformed to match the modes specified during construction:
 
-    >>> print(results.all_samples)
+    >>> print(results.samples_dict)
     {0: [array([1.26208025]), array([1.53910032]), array([-1.29648336]),
     array([0.75743215]), array([-0.17850101]), array([-1.44751996])]}
 

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -50,7 +50,7 @@ def job(connection, monkeypatch):
     job = xcc.Job(id_="123", connection=connection)
     job._details = {"status": "open"}
 
-    result = Result({"output": np.array([[1, 2], [3, 4]])})
+    result = Result({"output": [np.array([[1, 2], [3, 4]])]})
 
     monkeypatch.setattr(xcc.Job, "submit", mock_return(job))
     monkeypatch.setattr(sf.engine.Job, "refresh", refresh)

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -50,7 +50,7 @@ def job(connection, monkeypatch):
     job = xcc.Job(id_="123", connection=connection)
     job._details = {"status": "open"}
 
-    result = Result({"output": [np.array([[1, 2], [3, 4]])]})
+    result = Result({"output": np.array([[1, 2], [3, 4]])})
 
     monkeypatch.setattr(xcc.Job, "submit", mock_return(job))
     monkeypatch.setattr(sf.engine.Job, "refresh", refresh)

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -50,7 +50,7 @@ def job(connection, monkeypatch):
     job = xcc.Job(id_="123", connection=connection)
     job._details = {"status": "open"}
 
-    result = Result({"samples": np.array([[1, 2], [3, 4]])})
+    result = Result({"output": [np.array([[1, 2], [3, 4]])]})
 
     monkeypatch.setattr(xcc.Job, "submit", mock_return(job))
     monkeypatch.setattr(sf.engine.Job, "refresh", refresh)

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -111,9 +111,7 @@ class TestRemoteEngine:
         assert result is not None
         assert np.array_equal(result.samples, [[1, 2], [3, 4]])
 
-        match = r"The state is undefined for a stateless computation."
-        with pytest.raises(AttributeError, match=match):
-            _ = result.state
+        result.state is None
 
     def test_run_async(self, prog):
         """Tests that a non-blocking job execution can succeed."""
@@ -129,9 +127,7 @@ class TestRemoteEngine:
         assert job.meta == {"foo": "bar"}
         assert np.array_equal(job.result.samples, [[1, 2], [3, 4]])
 
-        match = r"The state is undefined for a stateless computation."
-        with pytest.raises(AttributeError, match=match):
-            _ = job.result.state
+        job.result.state is None
 
     def test_run_async_options_from_kwargs(self, prog, blackbird):
         """Tests that :meth:`RemoteEngine.run_async` passes all keyword

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -50,7 +50,7 @@ def job(connection, monkeypatch):
     job = xcc.Job(id_="123", connection=connection)
     job._details = {"status": "open"}
 
-    result = Result(np.array([[1, 2], [3, 4]]), is_stateful=False)
+    result = Result({"samples": np.array([[1, 2], [3, 4]])})
 
     monkeypatch.setattr(xcc.Job, "submit", mock_return(job))
     monkeypatch.setattr(sf.engine.Job, "refresh", refresh)

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -25,15 +25,6 @@ pytestmark = pytest.mark.api
 class TestResult:
     """Tests for the ``Result`` class."""
 
-    def test_stateless_result_raises_on_state_access(self):
-        """Tests that `result.state` raises an error for a stateless result."""
-        result = Result({"samples": np.array([[1, 2], [3, 4]])})
-
-        with pytest.raises(
-            AttributeError, match="The state is undefined for a stateless computation."
-        ):
-            result.state
-
     def test_stateless_print(self, capfd):
         """Test that printing a result object with no state provides the correct output."""
         result = Result({"samples": np.array([[1, 2], [3, 4], [5, 6]])})

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -19,8 +19,6 @@ import pytest
 
 from strawberryfields.api import Result
 
-# pylint: disable=bad-continuation,no-self-use,pointless-statement
-
 pytestmark = pytest.mark.api
 
 
@@ -29,7 +27,7 @@ class TestResult:
 
     def test_stateless_result_raises_on_state_access(self):
         """Tests that `result.state` raises an error for a stateless result."""
-        result = Result(np.array([[1, 2], [3, 4]]), is_stateful=False)
+        result = Result({"samples": np.array([[1, 2], [3, 4]])})
 
         with pytest.raises(
             AttributeError, match="The state is undefined for a stateless computation."
@@ -38,7 +36,7 @@ class TestResult:
 
     def test_stateless_print(self, capfd):
         """Test that printing a result object with no state provides the correct output."""
-        result = Result(np.array([[1, 2], [3, 4], [5, 6]]), is_stateful=False)
+        result = Result({"samples": np.array([[1, 2], [3, 4], [5, 6]])})
         print(result)
         out, err = capfd.readouterr()
         assert "modes=2" in out
@@ -47,34 +45,33 @@ class TestResult:
 
     def test_state_print(self, capfd):
         """Test that printing a result object with a state provides the correct output."""
-        result = Result(np.array([[1, 2], [3, 4], [5, 6]]), is_stateful=True)
+        result = Result({"samples": np.array([[1, 2], [3, 4], [5, 6]])})
+        result._state = [[1, 2], [3, 4]]
         print(result)
         out, err = capfd.readouterr()
         assert "modes=2" in out
         assert "shots=3" in out
         assert "contains state=True" in out
 
-    @pytest.mark.parametrize("stateful", [True, False])
-    def test_tdm_print(self, stateful, capfd):
+    def test_tdm_print(self, capfd):
         """Test that printing a result object with TDM samples provides the correct output."""
         samples = np.ones((2, 3, 4))
-        result = Result(samples, is_stateful=stateful)
+        result = Result({"samples": samples})
         print(result)
         out, err = capfd.readouterr()
         assert "spatial_modes=3" in out
         assert "shots=2" in out
         assert "timebins=4" in out
-        assert f"contains state={stateful}" in out
+        assert "contains state=False" in out
 
-    @pytest.mark.parametrize("stateful", [True, False])
-    def test_unkown_shape_print(self, stateful, capfd):
+    def test_unkown_shape_print(self, capfd):
         """Test that printing a result object with samples with an unknown shape
         provides the correct output."""
         samples = np.ones((2, 3, 4, 5))
-        result = Result(samples, is_stateful=stateful)
+        result = Result({"samples": samples})
         print(result)
         out, err = capfd.readouterr()
         assert "modes" not in out
         assert "shots" not in out
         assert "timebins" not in out
-        assert f"contains state={stateful}" in out
+        assert "contains state=False" in out

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -27,7 +27,7 @@ class TestResult:
 
     def test_stateless_print(self, capfd):
         """Test that printing a result object with no state provides the correct output."""
-        result = Result({"samples": np.array([[1, 2], [3, 4], [5, 6]])})
+        result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])]})
         print(result)
         out, err = capfd.readouterr()
         assert "modes=2" in out
@@ -36,7 +36,7 @@ class TestResult:
 
     def test_state_print(self, capfd):
         """Test that printing a result object with a state provides the correct output."""
-        result = Result({"samples": np.array([[1, 2], [3, 4], [5, 6]])})
+        result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])]})
         result._state = [[1, 2], [3, 4]]
         print(result)
         out, err = capfd.readouterr()
@@ -47,7 +47,7 @@ class TestResult:
     def test_tdm_print(self, capfd):
         """Test that printing a result object with TDM samples provides the correct output."""
         samples = np.ones((2, 3, 4))
-        result = Result({"samples": samples})
+        result = Result({"output": [samples]})
         print(result)
         out, err = capfd.readouterr()
         assert "spatial_modes=3" in out
@@ -59,7 +59,7 @@ class TestResult:
         """Test that printing a result object with samples with an unknown shape
         provides the correct output."""
         samples = np.ones((2, 3, 4, 5))
-        result = Result({"samples": samples})
+        result = Result({"output": [samples]})
         print(result)
         out, err = capfd.readouterr()
         assert "modes" not in out

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -256,7 +256,7 @@ class TestBosonicCatStates:
 
             backend = bosonic.BosonicBackend()
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0], results[1][0]
+            res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
 
@@ -341,7 +341,7 @@ class TestBosonicFockStates:
 
             backend = bosonic.BosonicBackend()
             _, results = backend.run_prog(prog)
-            res0 = results[0][0]
+            res0 = results[0][0][0]
             if n == 0:
                 assert res0 == 0
             else:
@@ -361,7 +361,7 @@ class TestBosonicFockStates:
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0], results[1][0]
+            res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
     def test_g2_threshold(self):
@@ -377,7 +377,7 @@ class TestBosonicFockStates:
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0], results[1][0]
+            res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
 
@@ -620,7 +620,7 @@ class TestBosonicPrograms:
         # Check samples
         for i in range(2):
             assert i in samples_dict.keys()
-            assert samples_dict[i].shape == (1,)
+            assert samples_dict[i].shape == (1, 1)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
@@ -641,7 +641,7 @@ class TestBosonicPrograms:
 
         # Check samples
         assert 0 in samples_dict.keys()
-        assert samples_dict[0].shape == (int(shots),)
+        assert samples_dict[0].shape == (1, int(shots))
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -255,7 +255,7 @@ class TestBosonicCatStates:
                 sf.ops.MeasureThreshold() | q[1]
 
             backend = bosonic.BosonicBackend()
-            _, _, results = backend.run_prog(prog)
+            _, results = backend.run_prog(prog)
             res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
@@ -340,7 +340,7 @@ class TestBosonicFockStates:
                 sf.ops.MeasureThreshold() | q[0]
 
             backend = bosonic.BosonicBackend()
-            _, _, results = backend.run_prog(prog)
+            _, results = backend.run_prog(prog)
             res0 = results[0][0][0]
             if n == 0:
                 assert res0 == 0
@@ -360,7 +360,7 @@ class TestBosonicFockStates:
 
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
-            _, _, results = backend.run_prog(prog)
+            _, results = backend.run_prog(prog)
             res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
@@ -376,7 +376,7 @@ class TestBosonicFockStates:
 
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
-            _, _, results = backend.run_prog(prog)
+            _, results = backend.run_prog(prog)
             res0, res1 = results[0][0][0], results[1][0][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
@@ -611,7 +611,7 @@ class TestBosonicPrograms:
             sf.ops.MeasureX | q[0]
             sf.ops.MeasureHD | q[1]
         backend = bosonic.BosonicBackend()
-        applied, samples, all_samples = backend.run_prog(prog)
+        applied, samples_dict = backend.run_prog(prog)
         state = backend.state()
 
         # Check output is vacuum since everything was measured
@@ -619,8 +619,8 @@ class TestBosonicPrograms:
 
         # Check samples
         for i in range(2):
-            assert i in samples.keys()
-            assert samples[i].shape == (1,)
+            assert i in samples_dict.keys()
+            assert samples_dict[i].shape == (1,)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
@@ -633,15 +633,15 @@ class TestBosonicPrograms:
             sf.ops.MeasureHomodyne(0) | q[0]
 
         backend = bosonic.BosonicBackend()
-        applied, samples, all_samples = backend.run_prog(prog, shots=shots)
+        applied, samples_dict = backend.run_prog(prog, shots=shots)
         state = backend.state()
 
         # Check output is vacuum since everything was measured
         assert np.allclose(state.fidelity_vacuum(), 1)
 
         # Check samples
-        assert 0 in samples.keys()
-        assert samples[0].shape == (int(shots),)
+        assert 0 in samples_dict.keys()
+        assert samples_dict[0].shape == (int(shots),)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)
@@ -653,13 +653,13 @@ class TestBosonicPrograms:
             sf.ops.MSgate(1, 0, 1, 1, avg=False) | q[1]
             sf.ops.MSgate(1, 0, 1, 1, avg=False) | q[1]
         backend = bosonic.BosonicBackend()
-        applied, samples, all_samples = backend.run_prog(prog)
+        applied, samples_dict = backend.run_prog(prog)
 
         # Check number of active modes did not change
         assert backend.get_modes() == [0, 1]
 
         # Check samples for the data modes are empty
-        assert samples == {}
+        assert samples_dict == {}
 
         # Check ancilla samples exist for the second mode
         ancilla_samples = backend.ancillae_samples_dict

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -256,7 +256,7 @@ class TestBosonicCatStates:
 
             backend = bosonic.BosonicBackend()
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0][0], results[1][0][0]
+            res0, res1 = results[0][0], results[1][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
 
@@ -341,7 +341,7 @@ class TestBosonicFockStates:
 
             backend = bosonic.BosonicBackend()
             _, results = backend.run_prog(prog)
-            res0 = results[0][0][0]
+            res0 = results[0][0]
             if n == 0:
                 assert res0 == 0
             else:
@@ -361,7 +361,7 @@ class TestBosonicFockStates:
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0][0], results[1][0][0]
+            res0, res1 = results[0][0], results[1][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
     def test_g2_threshold(self):
@@ -377,7 +377,7 @@ class TestBosonicFockStates:
             backend = bosonic.BosonicBackend()
             results = backend.run_prog(prog)
             _, results = backend.run_prog(prog)
-            res0, res1 = results[0][0][0], results[1][0][0]
+            res0, res1 = results[0][0], results[1][0]
             assert ([res0, res1] == [0, 1]) or ([res0, res1] == [1, 0])
 
 

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -620,7 +620,7 @@ class TestBosonicPrograms:
         # Check samples
         for i in range(2):
             assert i in samples_dict.keys()
-            assert samples_dict[i].shape == (1, 1)
+            assert samples_dict[i][0].shape == (1,)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)
@@ -641,7 +641,7 @@ class TestBosonicPrograms:
 
         # Check samples
         assert 0 in samples_dict.keys()
-        assert samples_dict[0].shape == (1, int(shots))
+        assert samples_dict[0][0].shape == (int(shots),)
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("r", R_VALS)

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -253,7 +253,7 @@ class TestEngineProgramInteraction:
         assert [bool(i) for i in result.samples[0]] == correct_samples
 
     @pytest.mark.parametrize("eng", engines)
-    def test_all_samples_one_meas_per_mode(self, eng):
+    def test_samples_dict_one_measurement_per_mode(self, eng):
         """Test that samples are stored for the correct modes with
         a single measurement each mode."""
         prog = sf.Program(5)
@@ -265,17 +265,17 @@ class TestEngineProgramInteraction:
 
         # Check that the number of all the samples equals to the number
         # of measurements
-        assert len(result.all_samples.values()) == 3
+        assert len(result.samples_dict.values()) == 3
 
         correct_modes = [2, 1, 3]
         correct_samples = [[0], [0], [0]]
 
-        assert result.all_samples[1] == [0]
-        assert result.all_samples[3] == [0]
-        assert result.all_samples[2] == [0]
+        assert result.samples_dict[1] == [0]
+        assert result.samples_dict[3] == [0]
+        assert result.samples_dict[2] == [0]
 
     @pytest.mark.parametrize("eng", engines)
-    def test_all_samples_multi_meas_per_mode(self, eng):
+    def test_samples_dict_multiple_measurements_per_mode(self, eng):
         """Test that samples are stored for the correct modes with
         multiple measurements on certain modes."""
         prog = sf.Program(5)
@@ -286,13 +286,13 @@ class TestEngineProgramInteraction:
 
         result = eng.run(prog)
 
-        assert result.all_samples[1] == [0]
-        assert result.all_samples[3] == [0]
-        assert [bool(i) for i in result.all_samples[2]] == [0, 1]
+        assert result.samples_dict[1] == [0]
+        assert result.samples_dict[3] == [0]
+        assert [bool(i) for i in result.samples_dict[2]] == [0, 1]
 
     @pytest.mark.parametrize("eng", engines)
-    def test_all_samples_multi_runs(self, eng):
-        """Test that consequtive engine runs reset the _all_samples
+    def test_samples_dict_multiple_runs(self, eng):
+        """Test that consecutive engine runs reset the samples_dict
         attribute by checking the length of the attribute."""
         prog = sf.Program(5)
         with prog.context as q:
@@ -304,9 +304,9 @@ class TestEngineProgramInteraction:
 
         # Check that the number of all the samples equals to the number
         # of measurements
-        assert result.all_samples[1] == [0]
-        assert result.all_samples[3] == [0]
-        assert [bool(i) for i in result.all_samples[2]] == [0, 1]
+        assert result.samples_dict[1] == [0]
+        assert result.samples_dict[3] == [0]
+        assert [bool(i) for i in result.samples_dict[2]] == [0, 1]
 
         prog = sf.Program(5)
         with prog.context as q:
@@ -314,11 +314,11 @@ class TestEngineProgramInteraction:
 
         result = eng.run(prog)
 
-        # Check that _all_samples contains the same elements and new items were
+        # Check that samples_dict contains the same elements and new items were
         # not appended
-        assert result.all_samples[0] == [0]
+        assert result.samples_dict[0] == [0]
 
-    def test_all_samples_multiple_shots(self):
+    def test_samples_dict_multiple_shots(self):
         """Test the case of storing all samples for multiple shots"""
         eng = sf.Engine("gaussian", backend_options={"cutoff_dim": 6})
         shots = 5
@@ -330,16 +330,16 @@ class TestEngineProgramInteraction:
 
         result = eng.run(prog, shots=shots)
 
-        assert len(result.all_samples[1]) == 1
-        assert len(result.all_samples[3]) == 1
-        assert len(result.all_samples[2]) == 2
+        assert len(result.samples_dict[1]) == 1
+        assert len(result.samples_dict[3]) == 1
+        assert len(result.samples_dict[2]) == 2
 
-        assert np.array_equal(result.all_samples[1][0], np.array([0, 0, 0, 0, 0]))
-        assert np.array_equal(result.all_samples[3][0], np.array([0, 0, 0, 0, 0]))
-        assert np.array_equal(result.all_samples[2][0], np.array([0, 0, 0, 0, 0]))
-        assert np.array_equal(result.all_samples[2][1], np.array([0, 0, 0, 0, 0]))
+        assert np.array_equal(result.samples_dict[1][0], np.array([0, 0, 0, 0, 0]))
+        assert np.array_equal(result.samples_dict[3][0], np.array([0, 0, 0, 0, 0]))
+        assert np.array_equal(result.samples_dict[2][0], np.array([0, 0, 0, 0, 0]))
+        assert np.array_equal(result.samples_dict[2][1], np.array([0, 0, 0, 0, 0]))
 
-    def test_all_samples_batched(self):
+    def test_samples_dict_batched(self):
         """Test the case of storing all samples for batches"""
         batch_size = 2
         eng = sf.Engine("tf", backend_options={"batch_size": batch_size, "cutoff_dim": 6})
@@ -350,14 +350,14 @@ class TestEngineProgramInteraction:
             ops.MeasureFock() | q[2]
 
         result = eng.run(prog)
-        assert len(result.all_samples[1]) == 1
-        assert len(result.all_samples[3]) == 1
-        assert len(result.all_samples[2]) == 2
+        assert len(result.samples_dict[1]) == 1
+        assert len(result.samples_dict[3]) == 1
+        assert len(result.samples_dict[2]) == 2
 
-        assert np.array_equal(result.all_samples[1][0].numpy(), np.array([[0], [0]]))
-        assert np.array_equal(result.all_samples[3][0].numpy(), np.array([[0], [0]]))
-        assert np.array_equal(result.all_samples[2][0].numpy(), np.array([[0], [0]]))
-        assert np.array_equal(result.all_samples[2][1].numpy(), np.array([[0], [0]]))
+        assert np.array_equal(result.samples_dict[1][0].numpy(), np.array([[0], [0]]))
+        assert np.array_equal(result.samples_dict[3][0].numpy(), np.array([[0], [0]]))
+        assert np.array_equal(result.samples_dict[2][0].numpy(), np.array([[0], [0]]))
+        assert np.array_equal(result.samples_dict[2][1].numpy(), np.array([[0], [0]]))
 
 
 class TestMultipleShotsErrors:

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -82,7 +82,7 @@ class TestEngineProgramInteraction:
             ops.MeasureFock() | q
 
         results = eng.run(prog)
-        assert results.samples.shape[0] == 1
+        assert len(results.samples) == 1
 
     def test_shots_run_options(self):
         """Test that run_options takes precedence over default"""
@@ -95,7 +95,7 @@ class TestEngineProgramInteraction:
 
         prog.run_options = {"shots": 5}
         results = eng.run(prog)
-        assert results.samples.shape[0] == 5
+        assert len(results.samples) == 5
 
     def test_shots_passed(self):
         """Test that shots supplied via eng.run takes precedence over
@@ -109,7 +109,7 @@ class TestEngineProgramInteraction:
 
         prog.run_options = {"shots": 5}
         results = eng.run(prog, shots=2)
-        assert results.samples.shape[0] == 2
+        assert len(results.samples) == 2
         assert prog.run_options["shots"] == 5
 
     def test_history(self, eng, prog):
@@ -229,7 +229,7 @@ class TestEngineProgramInteraction:
         # check that shape is (shots, measured_modes)
         assert result.samples.shape == (1, 4)
 
-        # check that MesureFock measures `0` while MeasureX does NOT measure `0`.
+        # check that MessureFock measures `0` while MeasureX does NOT measure `0`.
         correct_samples = [0, 0, 1, 0]
         assert [bool(i) for i in result.samples[0]] == correct_samples
 
@@ -248,7 +248,7 @@ class TestEngineProgramInteraction:
         # check that shape is (shots, measured_modes)
         assert result.samples.shape == (1, 3)
 
-        # check that MesureFock measures `0` while MeasureX does NOT measure `0`.
+        # check that MeasureFock measures `0` while MeasureX does NOT measure `0`.
         correct_samples = [0, 1, 0]
         assert [bool(i) for i in result.samples[0]] == correct_samples
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -699,7 +699,7 @@ class TestEngineTDMProgramInteraction:
             ops.MeasureHomodyne(p[1]) | q[0]
 
         results = eng.run(prog)
-        assert results.samples.shape[0] == 1
+        assert len(results.samples) == 1
 
     def test_shots_run_options(self):
         """Test that run_options takes precedence over default"""
@@ -712,7 +712,7 @@ class TestEngineTDMProgramInteraction:
 
         prog.run_options = {"shots": 5}
         results = eng.run(prog)
-        assert results.samples.shape[0] == 5
+        assert len(results.samples) == 5
 
     def test_shots_passed(self):
         """Test that shots supplied via eng.run takes precedence over
@@ -726,7 +726,7 @@ class TestEngineTDMProgramInteraction:
 
         prog.run_options = {"shots": 5}
         results = eng.run(prog, shots=2)
-        assert results.samples.shape[0] == 2
+        assert len(results.samples) == 2
         assert prog.run_options["shots"] == 5
 
     def test_shots_with_timebins_non_multiple_of_concurrent_modes(self):


### PR DESCRIPTION
**Context:**
As part of the XCC integration, the Result class needs to be updated.

**Description of the Change:**
* The `Result` class now only takes a result dictionary containing all samples.
* The `samples` property returns the first entry in the result dictionary (which should be the pure samples).
* `all_samples` have been renamed to `samples_dict`.
* `Result._is_stateful` has been removed in favour of `self._state is not None`.

**Benefits:**
Things work better together with XCC and the dictionary type samples that will be returned from the HW.

**Possible Drawbacks:**
* The `samples` property returns the first entry in the result dictionary _assuming_ they are the pure samples).
* `Result._is_stateful` has been removed, and does not seem to have a clear use case.

**Related GitHub Issues:**
None
