### PR TITLE
Run CI tests without Tensorflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
       SYMPY_USE_CACHE: "no"
       OPTIONS: ${{ matrix.options }}
       BATCHED: ${{ matrix.batched }}
+      SKIP_DEPENDENCIES: "tensorflow|tensorboard"
 
     strategy:
       matrix:
@@ -29,6 +30,7 @@ jobs:
             - {BATCHED: 1, OPTIONS: "tf and pure"}
             - {BATCHED: 1, OPTIONS: "tf and mixed"}
             - {BATCHED: 0, OPTIONS: "bosonic"}
+            - {BATCHED: 0, OPTIONS: "not tf"}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -46,6 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          [ "$OPTIONS" = "not tf" ] && gawk -i inplace '!/('$SKIP_DEPENDENCIES')/' requirements-ci.txt
           python3 -m pip install --upgrade pip
           pip install -r requirements-ci.txt
           pip install wheel codecov pytest pytest-cov pytest-randomly pytest-mock pytest-logger --upgrade

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
       SYMPY_USE_CACHE: "no"
       OPTIONS: ${{ matrix.options }}
       BATCHED: ${{ matrix.batched }}
-      SKIP_DEPENDENCIES: "tensorflow|tensorboard"
+      TF_DEPENDENCIES: "tensorflow|tensorboard"
 
     strategy:
       matrix:
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          [ "$OPTIONS" = "not tf" ] && gawk -i inplace '!/('$SKIP_DEPENDENCIES')/' requirements-ci.txt
+          [ "$OPTIONS" = "not tf" ] && gawk -i inplace '!/('$TF_DEPENDENCIES')/' requirements-ci.txt
           python3 -m pip install --upgrade pip
           pip install -r requirements-ci.txt
           pip install wheel codecov pytest pytest-cov pytest-randomly pytest-mock pytest-logger --upgrade

--- a/tests/backend/test_states_probabilities.py
+++ b/tests/backend/test_states_probabilities.py
@@ -19,10 +19,10 @@ from scipy.special import factorial as fac
 
 try:
     import tensorflow as tf
-except ImportError:
-    import unittest.mock as mock
 
-    tf = mock.Mock()
+    tf_available = True
+except:
+    tf_available = False
 
 
 MAG_ALPHAS = np.linspace(0, 0.8, 3)
@@ -91,7 +91,7 @@ class TestAllFockProbs:
         state = backend.state()
 
         probs = state.all_fock_probs(cutoff=cutoff)
-        if isinstance(probs, tf.Tensor):
+        if tf_available and isinstance(probs, tf.Tensor):
             probs = probs.numpy()
         probs = probs.flatten()
 
@@ -127,7 +127,7 @@ class TestAllFockProbs:
         for n in range(cutoff):
             for m in range(cutoff):
                 probs = state.all_fock_probs(cutoff=cutoff)
-                if isinstance(probs, tf.Tensor):
+                if tf_available and isinstance(probs, tf.Tensor):
                     probs = probs.numpy()
 
                 assert np.allclose(probs.flatten(), ref_probs, atol=tol, rtol=0)

--- a/tests/integration/test_ops_integration.py
+++ b/tests/integration/test_ops_integration.py
@@ -25,9 +25,9 @@ from strawberryfields.backends.states import BaseFockState, BaseGaussianState
 try:
     import tensorflow as tf
 except:
-    backends = ["fock", "tf"]
-else:
     backends = ["fock"]
+else:
+    backends = ["fock", "tf"]
 
 # make test deterministic
 np.random.seed(42)


### PR DESCRIPTION
**Context:**
Currently, no tests are being run without TensorFlow installed. This makes it easy to mistakenly add code that is dependent on TensorFlow to core Strawberry Fields, which doesn't have TensorFlow as a requirement.

**Description of the Change:**
Adds a CI action that runs the relevant tests in an environment without TensorFlow installed. 

This is done by 
- adding a new strategy to the `core-test` job where pytest will run all tests except those marked with `"tf"`. That is, setting `OPTIONS="not tf"`,
- creating a new environment variable `TF_DEPENDENCIES="tensorflow|tensorboard"` listing the dependencies to be removed from the `requirements-ci.txt` file,
- using `awk` to remove dependencies listed on `TF_DEPENDENCIES` from the `requirements-ci.txt` file when `OPTIONS="not tf"`.

**Benefits:**
Avoid to mistakenly add code that is dependent on TensorFlow to core Strawberry Fields.

**Possible Drawbacks:**
Longer CI run times

**Related GitHub Issues:**
Closes #641 
