### PR TITLE
Assert spec and layout target equality

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,6 +25,10 @@
   utility function.
   [(#686)](https://github.com/XanaduAI/strawberryfields/pull/686)
 
+* A `Device.assert_spec` static method is added which checks that the target in the layout is the same as
+  the target field in the specification. This check is also performed at `Device` initialization.
+  [(#687)](https://github.com/XanaduAI/strawberryfields/pull/687)
+
 <h3>Breaking Changes</h3>
 
 * `DeviceSpec` is renamed to `Device`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,7 +25,7 @@
   utility function.
   [(#686)](https://github.com/XanaduAI/strawberryfields/pull/686)
 
-* A `Device.assert_spec` static method is added which checks that the target in the layout is the same as
+* A `Device.validate_target` static method is added which checks that the target in the layout is the same as
   the target field in the specification. This check is also performed at `Device` initialization.
   [(#687)](https://github.com/XanaduAI/strawberryfields/pull/687)
 

--- a/strawberryfields/device.py
+++ b/strawberryfields/device.py
@@ -59,7 +59,7 @@ class Device:
         layout = spec["layout"]
         target = spec["target"]
 
-        groups = re.findall(r"target (\w+)", layout or "")
+        groups = re.findall(r"\b(?=\w)target (\w+)", layout or "")
         if len(groups) <= 1:
             if len(groups) == 1 and target != groups[0]:
                 raise ValueError(

--- a/strawberryfields/device.py
+++ b/strawberryfields/device.py
@@ -46,17 +46,19 @@ class Device:
                 f"Device specification is missing the following keys: {sorted(missing_keys)}"
             )
 
-        self._spec = self.assert_spec(spec)
+        self._spec = self.validate_target(spec)
         self._certificate = cert
 
     @staticmethod
-    def assert_spec(spec: Mapping[str, Any]):
+    def validate_target(spec: Mapping[str, Any]):
         """Check that the target in the specification is equal to the layout target.
 
         Returns:
-            Dict: dictionary representing the raw device specification."""
+            Dict: dictionary representing the raw device specification.
+        """
         layout = spec["layout"]
         target = spec["target"]
+
         groups = re.findall(r"target (\w+)", layout or "")
         if len(groups) <= 1:
             if len(groups) == 1 and target != groups[0]:

--- a/strawberryfields/device.py
+++ b/strawberryfields/device.py
@@ -195,5 +195,6 @@ class Device:
         # evaluate the blackbird template
         bb = bb(**parameters)
         prog = to_program(bb)
+        prog.compile(compiler=self.default_compiler)
 
         return prog

--- a/tests/api/test_devicespec.py
+++ b/tests/api/test_devicespec.py
@@ -149,6 +149,36 @@ class TestDevice:
         with pytest.raises(ValueError, match="missing a circuit layout"):
             Device(spec=device_dict_no_layout).create_program(**params)
 
+    def test_different_targets(self):
+        """Test that different targets in layout and spec raises an error."""
+        layout_different_target = inspect.cleandoc(
+            """
+            name mock
+            version 1.0
+            target banana
+
+            S2gate({squeezing_amplitude_0}, 0.0) | [0, 1]
+            MZgate({phase_0}, {phase_1}) | [0, 1]
+            MeasureFock() | [0, 1]
+            """
+        )
+        device_dict_different_target = {
+            "target": "pawpaw",
+            "layout": layout_different_target,
+            "modes": 2,
+            "compiler": ["Xcov"],
+            "gate_parameters": {
+                "squeezing_amplitude_0": [0, 1],
+                "phase_0": [0, [0, 6.3]],
+                "phase_1": [[0.5, 1.4]],
+            },
+        }
+        with pytest.raises(
+            ValueError,
+            match="Target in specification 'pawpaw' differs from the target in layout 'banana'.",
+        ):
+            Device(spec=device_dict_different_target)
+
     @pytest.mark.parametrize(
         "params", [{"phase_0": 7.5}, {"phase_1": 0.4}, {"squeezing_amplitude_0": 0.5}]
     )


### PR DESCRIPTION
**Context:**
Currently, there's no check against using different targets in the specification (`Device.target`, or `Device._spec["target"]`) and in the Blackbird layout (target field in `Device.layout`, or `BlackbirdProgram.target`). This shouldn't be an issue for the user unless the specification is incorrect, although it's safer to have a check for this at device creation directly.

**Description of the Change:**
* A `Device.assert_spec` static method is added which checks that the target in the layout is the same as the target field in the specification. This check is also performed at `Device` initialization.
* If no target is specified in the layout, the device target is used instead. This is useful e.g., when compiling a program with a device (currently, if this would be attempted without a target in the layout, an obscure `CircuitError` would be raised.

**Benefits:**
* The target in the layout can either be omitted, or _must_ be the same as the target in the specification.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
