### PR TITLE
Compile info and target to `TDMProgram.compile`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 <h3>Bug fixes</h3>
 
+* ``program.compile_info`` and ``program.target`` are correctly set if compilation is successfully
+  completed when compiling a ``TDMProgram``.
+  [(#659)](https://github.com/XanaduAI/strawberryfields/pull/659)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Theodor Isacsson
 
 # Release 0.20.0 (current release)
 

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -598,7 +598,7 @@ class Program:
                 program compilation
             compiler (str, ~strawberryfields.compilers.Compiler): Compiler name or compile strategy
                 to use. If a device is specified, this overrides the compile strategy specified by
-                the hardware :class:`~.DevicSpec`.
+                the hardware :class:`~.DeviceSpec`.
 
         Keyword Args:
             optimize (bool): If True, try to optimize the program by merging and canceling gates.

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -437,9 +437,11 @@ class TDMProgram(Program):
 
     # pylint: disable=too-many-branches
     def compile(self, *, device=None, compiler=None):
-        """Compile the time-domain program given a Strawberry Fields photonic hardware device specification.
+        """Compile the time-domain program given a Strawberry Fields photonic hardware device
+        specification.
 
-        Currently, the compilation is simply a check that the program matches the device.
+        The compilation simply checks that the program matches the device and sets the compile
+        information and the program target to the correct device target.
 
         Args:
             device (~strawberryfields.DeviceSpec): device specification object to use for

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -440,8 +440,8 @@ class TDMProgram(Program):
         """Compile the time-domain program given a Strawberry Fields photonic hardware device
         specification.
 
-        The compilation simply checks that the program matches the device and sets the compile
-        information and the program target to the correct device target.
+        The compilation checks that the program matches the device and sets the compile information
+        and the program target to the correct device target.
 
         Args:
             device (~strawberryfields.DeviceSpec): device specification object to use for

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -557,6 +557,8 @@ class TDMProgram(Program):
                                     device.target, program_param, param_range
                                 )
                             )
+            self._compile_info = (device, "TDM")
+            self._target = device.target
             return self
 
         raise CircuitError("TDM programs cannot be compiled without a valid device specification.")


### PR DESCRIPTION
**Context:**
The `Program.compile` method sets the program target (which is `None` at start) to the device target (e.g., `X8_01`) and updates `Program.compile_info`. This never happens in `TDMProgram.compile`, so `prog.target` is always `None`, which in turn causes the Blackbird serialize method to ignore the passed shots option, since it has no target name.

For example, the BlackbirdProgram.target for a regular `sf.Program` could be `{'name': 'X8_01', 'options': {'shots': 1}}` which would serialize into target `X8_01 (shots=1)`. The corresponding for an `sf.TDMProgram` would be `{'name': None, 'options': {'shots': 1}}`, which wouldn’t serialize since there’s no target name.

**Description of the Change:**
`program.compile_info` and `program.target` are set if compilation (i.e., validation) is successful for the `TDMProgram`.

**Benefits:**
The correct target is now passed along correctly to the program when compiling, and is correctly serialized into a Blackbird script before being sent to hardware.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
