### PR TITLE
Update random tests and seeds to use `pytest-randomly`

### DIFF
--- a/tests/apps/train/test_cost.py
+++ b/tests/apps/train/test_cost.py
@@ -251,7 +251,6 @@ class TestStochasticIntegrationPNR:
         sampling from single mode squeezed states whose photon number distribution is specified
         by the negative binomial."""
         ps = 1 / (1 + np.array(n_mean_by_mode))
-        np.random.seed(0)
         return np.array([2 * np.random.negative_binomial(0.5, p, n_samples) for p in ps]).T
 
     def h_setup(self, objectives):

--- a/tests/backend/test_multimode_state_preparations.py
+++ b/tests/backend/test_multimode_state_preparations.py
@@ -21,9 +21,6 @@ import numpy as np
 from strawberryfields import ops
 from strawberryfields.utils import random_covariance, displaced_squeezed_state
 
-# make test deterministic
-np.random.seed(42)
-
 
 MAG_ALPHAS = np.linspace(0, 0.8, 3)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 3, endpoint=False)

--- a/tests/backend/test_state_preparations.py
+++ b/tests/backend/test_state_preparations.py
@@ -22,7 +22,6 @@ import numpy as np
 MAG_ALPHAS = np.linspace(0, 0.8, 4)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
 NBARS = np.linspace(0, 5, 7)
-SEED = 143
 
 
 class TestRepresentationIndependent:
@@ -89,7 +88,6 @@ class TestFockRepresentation:
 
     def test_prepare_ket_state(self, setup_backend, cutoff, tol):
         """Tests if a ket state with arbitrary parameters is correctly prepared."""
-        np.random.seed(SEED)
         random_ket = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(-1, 1, cutoff)
         random_ket = random_ket / np.linalg.norm(random_ket)
         backend = setup_backend(1)
@@ -106,7 +104,6 @@ class TestFockRepresentation:
         if batch_size is None:
             pytest.skip("Test skipped if no batching")
 
-        np.random.seed(SEED)
         random_kets = np.array(
             [
                 (lambda ket: ket / np.linalg.norm(ket))(
@@ -135,7 +132,6 @@ class TestFockRepresentation:
     def test_prepare_rank_two_dm_state(self, setup_backend, cutoff, tol):
         """Tests if rank two dm states with arbitrary parameters are correctly prepared."""
 
-        np.random.seed(SEED)
         random_ket1 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(-1, 1, cutoff)
         random_ket1 = random_ket1 / np.linalg.norm(random_ket1)
         random_ket2 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(-1, 1, cutoff)
@@ -168,7 +164,6 @@ class TestFockRepresentation:
     def test_prepare_random_dm_state(self, setup_backend, batch_size, pure, cutoff, tol):
         """Tests if a random dm state is correctly prepared."""
 
-        np.random.seed(SEED)
         random_rho = np.random.normal(size=[cutoff, cutoff]) + 1j * np.random.normal(
             size=[cutoff, cutoff]
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,6 @@ import pytest
 
 import numpy as np
 
-np.random.seed(42)
-
 import strawberryfields as sf
 from strawberryfields.engine import LocalEngine
 from strawberryfields.program import Program

--- a/tests/frontend/compilers/test_gaussianunitary.py
+++ b/tests/frontend/compilers/test_gaussianunitary.py
@@ -27,8 +27,6 @@ from thewalrus.symplectic import expand, interferometer
 
 pytestmark = pytest.mark.frontend
 
-np.random.seed(42)
-
 
 def random_params(size, sq_bound, disp_bound):
     """Returns random parameters of a Gaussian circuit

--- a/tests/frontend/compilers/test_passive.py
+++ b/tests/frontend/compilers/test_passive.py
@@ -31,8 +31,6 @@ from thewalrus.symplectic import interferometer
 
 pytestmark = pytest.mark.frontend
 
-np.random.seed(42)
-
 
 @pytest.mark.parametrize("depth", [1, 3, 6])
 @pytest.mark.parametrize("width", [5, 10, 15])

