### PR TITLE
fix teleportation.py beamsplitter phase (to 0)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,7 @@
   specification.
   [(#661)](https://github.com/XanaduAI/strawberryfields/pull/661)
   
-* The teleportation tutorial `examples/teleportation.py` now uses the correct value (now ϕ=0 instead of ϕ=π/2) for the phase shift of the beam     splitters.
+* The teleportation tutorial `examples/teleportation.py` now uses the correct value (now `phi = 0` instead of `phi = np.pi / 2`) for the phase shift of the beamsplitters.
   [(#674)](https://github.com/XanaduAI/strawberryfields/pull/674)
 
 <h3>Documentation</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
   circuit layout. Without a layout, the gate parameters cannot be validated against the device
   specification.
   [(#661)](https://github.com/XanaduAI/strawberryfields/pull/661)
+  
+* The teleportation tutorial `examples/teleportation.py` now uses the correct value (now ϕ=0 instead of ϕ=π/2) for the phase shift of the beam     splitters.
+  [(#674)](https://github.com/XanaduAI/strawberryfields/pull/674)
 
 <h3>Documentation</h3>
 
@@ -21,7 +24,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Theodor Isacsson
+Theodor Isacsson, Jon Schlipf
 
 # Release 0.21.0 (current release)
 

--- a/examples/teleportation.py
+++ b/examples/teleportation.py
@@ -29,7 +29,7 @@ with prog.context as q:
     Squeezed(2) | q[2]
 
     # apply gates
-    BS = BSgate(pi / 4, pi)
+    BS = BSgate(pi / 4,0)
     BS | (q[1], q[2])
     BS | (q[0], q[1])
 

--- a/examples/teleportation.py
+++ b/examples/teleportation.py
@@ -29,7 +29,7 @@ with prog.context as q:
     Squeezed(2) | q[2]
 
     # apply gates
-    BS = BSgate(pi / 4,0)
+    BS = BSgate(pi / 4, 0)
     BS | (q[1], q[2])
     BS | (q[0], q[1])
 


### PR DESCRIPTION
**Context:**
The teleportation example fails to teleport the state. Setting the BS phase to 0 apparently fixes this for various numeric examples. The phase was 0 in the previous version of this example as well as the theory part of the html example in the docs.

**Description of the Change:**
The beam splitter phase in the teleportation example was set to 0.

**Benefits:**
The teleported state on q[2] can now be confirmed to have its probability distribution around the original state (via Wigner plots etc.).

**Possible Drawbacks:**
None

**Related GitHub Issues:**
