### PR TITLE
Update max measurements check

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 * Updates `Program.assert_max_number_of_measurements` to expect the maximum number
   of measurements from the device specification as a flat dictionary entry instead
-  of a nested one:
+  of a nested one.
+  [(#662)](https://github.com/XanaduAI/strawberryfields/pull/662)
 
   ```python
   "modes": {

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,30 @@
   a `TDMProgram` is compiled using the "TDM" compiler.
   [(#659)](https://github.com/XanaduAI/strawberryfields/pull/659)
 
+* Updates `Program.assert_max_number_of_measurements` to expect the maximum number
+  of measurements from the device specification as a flat dictionary entry instead
+  of a nested one:
+
+  ```python
+  "modes": {
+      "pnr_max": 20,
+      "homodyne_max": 1000,
+      "heterodyne_max": 1000,
+  }
+  ```
+
+  instead of
+
+  ```python
+  "modes": {
+      "max": {
+          "pnr": 20,
+          "homodyne": 1000,
+          "heterodyne": 1000,
+      }
+  }
+  ```
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -606,7 +606,7 @@ class Program:
             warn_connected (bool): If True, the user is warned if the quantum circuit is not weakly
                 connected. The default is True.
             shots (int): Number of times the program measurement evaluation is repeated. Passed
-                along to the compiled program's `run_options`.
+                along to the compiled program's ``run_options``.
 
         Returns:
             Program: compiled program

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -530,9 +530,14 @@ class Program:
             max_homodyne = device.modes["homodyne_max"]
             max_heterodyne = device.modes["heterodyne_max"]
         except (KeyError, TypeError) as e:
+            device_modes = device.modes
+            if isinstance(device.modes, dict):
+                device_modes = set(device.modes.keys())
+
             raise KeyError(
-                "Device specification must contain an entry for the maximum allowed number "
-                "of measurements. Have you specified the correct target?"
+                "Expected keys for the maximum allowed number of PNR ('pnr_max'), homodyne "
+                "('homodyne_max'), and heterodyne ('heterodyne_max') measurements. Got keys "
+                f"{device_modes}"
             ) from e
 
         for c in self.circuit:

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -526,13 +526,13 @@ class Program:
         num_pnr, num_homodyne, num_heterodyne = 0, 0, 0
 
         try:
-            max_pnr = device.modes["max"]["pnr"]
-            max_homodyne = device.modes["max"]["homodyne"]
-            max_heterodyne = device.modes["max"]["heterodyne"]
+            max_pnr = device.modes["pnr_max"]
+            max_homodyne = device.modes["homodyne_max"]
+            max_heterodyne = device.modes["heterodyne_max"]
         except (KeyError, TypeError) as e:
             raise KeyError(
                 "Device specification must contain an entry for the maximum allowed number "
-                "of measurments. Have you specified the correct target?"
+                "of measurements. Have you specified the correct target?"
             ) from e
 
         for c in self.circuit:
@@ -605,6 +605,8 @@ class Program:
                 The default is False.
             warn_connected (bool): If True, the user is warned if the quantum circuit is not weakly
                 connected. The default is True.
+            shots (int): Number of times the program measurement evaluation is repeated. Passed
+                along to the compiled program's `run_options`.
 
         Returns:
             Program: compiled program

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -277,7 +277,7 @@ class TestProgram:
             ops.S2gate(0.6) | [q[0], q[1]]
             ops.S2gate(0.6) | [q[1], q[2]]
 
-        with pytest.raises(KeyError, match="Have you specified the correct target?"):
+        with pytest.raises(KeyError, match="Expected keys for the maximum allowed number of PNR"):
             prog.assert_max_number_of_measurements(spec)
 
     def test_has_post_selection(self):

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -245,7 +245,7 @@ class TestProgram:
         # set maximum number of measurements to 2, and measure 3 in prog below
         device_dict = {
             "target": "simulon_gaussian",
-            "modes": {"max": {"pnr": 2, "homodyne": 2, "heterodyne": 2}},
+            "modes": {"pnr_max": 2, "homodyne_max": 2, "heterodyne_max": 2},
             "layout": "",
             "gate_parameters": {},
             "compiler": ["gaussian"],
@@ -565,7 +565,7 @@ class TestValidation:
         # set maximum number of measurements to 2, and measure 3 in prog below
         device_dict = {
             "target": "simulon_gaussian",
-            "modes": {"max": {"pnr": 2, "homodyne": 2, "heterodyne": 2}},
+            "modes": {"pnr_max": 2, "homodyne_max": 2, "heterodyne_max": 2},
             "layout": "",
             "gate_parameters": {},
             "compiler": ["gaussian"],

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -260,6 +260,28 @@ class TestProgram:
         with pytest.raises(program.CircuitError, match=f"contains 3 {measure_name} measurements"):
             prog.assert_max_number_of_measurements(spec)
 
+    def test_keyerror_assert_max_number_of_measurements(self):
+        """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
+        with an incorrect device spec modes entry."""
+        # set maximum number of measurements to 2, and measure 3 in prog below
+        device_dict = {
+            "target": "simulon_gaussian",
+            "modes": {"max": {"pnr": 2, "homodyne": 2, "heterodyne": 2}},
+            "layout": "",
+            "gate_parameters": {},
+            "compiler": ["gaussian"],
+        }
+        spec = sf.DeviceSpec(spec=device_dict)
+
+        prog = sf.Program(3)
+        with prog.context as q:
+            for reg in q:
+                ops.MeasureFock() | reg
+
+        match = "Expected keys for the maximum allowed number of PNR"
+        with pytest.raises(KeyError, match=match):
+            prog.assert_max_number_of_measurements(spec)
+
     def test_assert_max_number_of_measurements_wrong_entry(self):
         """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
         with the incorrect type of device spec mode entry."""


### PR DESCRIPTION
**Context:**
The platform returns a flat dictionary entry for the maximum number of measurements allowed when running jobs on Simulon. Strawberry Fields currently expects a nested dictionary entry (which was added in #545).

**Description of the Change:**
`Program.assert_max_number_of_measurements` is updated to use the flat modes entry when checking for maximum allowed measurements. 

**Benefits:**
`simulon_gaussian` is one step closer to working again.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