--- a/tests/frontend/compilers/test_xcov.py
+++ b/tests/frontend/compilers/test_xcov.py
@@ -31,7 +31,6 @@ from thewalrus.symplectic import two_mode_squeezing, expand
 
 pytestmark = pytest.mark.frontend
 
-np.random.seed(42)
 
 SQ_AMPLITUDE = 1
 """float: the allowed squeezing amplitude"""

--- a/tests/frontend/compilers/test_xunitary.py
+++ b/tests/frontend/compilers/test_xunitary.py
@@ -32,7 +32,6 @@ from thewalrus.symplectic import two_mode_squeezing, expand
 
 pytestmark = pytest.mark.frontend
 
-np.random.seed(42)
 
 SQ_AMPLITUDE = 1
 """float: the allowed squeezing amplitude"""

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -29,10 +29,6 @@ from strawberryfields.utils import random_interferometer as haar_measure
 N_SAMPLES = 10
 
 
-# fix the seed to make the test deterministic
-np.random.seed(42)
-
-
 def omega(n):
     """Returns the symplectic matrix for n modes"""
     idm = np.identity(n)

--- a/tests/frontend/test_ops_channel.py
+++ b/tests/frontend/test_ops_channel.py
@@ -24,8 +24,6 @@ from strawberryfields import ops
 from strawberryfields.program_utils import MergeFailure
 from strawberryfields import utils
 
-# make test deterministic
-np.random.seed(42)
 a = np.random.random()
 b = np.random.random()
 c = np.random.random()

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -30,9 +30,6 @@ from strawberryfields import ops
 pytestmark = pytest.mark.frontend
 
 
