### PR TITLE
Add missed API extraction updates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -323,7 +323,9 @@
   been moved to the root `strawberryfields` folder. They can now be imported as follows:
 
   ```python
-  from strawberryfields import DeviceSpec, Result
+  import strawberryfields  as sf
+  # sf.DeviceSpec
+  # sf.Result
   ```
 
 <h3>Bug fixes</h3>

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -38,6 +38,8 @@ __all__ = [
     "RemoteEngine",
     "Program",
     "TDMProgram",
+    "DeviceSpec",
+    "Result",
     "version",
     "save",
     "load",


### PR DESCRIPTION
**Context:**
These changes should've been included in the #652 PR. 

**Description of the Change:**
* Adds `DeviceSpec` and `Result` to `strawberryfields.__init__.__all__`.
* Updates a code snippet in the changelog regarding how to use `DeviceSpec` and `Result`.

**Benefits:**
Things are slightly nicer.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
