### PR TITLE
Tidy up (un)rolling

### DIFF
--- a/tests/frontend/test_space_unroll.py
+++ b/tests/frontend/test_space_unroll.py
@@ -211,26 +211,23 @@ def test_space_unrolling():
             Rgate(p[i + d]) | q[n[i]]
             BSgate(p[i], np.pi / 2) | (q[n[i + 1]], q[n[i]])
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
 
     prog.space_unroll()
 
     assert prog.timebins == 259
-    assert prog.num_subsystems == 259
+    vac_modes = prog.concurr_modes - 1
+    assert prog.num_subsystems == prog.timebins + vac_modes
 
     # check that the number of gates are correct.
-    assert sum([isinstance(cmd.op, Sgate) for cmd in prog.circuit]) == 216
-    assert (
-        sum([isinstance(cmd.op, Rgate) for cmd in prog.circuit]) == 259 - 43 + 259 - 42 + 259 - 36
-    )
-    assert (
-        sum([isinstance(cmd.op, BSgate) for cmd in prog.circuit]) == 259 - 43 + 259 - 42 + 259 - 36
-    )
+    assert [isinstance(cmd.op, Sgate) for cmd in prog.circuit].count(True) == prog.timebins
+    assert [isinstance(cmd.op, Rgate) for cmd in prog.circuit].count(True) == 259 * len(delays)
+    assert [isinstance(cmd.op, BSgate) for cmd in prog.circuit].count(True) == 259 * len(delays)
 
     prog.space_unroll()
 
     # space-unroll the program twice to check that it works
-    assert prog._is_space_unrolled == True
+    assert prog.is_unrolled == True
 
 
 def test_rolling_space_unrolled():
@@ -255,17 +252,17 @@ def test_rolling_space_unrolled():
     num_subsystems_pre_roll = prog.num_subsystems
     init_num_subsystems_pre_roll = prog.init_num_subsystems
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
 
     # space-unroll the program
     prog.space_unroll()
 
-    assert prog._is_space_unrolled == True
+    assert prog.is_unrolled == True
 
     # roll the program back up
     prog.roll()
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
     assert prog.num_subsystems == num_subsystems_pre_roll
     assert prog.init_num_subsystems == init_num_subsystems_pre_roll
 


### PR DESCRIPTION
**Context:**
Rolling/unrolling/space-unrolling wasn't always working as one might intuitively expect. This PR tweaks the (un)rolling a bit and also fixes a few issues.

**Description of the Change:**
* A locked program can now be (un)rolled, and automatically restores the lock if there.
* Rolling and unrolling now _only_ happens in place. It has previously also been returning the (un)rolled circuit, but this was never used.
* Fixed bug when trying to unroll an already unrolled program with a different number of shots.
* Fixed bug with vacuum modes missing.
* Tidied up some docstrings.

**Benefits:**
Things look and work better.

**Possible Drawbacks:**
(un)rolling no longer returns the (un)rolled circuit. It only happens in place.

**Related GitHub Issues:**
None
