### PR TITLE
`shots=None` will not execute any measurement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,8 @@
 * A `Device.certificate` method is added which returns the hardware device certificate.
   [(#679)](https://github.com/XanaduAI/strawberryfields/pull/679)
 
+* Setting `shots=None` on the engine or program run options will not execute any measurements applied on the circuit. [(#682)](https://github.com/XanaduAI/strawberryfields/pull/682)
+
 <h3>Breaking Changes</h3>
 
 * `DeviceSpec` is renamed to `Device`.
@@ -33,7 +35,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Theodor Isacsson, Jon Schlipf, Hossein Seifoory
+Sebastian Duque, Theodor Isacsson, Jon Schlipf, Hossein Seifoory
 
 # Release 0.21.0 (current release)
 

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -451,12 +451,14 @@ class LocalEngine(BaseEngine):
             # if a tdm program is input in a rolled state, then unroll it
             if not program.is_unrolled:
                 received_rolled_circuit = True
-                program.unroll(shots=shots)
+                # if shots = None, then set shots=1 here only to unroll the program
+                program.unroll(shots=shots if shots is not None else 1)
 
             # Shots >1 for a TDM program simply corresponds to creating
             # multiple copies of the program, and appending them to run sequentially.
-            # As a result, we set the backend shots to 1 for the Gaussian backend.
-            kwargs["shots"] = 1
+            # As a result, we set the backend shots to 1 for the Gaussian backend
+            # unless shots was set to `None`.
+            kwargs["shots"] = 1 if shots else None
 
         args = args or {}
         compile_options = compile_options or {}

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -316,6 +316,12 @@ class Measurement(Operation):
             shots (int): Number of independent evaluations to perform.
                 Only applies to Measurements.
         """
+        # Do not apply any measurement operation in the circuit
+        # if `shots` is set to None
+        _shots = kwargs.get("shots", 1)
+        if _shots is None:
+            return None
+
         values = super().apply(reg, backend, **kwargs)
 
         # store the results in the register reference objects

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -84,7 +84,8 @@ class TestEngineProgramInteraction:
         results = eng.run(prog)
         assert len(results.samples) == 1
 
-    def test_shots_run_options(self):
+    @pytest.mark.parametrize("shots,len_samples", [(None, 0), (5, 5)])
+    def test_shots_run_options(self, shots, len_samples):
         """Test that run_options takes precedence over default"""
         prog = sf.Program(1)
         eng = sf.Engine("gaussian")
@@ -93,23 +94,23 @@ class TestEngineProgramInteraction:
             ops.Sgate(0.5) | q[0]
             ops.MeasureFock() | q
 
-        prog.run_options = {"shots": 5}
+        prog.run_options = {"shots": shots}
         results = eng.run(prog)
-        assert len(results.samples) == 5
+        assert len(results.samples) == len_samples
 
-    def test_shots_passed(self):
+    @pytest.mark.parametrize("shots,len_samples", [(None, 0), (2, 2)])
+    def test_shots_passed(self, shots, len_samples):
         """Test that shots supplied via eng.run takes precedence over
         run_options and that run_options isn't changed"""
         prog = sf.Program(1)
         eng = sf.Engine("gaussian")
-
         with prog.context as q:
             ops.Sgate(0.5) | q[0]
             ops.MeasureFock() | q
 
         prog.run_options = {"shots": 5}
-        results = eng.run(prog, shots=2)
-        assert len(results.samples) == 2
+        results = eng.run(prog, shots=shots)
+        assert len(results.samples) == len_samples
         assert prog.run_options["shots"] == 5
 
     def test_history(self, eng, prog):

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -702,7 +702,8 @@ class TestEngineTDMProgramInteraction:
         results = eng.run(prog)
         assert len(results.samples) == 1
 
-    def test_shots_run_options(self):
+    @pytest.mark.parametrize("shots,len_samples", [(None, 0), (5, 5)])
+    def test_shots_run_options(self, shots, len_samples):
         """Test that run_options takes precedence over default"""
         prog = sf.TDMProgram(2)
         eng = sf.Engine("gaussian")
@@ -711,11 +712,12 @@ class TestEngineTDMProgramInteraction:
             ops.Sgate(p[0]) | q[0]
             ops.MeasureHomodyne(p[1]) | q[0]
 
-        prog.run_options = {"shots": 5}
+        prog.run_options = {"shots": shots}
         results = eng.run(prog)
-        assert len(results.samples) == 5
+        assert len(results.samples) == len_samples
 
-    def test_shots_passed(self):
+    @pytest.mark.parametrize("shots,len_samples", [(None, 0), (2, 2)])
+    def test_shots_passed(self, shots, len_samples):
         """Test that shots supplied via eng.run takes precedence over
         run_options and that run_options isn't changed"""
         prog = sf.TDMProgram(2)
@@ -726,8 +728,8 @@ class TestEngineTDMProgramInteraction:
             ops.MeasureHomodyne(p[1]) | q[0]
 
         prog.run_options = {"shots": 5}
-        results = eng.run(prog, shots=2)
-        assert len(results.samples) == 2
+        results = eng.run(prog, shots=shots)
+        assert len(results.samples) == len_samples
         assert prog.run_options["shots"] == 5
 
     def test_shots_with_timebins_non_multiple_of_concurrent_modes(self):


### PR DESCRIPTION
**Context:**
Simulating a circuit requires to execute the measurements to return results. This execution can take long time, however there are cases where no execution is required, e. g., when calculating the covariance matrix of the circuit.

**Description of the Change:**
If `shots=None` the backend bypasses the execution (i.e. the `apply` method) of any op of class `Measurement` that belongs to the circuit.

**Benefits:**
Users can define circuits and bypass measurements to avoid lengthy executions of simulations if not needed.
