### PR TITLE
Change default `X12` target to `X12_02`

### DIFF
--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -564,7 +564,7 @@ class RemoteEngine:
     """
 
     POLLING_INTERVAL_SECONDS = 1
-    DEFAULT_TARGETS = {"X8": "X8_01", "X12": "X12_01"}
+    DEFAULT_TARGETS = {"X8": "X8_01", "X12": "X12_02"}
 
     def __init__(
         self,


### PR DESCRIPTION
**Context:**
`X12_01` is no longer in use. Instead, `X12` should point to `X12_02`.

**Description of the Change:**
`X12` now points to `X12_02`.

**Benefits:**
The correct `X12` device is targeted.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
