### PR TITLE
Bump XCC version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ toml==0.10.2
 typing-extensions==4.1.1
 urllib3==1.26.8
 quantum-xir==0.2.1
-xanadu-cloud-client==0.1.2
+xanadu-cloud-client==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "toml",
     "urllib3>=1.25.3",
     "quantum-xir>=0.1.1",
-    "xanadu-cloud-client>=0.1.1",
+    "xanadu-cloud-client>=0.2.0",
 ]
 
 info = {


### PR DESCRIPTION
**Context:**
A new version of XCC has been released, containing changes improving the download speeds samples from running remote jobs.

**Description of the Change:**
The version of XCC is bumped to the latest version in `requirements.txt` and `setup.py`.

**Benefits:**
Remote jobs now benefit from the faster sample downloading in the latest version of XCC.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
