### PR TITLE
Set `SYMPY_USE_CACHE` environment variable to "no"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      SYMPY_USE_CACHE: "no"
       OPTIONS: ${{ matrix.options }}
       BATCHED: ${{ matrix.batched }}
 


### PR DESCRIPTION
**Context:**
Quick fix for an issue with SymPy caching expressions and wrongly using a cached register reference instead of the new one. See issue #683 for details.

**Description of the Change:**
Sets the `SYMPY_USE_CACHE` environment variable to "no" in CI, so that no caching is done when running tests. 

**Benefits:**
Certain cases when SymPy parameters are cached and incorrectly retrieved will (hopefully) no longer happen in the CI tests.

**Possible Drawbacks:**
This is just a quick fix for the CI tests. The issue is still present in the code-base.

**Related GitHub Issues:**
#683