### PR TITLE
Remove `fill_template` calls in `RemoteEngine.run_async`

### DIFF
--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -719,9 +719,6 @@ class RemoteEngine:
         kwargs.update(self._backend_options)
 
         device = self.device_spec
-        if isinstance(program, TDMProgram) and not device.layout_is_formatted():
-            device.fill_template(program)
-
         compiler_name = compile_options.get("compiler", device.default_compiler)
 
         program_is_compiled = program.compile_info is not None


### PR DESCRIPTION
**Context:**
Some traces of removed methods were left from the `DeviceSpec` XCC integration update.

**Description of the Change:**
Removes non-existing `DeviceSpec.fill_template` and `DeviceSpec.is_formatted` calls in `RemoteEngine.run_async`

**Benefits:**
It will now work to run TDM programs remotely using the updated `DeviceSpec` class.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
