### PR TITLE
Deep copy from `Program.compile()`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,10 @@
   instead of `phi = np.pi / 2`) for the phase shift of the beamsplitters.
   [(#674)](https://github.com/XanaduAI/strawberryfields/pull/674)
 
+* `Program.compile()` returns a deep copy of the program, instead of a shallow copy, while still keeping
+  the same register references.
+  [(#675)](https://github.com/XanaduAI/strawberryfields/pull/675)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,9 +44,9 @@
   instead of `phi = np.pi / 2`) for the phase shift of the beamsplitters.
   [(#674)](https://github.com/XanaduAI/strawberryfields/pull/674)
 
-* `Program.compile()` returns a deep copy of the program, instead of a shallow copy, while still keeping
-  the same register references.
-  [(#675)](https://github.com/XanaduAI/strawberryfields/pull/675)
+* `Program.compile()` returns a deep copy of the program attributes, except for the circuit and
+  the register references.
+  [(#688)](https://github.com/XanaduAI/strawberryfields/pull/688)
 
 <h3>Documentation</h3>
 

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -546,7 +546,9 @@ class Program:
             Program: a copy of the Program
         """
         self.lock()
-        p = copy.copy(self)  # shares RegRefs with the source
+        p = copy.deepcopy(self)
+        p.reg_refs = self.reg_refs  # shares RegRefs with the source
+
         # link to the original source Program
         if self.source is None:
             p.source = self

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -553,7 +553,7 @@ class Program:
             # should share the same register references. Program.circuit potentially
             # contains FreeParameters/MeasuredParameters, which contain RegRefs.
             if name not in ("circuit", "reg_refs", "init_reg_refs"):
-                setattr(name, val, copy.deepcopy(val))
+                setattr(p, name, copy.deepcopy(val))
 
         # link to the original source Program
         if self.source is None:

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -546,8 +546,14 @@ class Program:
             Program: a copy of the Program
         """
         self.lock()
-        p = copy.deepcopy(self)
-        p.reg_refs = self.reg_refs  # shares RegRefs with the source
+        p = copy.copy(self)
+
+        for name, val in self.__dict__.items():
+            # Deep-copy all attributes except 'circuit' and 'reg_refs', since the programs
+            # should share the same register references. Program.circuit potentially
+            # contains FreeParameters/MeasuredParameters, which contain RegRefs.
+            if name not in ("circuit", "reg_refs", "init_reg_refs"):
+                setattr(name, val, copy.deepcopy(val))
 
         # link to the original source Program
         if self.source is None:

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -543,11 +543,13 @@ class TestProgram:
             ops.MeasureFock() | q[1]
 
         prog_copy = prog._linked_copy()
+
+        # registers should be the same
         for i, regref in prog_copy.reg_refs.items():
             assert regref is prog.reg_refs[i]
 
         for i, cmd in enumerate(prog_copy.circuit):
-            assert cmd is not prog.circuit[i]
+            assert cmd is prog.circuit[i]
 
         assert prog_copy.source is prog
 

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -227,7 +227,7 @@ class TestProgram:
         assert prog_2.equivalence(prog_1, compare_params=compare_params)
 
     @pytest.mark.parametrize("compare_params", [True, False])
-    def test_neq_operator_equivalent(self, compare_params):
+    def test_equivalence_different_circuits(self, compare_params):
         """Programs with differnet, but equivalent, circuits."""
         prog_1 = sf.Program(3)
         prog_2 = sf.Program(3)

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -534,6 +534,23 @@ class TestProgram:
         assert prog_2.has_feed_forward is False
         assert prog_2.has_post_selection is False
 
+    def test_linked_copy(self, prog):
+        """Check that the ``_linked_copy`` method copies a program correctly."""
+
+        with prog.context as q:
+            ops.Fock(2) | q[0]
+            ops.BSgate() | (q[0], q[1])
+            ops.MeasureFock() | q[1]
+
+        prog_copy = prog._linked_copy()
+        for i, regref in prog_copy.reg_refs.items():
+            assert regref is prog.reg_refs[i]
+
+        for i, cmd in enumerate(prog_copy.circuit):
+            assert cmd is not prog.circuit[i]
+
+        assert prog_copy.source is prog
+
 
 class TestRegRefs:
     """Testing register references."""

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -228,7 +228,7 @@ class TestProgram:
 
     @pytest.mark.parametrize("compare_params", [True, False])
     def test_equivalence_different_circuits(self, compare_params):
-        """Programs with differnet, but equivalent, circuits."""
+        """Programs with different, but equivalent, circuits."""
         prog_1 = sf.Program(3)
         prog_2 = sf.Program(3)
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -518,11 +518,12 @@ def test_linked_copy():
     assert prog_copy.circuit
     assert prog.circuit
 
+    # registers should be the same
     for i, regref in prog_copy.reg_refs.items():
         assert regref is prog.reg_refs[i]
 
     for i, cmd in enumerate(prog_copy.circuit):
-        assert cmd is not prog.circuit[i]
+        assert cmd is prog.circuit[i]
 
     # tdm_params should be equal, but not the same
     assert prog_copy.tdm_params is not prog.tdm_params

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -505,6 +505,32 @@ device_spec["layout"] = device_spec["layout"].format(target=target, tm=tm)
 device = Device(device_spec)
 
 
+def test_linked_copy():
+    """Check that the ``_linked_copy`` method copies a TDM program correctly."""
+    sq_r = 0.5643
+    c = 2
+    alpha = [np.pi / 4, 0] * c
+    phi = [0, np.pi / 2] * c
+    theta = [0, 0, np.pi / 2, np.pi / 2]
+    prog = singleloop_program(sq_r, alpha, phi, theta)
+
+    prog_copy = prog._linked_copy()
+    assert prog_copy.circuit
+    assert prog.circuit
+
+    for i, regref in prog_copy.reg_refs.items():
+        assert regref is prog.reg_refs[i]
+
+    for i, cmd in enumerate(prog_copy.circuit):
+        assert cmd is not prog.circuit[i]
+
+    # tdm_params should be equal, but not the same
+    assert prog_copy.tdm_params is not prog.tdm_params
+    assert prog_copy.tdm_params == prog.tdm_params
+
+    assert prog_copy.source is prog
+
+
 class TestTDMcompiler:
     """Test class for checking error messages from the compiler"""
 


### PR DESCRIPTION
**Context:**
The compiler create a linked copy of the program by calling `Program._linked_copy()`, which retains the same regrefs. Since the copy is shallow, it also keeps the same TDM parameters in a TDM program. These parameters are updated by the compiler and thus changed in both the compiled program _and_ the initial program, while the circuit is only changed in the compiled program.

**Description of the Change:**
* `Program._linked_copy()` is updated to create a deep-copy of all attributes except the ones containing register references, including e.g., the TDM parameters.
* The initial program's regrefs are linked to the compiled programs regrefs instead of implicitly referenced by using a shallow copy.

**Benefits:**
The compiler actually returns a copy of the program without changing anything in the original program.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
