### PR TITLE
Raw results and metadata

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <h3>New features since last release</h3>
 
+* A `Result.raw` property is added to retrieve the raw results from a job.
+  [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
+
+* A `Result.metadata` property is added to retrieve the job results metadata.
+  [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
+
+* A setter method for `Result.state` is added for setting a state for a local simulation if a state
+  has not previously been set.
+  [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
+
 <h3>Breaking Changes</h3>
 
 <h3>Bug fixes</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 <h3>New features since last release</h3>
 
-* A `Result.raw` property is added to retrieve the raw results from a job.
-  [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
-
 * A `Result.metadata` property is added to retrieve the metadata of a job result.
   [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 * A `Result.raw` property is added to retrieve the raw results from a job.
   [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
 
-* A `Result.metadata` property is added to retrieve the job results metadata.
+* A `Result.metadata` property is added to retrieve the metadata of a job result.
   [(#663)](https://github.com/XanaduAI/strawberryfields/pull/663)
 
 * A setter method for `Result.state` is added for setting a state for a local simulation if a state

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -672,7 +672,7 @@ Antal Száva, Federico Rueda, Yuan Yao.
       sf.ops.MSgate(r, phi=0, r_anc=1.2, eta_anc=1, avg=False) | q
 
   results = eng.run(prog)
-  ancilla_samples = results.ancilla_samples
+  ancillae_samples = results.ancillae_samples
 
   xvec = np.arange(-5, 5, 0.01)
   pvec = np.arange(-5, 5, 0.01)

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -95,7 +95,7 @@ which is responsible for executing the program on a specified backend
 
 .. code-block:: python3
 
-    # intialize the fock backend with a
+    # initialize the fock backend with a
     # Fock cutoff dimension (truncation) of 5
     eng = sf.Engine("fock", backend_options={"cutoff_dim": 5})
 
@@ -234,7 +234,7 @@ the mathematical functions in the :data:`strawberryfields.math` namespace.
         ops.Sgate(1 - sf.math.sin(q[0].par)) | q[1]  # measured parameter
         ops.MeasureFock()    | q[1]
 
-    # intialize the Fock backend
+    # initialize the Fock backend
     eng = sf.Engine('fock', backend_options={'cutoff_dim': 5})
 
     # run the program, with the free parameter 'a' bound to the value 0.9

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,3 +17,4 @@ sphinxcontrib-bibtex==0.4.2
 tensorflow==2.6.1
 thewalrus>=0.17.0
 toml
+mistune==0.8.4

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -132,11 +132,11 @@ class BosonicBackend(BaseBosonic):
             Ket,
             _New_modes,
         )
-        ancilla_gates = (MSgate,)
+        ancillae_gates = (MSgate,)
         for cmd in prog.circuit:
             # For ancilla-assisted gates, if they return measurement values, store
             # them in ancillae_samples_dict
-            if isinstance(cmd.op, ancilla_gates):
+            if isinstance(cmd.op, ancillae_gates):
                 # if the op returns a measurement outcome store it in a dictionary
                 val = cmd.op.apply(cmd.reg, self, **kwargs)
                 if val is not None:
@@ -747,8 +747,8 @@ class BosonicBackend(BaseBosonic):
         Returns:
             float: the measurement outcome of the ancilla
         """
-        ancilla_val = self.circuit.mb_squeeze_single_shot(mode, r, phi, r_anc, eta_anc)
-        return ancilla_val
+        ancillae_val = self.circuit.mb_squeeze_single_shot(mode, r, phi, r_anc, eta_anc)
+        return ancillae_val
 
     def beamsplitter(self, theta, phi, mode1, mode2):
         self.circuit.beamsplitter(theta, phi, mode1, mode2)

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -197,7 +197,7 @@ class BaseEngine(abc.ABC):
             print_fn (function): optional custom function to use for string printing.
         """
         for k, r in enumerate(self.run_progs):
-            print_fn("Run {}:".format(k))
+            print_fn(f"Run {k}:")
             r.print(print_fn)
 
     @abc.abstractmethod
@@ -265,7 +265,7 @@ class BaseEngine(abc.ABC):
                 # there was a previous program segment
                 if not p.can_follow(prev):
                     raise RuntimeError(
-                        "Register mismatch: program {}, '{}'.".format(len(self.run_progs), p.name)
+                        f"Register mismatch: program {len(self.run_progs)}, '{p.name}'."
                     )
 
                 # Copy the latest measured values in the RegRefs of p.
@@ -336,7 +336,7 @@ class LocalEngine(BaseEngine):
         return super().__new__(cls)
 
     def __str__(self):
-        return self.__class__.__name__ + "({})".format(self.backend_name)
+        return self.__class__.__name__ + f"({self.backend_name})"
 
     def reset(self, backend_options=None):
         backend_options = backend_options or {}
@@ -374,15 +374,14 @@ class LocalEngine(BaseEngine):
             except NotApplicableError:
                 # command is not applicable to the current backend type
                 raise NotApplicableError(
-                    "The operation {} cannot be used with {}.".format(cmd.op, self.backend)
+                    f"The operation {cmd.op} cannot be used with {self.backend}."
                 ) from None
 
             except NotImplementedError:
                 # command not directly supported by backend API
                 raise NotImplementedError(
-                    "The operation {} has not been implemented in {} for the arguments {}.".format(
-                        cmd.op, self.backend, kwargs
-                    )
+                    f"The operation {cmd.op} has not been implemented in {self.backend} for the "
+                    f"arguments {kwargs}."
                 ) from None
 
         # combine the samples sorted by mode, and cast correctly to array or tensor
@@ -788,9 +787,7 @@ class RemoteEngine:
         return job
 
     def __repr__(self):
-        return "<{}: target={}, connection={}>".format(
-            self.__class__.__name__, self.target, self._connection
-        )
+        return f"<{self.__class__.__name__}: target={self.target}, connection={self._connection}>"
 
     def __str__(self):
         return self.__repr__()

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -523,7 +523,7 @@ class LocalEngine(BaseEngine):
             # state object requested
             # session and feed_dict are needed by TF backend both during simulation (if program
             # contains measurements) and state object construction.
-            result._state = self.backend.state(**temp_run_options)
+            result.state = self.backend.state(**temp_run_options)
             if self.backend_name == "bosonic":
                 result._ancilla_samples = self.backend.ancillae_samples_dict.copy()
         return result

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -274,7 +274,7 @@ class BaseEngine(abc.ABC):
                 # Copy the latest measured values in the RegRefs of p.
                 # We cannot copy from prev directly because it could be used in more than one
                 # engine.
-                for k, v in enumerate(self.samples or []):
+                for k, v in enumerate(self.samples):
                     p.reg_refs[k].val = v
 
             # bind free parameters to their values

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -1446,8 +1446,8 @@ class MSgate(Channel):
             return None
 
         s = np.sqrt(sf.hbar / 2)
-        ancilla_val = backend.mb_squeeze_single_shot(*reg, r, phi, r_anc, eta_anc)
-        return ancilla_val / s
+        ancillae_val = backend.mb_squeeze_single_shot(*reg, r, phi, r_anc, eta_anc)
+        return ancillae_val / s
 
 
 class PassiveChannel(Channel):

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -86,8 +86,13 @@ class Result:
     def raw(self) -> Mapping[str, Union[np.ndarray, List[np.ndarray]]]:
         """The raw results dictionary containing any samples and metadata.
 
+        .. warning::
+
+            The raw values are returned by reference, meaning that any changes to
+            them will be reflected in the ``Result`` object.
+
         Returns:
-            dict: samples and metadata
+            Mapping[str, Union[np.ndarray, List[np.ndarray]]: samples and metadata
         """
         return self._result
 
@@ -98,7 +103,7 @@ class Result:
         Returned measurement samples will have shape ``(shots, modes)``.
 
         Returns:
-            array[array[float, int]]: measurement samples returned from
+            ndarray[ndarray[float, int]]: measurement samples returned from
             program execution
         """
         output = self._result.get("output")
@@ -129,7 +134,7 @@ class Result:
             dictionary, on the other hand, keeps _all_ measurements.
 
         Returns:
-            dict[int, list]: mode index associated with the list of measurement outcomes
+            Mapping[int, List]: mode index associated with the list of measurement outcomes
         """
         return self._samples_dict
 
@@ -141,7 +146,7 @@ class Result:
         except for the samples, which is stored under the "output" key.
 
         Returns:
-            dict: dictionary containing job result metadata
+            Mapping[str, np.ndarray]: dictionary containing job result metadata
         """
         metadata = {key: val for key, val in self._result.items() if key != "output"}
         return metadata
@@ -156,7 +161,7 @@ class Result:
         gates applied to that mode.
 
         Returns:
-            dict[int, list]: mode index associated with the list of ancilla
+            Mapping[int, List]: mode index associated with the list of ancilla
             measurement outcomes
         """
         return self._ancillae_samples
@@ -197,7 +202,7 @@ class Result:
         # samples organized by measured mode. `self.samples` is either `None` or an array.
         if self.samples is not None and len(self.samples) != 0 and not self.samples_dict:
             raise ValueError("State can only be set for local simulations.")
-        if not isinstance(state, BaseState):
+        if not (isinstance(state, BaseState) or state is None):
             raise TypeError(f"State must be of type 'BaseState', not '{type(state)}'")
 
         self._state = state

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -185,7 +185,9 @@ class Result:
         """
         if self._state:
             raise TypeError("State already set and cannot be changed.")
-        if not self.samples_dict:
+        # Samples from local simulation jobs will always have a samples_dict containing the same
+        # samples organized by measured mode. `self.samples` is either `None` or an array.
+        if self.samples is not None and len(self.samples) !=0 and not self.samples_dict:
             raise ValueError("State can only be set for local simulations.")
         self._state = state
 

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -129,7 +129,7 @@ class Result:
     def metadata(self) -> Mapping:
         """Metadata for the job results.
 
-        The metadata is considered to be everything contained in the raw results
+        The metadata is considered to be everything contained in the raw result
         except for the samples, which is stored under the "output" key.
 
         Returns:

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -44,8 +44,6 @@ class Result:
 
     * ``results.metadata``: Metadata for job results.
 
-    * ``results.raw``: Raw results retrieved from the job, including samples and metadata.
-
     * ``results.ancillae_samples``: Measurement samples from any ancillary states
       used for measurement-based gates.
 
@@ -81,20 +79,6 @@ class Result:
 
         self._ancillae_samples = kwargs.get("ancillae_samples", None)
         self._samples_dict = kwargs.get("samples_dict", None)
-
-    @property
-    def raw(self) -> Mapping[str, Union[np.ndarray, List[np.ndarray]]]:
-        """The raw results dictionary containing any samples and metadata.
-
-        .. warning::
-
-            The raw values are returned by reference, meaning that any changes to
-            them will be reflected in the ``Result`` object.
-
-        Returns:
-            Mapping[str, Union[ndarray, list[ndarray]]: samples and metadata
-        """
-        return self._result
 
     @property
     def samples(self) -> Optional[np.ndarray]:
@@ -142,7 +126,7 @@ class Result:
     def metadata(self) -> Mapping[str, np.ndarray]:
         """Metadata for the job results.
 
-        The metadata is considered to be everything contained in the raw result
+        The metadata is considered to be everything contained in the raw results
         except for the samples, which is stored under the "output" key.
 
         Returns:

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -219,4 +219,4 @@ class Result:
                 f"contains state={self._state is not None}>"
             )
 
-        return "<Result: contains state={self._state is not None}>"
+        return f"<Result: contains state={self._state is not None}>"

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -16,7 +16,7 @@ This module provides a class that represents the result of a quantum computation
 """
 
 import warnings
-from typing import Mapping, Optional, Union, List
+from typing import Mapping, Optional, List
 
 import numpy as np
 

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -16,7 +16,7 @@ This module provides a class that represents the result of a quantum computation
 """
 
 import warnings
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Union, List
 
 import numpy as np
 
@@ -46,7 +46,7 @@ class Result:
 
     * ``results.raw``: Raw results retrieved from the job, including samples and metadata.
 
-    * ``results.ancilla_samples``: Measurement samples from any ancillary states
+    * ``results.ancillae_samples``: Measurement samples from any ancillary states
       used for measurement-based gates.
 
     **Example:**
@@ -75,13 +75,15 @@ class Result:
         but the return value of ``Result.state`` will be ``None``.
     """
 
-    def __init__(self, result: Mapping, ancilla_samples: Mapping = None) -> None:
+    def __init__(self, result: Mapping, **kwargs) -> None:
         self._state = None
         self._result = result
-        self._ancilla_samples = ancilla_samples
+
+        self._ancillae_samples = kwargs.get("ancillae_samples", None)
+        self._samples_dict = kwargs.get("samples_dict", None)
 
     @property
-    def raw(self) -> Mapping:
+    def raw(self) -> Mapping[str, Union[np.ndarray, List[np.ndarray]]]:
         """The raw results dictionary containing any samples and metadata.
 
         Returns:
@@ -111,7 +113,7 @@ class Result:
         return output[0]
 
     @property
-    def samples_dict(self) -> Mapping:
+    def samples_dict(self) -> Optional[Mapping[int, List]]:
         """All measurement samples as a dictionary. Only available on simulators.
 
         Returns a dictionary which associates each mode (keys) with the list of
@@ -119,14 +121,20 @@ class Result:
         several times. For multiple shots or batched execution, arrays and
         tensors are stored.
 
+        .. note::
+
+            The samples dictionary may contain samples that are not present in
+            the samples array. In the samples array, each time a mode is measured
+            the prior measured sample on the same mode is replaced. The samples
+            dictionary, on the other hand, keeps _all_ measurements.
+
         Returns:
             dict[int, list]: mode index associated with the list of measurement outcomes
         """
-        samples_dict = {key: val for key, val in self._result.items() if isinstance(key, int)}
-        return samples_dict
+        return self._samples_dict
 
     @property
-    def metadata(self) -> Mapping:
+    def metadata(self) -> Mapping[str, np.ndarray]:
         """Metadata for the job results.
 
         The metadata is considered to be everything contained in the raw result
@@ -139,7 +147,7 @@ class Result:
         return metadata
 
     @property
-    def ancilla_samples(self) -> Optional[Mapping]:
+    def ancillae_samples(self) -> Optional[Mapping[int, List]]:
         """All measurement samples from ancillary modes used for measurement-based
         gates.
 
@@ -151,7 +159,7 @@ class Result:
             dict[int, list]: mode index associated with the list of ancilla
             measurement outcomes
         """
-        return self._ancilla_samples
+        return self._ancillae_samples
 
     @property
     def state(self) -> Optional[BaseState]:
@@ -176,7 +184,7 @@ class Result:
         return self._state
 
     @state.setter
-    def state(self, state) -> None:
+    def state(self, state: BaseState) -> None:
         """Set the state on local simulations if not previously set.
 
         Raises:
@@ -189,6 +197,9 @@ class Result:
         # samples organized by measured mode. `self.samples` is either `None` or an array.
         if self.samples is not None and len(self.samples) != 0 and not self.samples_dict:
             raise ValueError("State can only be set for local simulations.")
+        if not isinstance(state, BaseState):
+            raise TypeError(f"State must be of type 'BaseState', not '{type(state)}'")
+
         self._state = state
 
     def __repr__(self) -> str:
@@ -197,12 +208,12 @@ class Result:
             # if samples has dim 2, assume they're from a standard Program
             shots, modes = self.samples.shape
 
-            if self.ancilla_samples is not None:
-                ancilla_modes = 0
-                for i in self.ancilla_samples.keys():
-                    ancilla_modes += len(self.ancilla_samples[i])
+            if self.ancillae_samples is not None:
+                ancillae_modes = 0
+                for i in self.ancillae_samples.keys():
+                    ancillae_modes += len(self.ancillae_samples[i])
                 return (
-                    f"<Result: shots={shots}, num_modes={modes}, num_ancillae={ancilla_modes}, "
+                    f"<Result: shots={shots}, num_modes={modes}, num_ancillae={ancillae_modes}, "
                     f"contains state={self._state is not None}>"
                 )
 

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -175,6 +175,20 @@ class Result:
         """
         return self._state
 
+    @state.setter
+    def state(self, state) -> None:
+        """Set the state on local simulations if not previously set.
+
+        Raises:
+            TypeError: if state is already set
+            ValueError: if result have ``samples_dict`` (i.e, do not come from a local simulation)
+        """
+        if self._state:
+            raise TypeError("State already set and cannot be changed.")
+        if not self.samples_dict:
+            raise ValueError("State can only be set for local simulations.")
+        self._state = state
+
     def __repr__(self) -> str:
         """String representation."""
         if self.samples is not None and self.samples.ndim == 2:

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -187,7 +187,7 @@ class Result:
             raise TypeError("State already set and cannot be changed.")
         # Samples from local simulation jobs will always have a samples_dict containing the same
         # samples organized by measured mode. `self.samples` is either `None` or an array.
-        if self.samples is not None and len(self.samples) !=0 and not self.samples_dict:
+        if self.samples is not None and len(self.samples) != 0 and not self.samples_dict:
             raise ValueError("State can only be set for local simulations.")
         self._state = state
 

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -92,7 +92,7 @@ class Result:
             them will be reflected in the ``Result`` object.
 
         Returns:
-            Mapping[str, Union[np.ndarray, List[np.ndarray]]: samples and metadata
+            Mapping[str, Union[ndarray, list[ndarray]]: samples and metadata
         """
         return self._result
 
@@ -134,7 +134,7 @@ class Result:
             dictionary, on the other hand, keeps _all_ measurements.
 
         Returns:
-            Mapping[int, List]: mode index associated with the list of measurement outcomes
+            Mapping[int, list]: mode index associated with the list of measurement outcomes
         """
         return self._samples_dict
 
@@ -146,7 +146,7 @@ class Result:
         except for the samples, which is stored under the "output" key.
 
         Returns:
-            Mapping[str, np.ndarray]: dictionary containing job result metadata
+            Mapping[str, ndarray]: dictionary containing job result metadata
         """
         metadata = {key: val for key, val in self._result.items() if key != "output"}
         return metadata
@@ -161,7 +161,7 @@ class Result:
         gates applied to that mode.
 
         Returns:
-            Mapping[int, List]: mode index associated with the list of ancilla
+            Mapping[int, list]: mode index associated with the list of ancilla
             measurement outcomes
         """
         return self._ancillae_samples

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -204,15 +204,17 @@ class Result:
                     f"contains state={self._state is not None}>"
                 )
 
-            return "<Result: shots={}, num_modes={}, contains state={}>".format(
-                shots, modes, self._state is not None
+            return (
+                f"<Result: shots={shots}, num_modes={modes}, contains "
+                f"state={self._state is not None}>"
             )
 
         if self.samples is not None and self.samples.ndim == 3:
             # if samples has dim 3, assume they're TDM
             shots, modes, timebins = self.samples.shape
-            return "<Result: shots={}, spatial_modes={}, timebins={}, contains state={}>".format(
-                shots, modes, timebins, self._state is not None
+            return (
+                f"<Result: shots={shots}, spatial_modes={modes}, timebins={timebins}, "
+                f"contains state={self._state is not None}>"
             )
 
-        return "<Result: contains state={}>".format(self._state is not None)
+        return "<Result: contains state={self._state is not None}>"

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -45,11 +45,6 @@ class TestResult:
         assert result.samples is not None
         assert np.array_equal(result.samples, test_samples)
 
-    def test_raw(self):
-        """Test that raw results are correctly returned."""
-        result = Result(raw_results)
-        assert result.raw == raw_results
-
     def test_samples_dict(self):
         """Test that ``samples_dict`` is correctly returned."""
         samples_dict = {0: [1, 2, 3], 1: [4, 5]}

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -16,30 +16,99 @@ Unit tests for strawberryfields.result
 """
 import numpy as np
 import pytest
+from strawberryfields.backends.states import BaseGaussianState
 
 from strawberryfields.result import Result
 
 pytestmark = pytest.mark.api
 
 
+raw_results = {
+    "output": [np.ones((2, 3, 4, 5))],
+    0: [1, 2, 3],
+    1: [4, 5],
+    "other_data": [1, 0, 1, 2],
+    "string": "metadata",
+}
+
+
 class TestResult:
     """Tests for the ``Result`` class."""
+
+    def test_samples(self):
+        """Test that ``samples`` is correctly returned."""
+        result = Result(raw_results)
+        assert result.samples is not None
+        assert np.equal(result.samples, np.ones((2, 3, 4, 5))).all()
+
+    def test_raw(self):
+        """Test that raw results are correctly returned."""
+        result = Result(raw_results)
+        assert result.raw == raw_results
+
+    def test_samples_dict(self):
+        """Test that ``samples_dict`` is correctly returned."""
+        result = Result(raw_results)
+        assert result.samples_dict == {0: [1, 2, 3], 1: [4, 5]}
+
+    def test_ancilla_samples(self):
+        """Test that ancilla samples are correctly returned."""
+        ancilla_samples = {0: [0, 1], 2: [1, 3]}
+        result = Result(raw_results, ancilla_samples=ancilla_samples)
+        assert result.ancilla_samples == ancilla_samples
+
+    def test_state(self):
+        """Test that the state can be correctly set and returned."""
+        state = BaseGaussianState((np.array([0.0, 0.0]), np.identity(2)), 1)
+        result = Result(raw_results)
+        result.state = state
+        assert result.state == state
+
+        with pytest.raises(TypeError, match="State already set and cannot be changed."):
+            result.state = state
+
+    def test_state_no_modes(self):
+        """Test that the correct error is raised when setting a state on remote job result."""
+        raw_results_without_modes = {
+            "output": [np.ones((2, 3, 4, 5))],
+            "other_data": [1, 0, 1, 2],
+            "string": "metadata",
+        }
+        state = BaseGaussianState((np.array([0.0, 0.0]), np.identity(2)), 1)
+        result = Result(raw_results_without_modes)
+
+        with pytest.raises(ValueError, match="State can only be set for local simulations."):
+            result.state = state
+
+    def test_metadata(self):
+        """Test that metadata is correctly returned."""
+        result = Result(raw_results)
+        assert result.metadata == {
+            0: [1, 2, 3],
+            1: [4, 5],
+            "other_data": [1, 0, 1, 2],
+            "string": "metadata",
+        }
+
+
+class TestResultPrint:
+    """Tests for printing the ``Result`` class."""
 
     def test_stateless_print(self, capfd):
         """Test that printing a result object with no state provides the correct output."""
         result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])]})
         print(result)
-        out, err = capfd.readouterr()
+        out, _ = capfd.readouterr()
         assert "modes=2" in out
         assert "shots=3" in out
         assert "contains state=False" in out
 
     def test_state_print(self, capfd):
         """Test that printing a result object with a state provides the correct output."""
-        result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])]})
-        result._state = [[1, 2], [3, 4]]
+        result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])], 0: [1, 2, 3, 4, 5, 6]})
+        result.state = [[1, 2], [3, 4]]
         print(result)
-        out, err = capfd.readouterr()
+        out, _ = capfd.readouterr()
         assert "modes=2" in out
         assert "shots=3" in out
         assert "contains state=True" in out
@@ -49,19 +118,19 @@ class TestResult:
         samples = np.ones((2, 3, 4))
         result = Result({"output": [samples]})
         print(result)
-        out, err = capfd.readouterr()
+        out, _ = capfd.readouterr()
         assert "spatial_modes=3" in out
         assert "shots=2" in out
         assert "timebins=4" in out
         assert "contains state=False" in out
 
-    def test_unkown_shape_print(self, capfd):
+    def test_unknown_shape_print(self, capfd):
         """Test that printing a result object with samples with an unknown shape
         provides the correct output."""
         samples = np.ones((2, 3, 4, 5))
         result = Result({"output": [samples]})
         print(result)
-        out, err = capfd.readouterr()
+        out, _ = capfd.readouterr()
         assert "modes" not in out
         assert "shots" not in out
         assert "timebins" not in out

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -95,10 +95,10 @@ class TestResultPrint:
         """Test that printing a result object with no state provides the correct output."""
         result = Result({"output": [np.array([[1, 2], [3, 4], [5, 6]])]})
         print(result)
-        out, _ = capfd.readouterr()
-        assert "modes=2" in out
-        assert "shots=3" in out
-        assert "contains state=False" in out
+        captured = capfd.readouterr()
+        assert "modes=2" in captured.out
+        assert "shots=3" in captured.out
+        assert "contains state=False" in captured.out
 
     def test_state_print(self, capfd):
         """Test that printing a result object with a state provides the correct output."""
@@ -108,21 +108,21 @@ class TestResultPrint:
         result = Result(samples, samples_dict=samples_dict)
         result.state = BaseGaussianState((np.array([0.0, 0.0]), np.identity(2)), 1)
         print(result)
-        out, _ = capfd.readouterr()
-        assert "modes=2" in out
-        assert "shots=3" in out
-        assert "contains state=True" in out
+        captured = capfd.readouterr()
+        assert "modes=2" in captured.out
+        assert "shots=3" in captured.out
+        assert "contains state=True" in captured.out
 
     def test_tdm_print(self, capfd):
         """Test that printing a result object with TDM samples provides the correct output."""
         samples = np.ones((2, 3, 4))
         result = Result({"output": [samples]})
         print(result)
-        out, _ = capfd.readouterr()
-        assert "spatial_modes=3" in out
-        assert "shots=2" in out
-        assert "timebins=4" in out
-        assert "contains state=False" in out
+        captured = capfd.readouterr()
+        assert "spatial_modes=3" in captured.out
+        assert "shots=2" in captured.out
+        assert "timebins=4" in captured.out
+        assert "contains state=False" in captured.out
 
     def test_unknown_shape_print(self, capfd):
         """Test that printing a result object with samples with an unknown shape
@@ -130,8 +130,8 @@ class TestResultPrint:
         samples = np.ones((2, 3, 4, 5))
         result = Result({"output": [samples]})
         print(result)
-        out, _ = capfd.readouterr()
-        assert "modes" not in out
-        assert "shots" not in out
-        assert "timebins" not in out
-        assert "contains state=False" in out
+        captured = capfd.readouterr()
+        assert "modes" not in captured.out
+        assert "shots" not in captured.out
+        assert "timebins" not in captured.out
+        assert "contains state=False" in captured.out

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -37,7 +37,7 @@ class TestResult:
         """Test that ``samples`` is correctly returned."""
         result = Result(raw_results)
         assert result.samples is not None
-        assert np.equal(result.samples, np.ones((2, 3, 4, 5))).all()
+        assert np.array_equal(result.samples, np.ones((2, 3, 4, 5)))
 
     def test_raw(self):
         """Test that raw results are correctly returned."""

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -662,9 +662,9 @@ class TestBosonicPrograms:
         assert samples_dict == {}
 
         # Check ancilla samples exist for the second mode
-        ancilla_samples = backend.ancillae_samples_dict
-        assert 1 in ancilla_samples.keys()
-        assert len(ancilla_samples[1]) == 2
+        ancillae_samples = backend.ancillae_samples_dict
+        assert 1 in ancillae_samples.keys()
+        assert len(ancillae_samples[1]) == 2
 
     @pytest.mark.parametrize("alpha", ALPHA_VALS)
     @pytest.mark.parametrize("phi", PHI_VALS)

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -142,7 +142,7 @@ class TestProperExecution:
         res = eng.run(prog)
 
         assert isinstance(eng, sf.engine.BosonicEngine)
-        assert len(res.ancilla_samples[0]) == 2
+        assert len(res.ancillae_samples[0]) == 2
         assert str(res) == "<Result: shots=0, num_modes=0, num_ancillae=2, contains state=True>"
 
     # TODO: Some of these tests should probably check *something* after execution


### PR DESCRIPTION
**Context:**
There's no way to access non-samples results (i.e., metadata) in the `Result` class.

**Description of the Change:**
* A `Result.raw` method is added that returns the raw result dictionary.
* A `Result.metadata` method is added that returns the metadata of the results (i.e., everything except the `"output"` entry).
* Tests are added for the `Result` class.
* A setter method is added for `Result.state` allowing a state to be set iff a state has not previously been set and the `Result` object contains `samples_dict` samples, indicating that it's a local simulation.

**Benefits:**
* Results metadata can be accessed without using the private `Result._result` method.
* The `Result` class is properly tested.
* The state can be properly set in the result object.

**Possible Drawbacks:**
* The state setter relies on the fact that all local simulations have a `samples_dict` (which is currently the case).

**Related GitHub Issues:**
None