-# make the test file deterministic
-np.random.seed(42)
-
 interferometer_meshes = [
     "rectangular",
     "rectangular_phase_end",

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -27,8 +27,6 @@ from strawberryfields.program_utils import MergeFailure, RegRefError
 from strawberryfields.parameters import par_evaluate
 
 
-# make test deterministic
-np.random.seed(42)
 A = np.random.random()
 B = np.random.random()
 C = np.random.random()

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -25,8 +25,6 @@ from strawberryfields.program_utils import MergeFailure, RegRefError, CircuitErr
 from strawberryfields import utils
 
 
-# make test deterministic
-np.random.seed(42)
 a = np.random.random()
 b = np.random.random()
 

--- a/tests/frontend/test_parameters.py
+++ b/tests/frontend/test_parameters.py
@@ -33,9 +33,6 @@ from strawberryfields.program_utils import RegRef
 pytestmark = pytest.mark.frontend
 
 
-# make test deterministic
-np.random.seed(32)
-
 SCALAR_TEST_VALUES = [3, 0.14, 4.2 + 0.5j]
 TEST_VALUES = SCALAR_TEST_VALUES + [np.array([0.1, 0.987654])]
 

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -27,8 +27,6 @@ from strawberryfields.parameters import ParameterError, FreeParameter
 from strawberryfields.compilers.compiler import Compiler
 
 
-# make test deterministic
-np.random.seed(42)
 A = np.random.random()
 
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -29,9 +29,6 @@ from strawberryfields.device import Device
 
 pytestmark = pytest.mark.frontend
 
-# make test deterministic
-np.random.seed(42)
-
 
 def singleloop(r, alpha, phi, theta, shots, shift="default"):
     """Single-loop program.
@@ -92,15 +89,12 @@ class TestTDMErrorRaising:
 def test_shift_by_specified_amount():
     """Checks that shifting by 1 is equivalent to shift='end' for a program
     with one spatial mode"""
-    np.random.seed(42)
     sq_r = 1.0
     shots = 1
     alpha = [0] * 4
     phi = [0] * 4
     theta = [0] * 4
-    np.random.seed(42)
     x = singleloop(sq_r, alpha, phi, theta, shots)
-    np.random.seed(42)
     y = singleloop(sq_r, alpha, phi, theta, shots, shift=1)
     assert np.allclose(x, y)
 
@@ -132,7 +126,6 @@ class TestSingleLoopNullifier:
     def test_epr(self):
         """Generates an EPR state and checks that the correct correlations (noise reductions) are observed
         from the samples"""
-        np.random.seed(42)
         vac_modes = 1
         sq_r = 5.0
         c = 2
@@ -175,7 +168,6 @@ class TestSingleLoopNullifier:
         See Eq. 5 of https://advances.sciencemag.org/content/5/5/eaaw4530
         """
         # Set up the circuit
-        np.random.seed(42)
         vac_modes = 1
         n = 4
         shots = 100
@@ -211,7 +203,6 @@ class TestSingleLoopNullifier:
         """Test that the nullifier have the correct value in the experiment described in
         See Eq. 10 of https://advances.sciencemag.org/content/5/5/eaaw4530
         """
-        np.random.seed(42)
         vac_modes = 1
         n = 20
         shots = 100
@@ -240,7 +231,6 @@ def test_one_dimensional_cluster_tokyo():
     One-dimensional temporal-mode cluster state as demonstrated in
     https://aip.scitation.org/doi/pdf/10.1063/1.4962732
     """
-    np.random.seed(42)
     sq_r = 5
 
     n = 10  # for an n-mode cluster state
@@ -286,7 +276,6 @@ def test_two_dimensional_cluster_denmark():
     """
     Two-dimensional temporal-mode cluster state as demonstrated in https://arxiv.org/pdf/1906.08709
     """
-    np.random.seed(42)
     sq_r = 3
     delay1 = 1  # number of timebins in the short delay line
     delay2 = 12  # number of timebins in the long delay line

--- a/tests/integration/test_decompositions_integration.py
+++ b/tests/integration/test_decompositions_integration.py
@@ -33,9 +33,6 @@ from strawberryfields import ops
 from strawberryfields.utils import random_interferometer as haar_measure
 from strawberryfields.utils.program_functions import extract_unitary
 
-# make the test file deterministic
-np.random.seed(42)
-
 
 u1 = random_interferometer(3)
 u2 = random_interferometer(3)

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -37,8 +37,6 @@ else:
     ]
 
 
-# make test deterministic
-np.random.seed(42)
 a = 0.1234
 b = -0.543
 c = 0.312

--- a/tests/integration/test_ops_integration.py
+++ b/tests/integration/test_ops_integration.py
@@ -29,8 +29,7 @@ except:
 else:
     backends = ["fock", "tf"]
 
-# make test deterministic
-np.random.seed(42)
+
 A = 0.1234
 B = -0.543
 

--- a/tests/integration/test_utils_integration.py
+++ b/tests/integration/test_utils_integration.py
@@ -37,7 +37,6 @@ from strawberryfields.backends.fockbackend.ops import beamsplitter as bs_U
 ALPHA = np.linspace(-0.15, 0.2, 4) + np.linspace(-0.2, 0.1, 4) * 1j
 R = np.linspace(0, 0.21, 4)
 PHI = np.linspace(0, 1.43, 4)
-np.random.seed(42)
 
 
 # ===================================================================================


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently different modules in the test suite use numpy seeds to make the tests in each particular module deterministic. However, using seeds in this manner breaks the possibility of using random ordering (to check for no inter-test dependency) and seeding of the full test suite through `pytest-randomly`; hence strawberry fields has been running its test suite with a fixed seed, i. e., `pytest --randomly-seed=42`.

**Description of the Change:**
This PR removes set numpy seeds from test modules when possible (some specific test do requiere to set a seed), leaving `pytest-randomly` as the responsible of setting and configuring the state of the random number generator.

**Benefits:**
Pytest no longer requires a fixed seed in order to execute the test suite allowing `pytest-randomly` to shuffle tests ordering and controlling the global state of the random number generator. In this sense, `pytest`/`pytest-randomly` will become the only "source of truth" regarding random number generation for the test.

**Possible Drawbacks:**
[The answer to the ultimate question of life, the universe, and everything](https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker's_Guide_to_the_Galaxy) is no longer hardcoded in strawberryfields. 