### PR TITLE
(un)locking when (un)rolling

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,13 +6,27 @@
 
 ### Improvements
 
+* A locked program can now be (un)rolled, and automatically restores the lock if there.
+[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+
+* Rolling and unrolling now only happens in place, and does no longer return the (un)rolled circuit.
+[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+
 ### Bug fixes
+
+* Trying to unroll an already unrolled program with a different number of shots works as expected.
+[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+
+* Fixed bug with vacuum modes missing.
+[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
 
 ### Documentation
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Theodor Isacsson
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Improvements
 
 * A locked program can now be (un)rolled, and automatically restores the lock if there.
-[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+[(#703)](https://github.com/XanaduAI/strawberryfields/pull/703)
 
 * Rolling and unrolling now only happens in place, and does no longer return the (un)rolled circuit.
 [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -626,8 +626,10 @@ class TDMProgram(Program):
             if self._unrolled_shots == shots:
                 self.circuit = self.unrolled_circuit
                 return
-            self._unrolled_shots = shots
             self.roll()
+
+        # store the number of shots in the unrolled circuit
+        self._unrolled_shots = shots
 
         if self.space_unrolled_circuit is not None:
             raise ValueError(
@@ -650,8 +652,10 @@ class TDMProgram(Program):
         if self.space_unrolled_circuit is not None and self._unrolled_shots == shots:
             self.circuit = self.space_unrolled_circuit
             return
-        self._unrolled_shots = shots
         self.roll()
+
+        # store the number of shots in the unrolled circuit
+        self._unrolled_shots = shots
 
         vac_modes = self.concurr_modes - 1
         self._num_added_subsystems = self.timebins - self.init_num_subsystems + vac_modes

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -626,9 +626,8 @@ class TDMProgram(Program):
             if self._unrolled_shots == shots:
                 self.circuit = self.unrolled_circuit
                 return
-            else:
-                self._unrolled_shots = shots
-                self.roll()
+            self._unrolled_shots = shots
+            self.roll()
 
         if self.space_unrolled_circuit is not None:
             raise ValueError(
@@ -651,9 +650,8 @@ class TDMProgram(Program):
         if self.space_unrolled_circuit is not None and self._unrolled_shots == shots:
             self.circuit = self.space_unrolled_circuit
             return
-        else:
-            self._unrolled_shots = shots
-            self.roll()
+        self._unrolled_shots = shots
+        self.roll()
 
         vac_modes = self.concurr_modes - 1
         self._num_added_subsystems = self.timebins - self.init_num_subsystems + vac_modes

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -639,7 +639,7 @@ class TDMProgram(Program):
         self._unroll_program(shots, space=False)
 
     def space_unroll(self, shots=1):
-        """Construct the space-unrolled program and set it to ``self.circuit`.
+        """Construct the space-unrolled program and set it to ``self.circuit``.
 
         Calls the ``_unroll_program`` method which constructs the space-unrolled single-shot program,
         storing it in `self.space_unrolled_circuit` when run for the first time, and returns the

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -622,6 +622,10 @@ class TDMProgram(Program):
         Args:
             shots (int): the number of times the circuit should be repeated
         """
+        _locked = self.locked
+        if self.locked:
+            self.locked = False
+
         if self.unrolled_circuit is not None:
             if self._unrolled_shots == shots:
                 self.circuit = self.unrolled_circuit
@@ -638,6 +642,7 @@ class TDMProgram(Program):
             )
 
         self._unroll_program(shots, space=False)
+        self.locked = _locked
 
     def space_unroll(self, shots=1):
         """Construct the space-unrolled program and set it to ``self.circuit``.
@@ -649,6 +654,10 @@ class TDMProgram(Program):
         Args:
             shots (int): the number of times the circuit should be repeated
         """
+        _locked = self.locked
+        if self.locked:
+            self.locked = False
+
         if self.space_unrolled_circuit is not None and self._unrolled_shots == shots:
             self.circuit = self.space_unrolled_circuit
             return
@@ -671,6 +680,7 @@ class TDMProgram(Program):
             )
 
         self._unroll_program(shots, space=True)
+        self.locked = _locked
 
     def _unroll_program(self, shots, space):
         """Construct the unrolled program either using space-unrolling or with register shift."""

--- a/tests/frontend/test_space_unroll.py
+++ b/tests/frontend/test_space_unroll.py
@@ -211,26 +211,23 @@ def test_space_unrolling():
             Rgate(p[i + d]) | q[n[i]]
             BSgate(p[i], np.pi / 2) | (q[n[i + 1]], q[n[i]])
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
 
     prog.space_unroll()
 
     assert prog.timebins == 259
-    assert prog.num_subsystems == 259
+    vac_modes = prog.concurr_modes - 1
+    assert prog.num_subsystems == prog.timebins + vac_modes
 
     # check that the number of gates are correct.
-    assert sum([isinstance(cmd.op, Sgate) for cmd in prog.circuit]) == 216
-    assert (
-        sum([isinstance(cmd.op, Rgate) for cmd in prog.circuit]) == 259 - 43 + 259 - 42 + 259 - 36
-    )
-    assert (
-        sum([isinstance(cmd.op, BSgate) for cmd in prog.circuit]) == 259 - 43 + 259 - 42 + 259 - 36
-    )
+    assert [isinstance(cmd.op, Sgate) for cmd in prog.circuit].count(True) == prog.timebins
+    assert [isinstance(cmd.op, Rgate) for cmd in prog.circuit].count(True) == 259 * len(delays)
+    assert [isinstance(cmd.op, BSgate) for cmd in prog.circuit].count(True) == 259 * len(delays)
 
     prog.space_unroll()
 
     # space-unroll the program twice to check that it works
-    assert prog._is_space_unrolled == True
+    assert prog.is_unrolled == True
 
 
 def test_rolling_space_unrolled():
@@ -255,17 +252,17 @@ def test_rolling_space_unrolled():
     num_subsystems_pre_roll = prog.num_subsystems
     init_num_subsystems_pre_roll = prog.init_num_subsystems
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
 
     # space-unroll the program
     prog.space_unroll()
 
-    assert prog._is_space_unrolled == True
+    assert prog.is_unrolled == True
 
     # roll the program back up
     prog.roll()
 
-    assert prog._is_space_unrolled == False
+    assert prog.is_unrolled == False
     assert prog.num_subsystems == num_subsystems_pre_roll
     assert prog.init_num_subsystems == init_num_subsystems_pre_roll
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -861,5 +861,9 @@ class TestUnrolling:
         prog.unroll(shots=shots)
         assert len(prog.circuit) == n * shots * prog_length
 
+        # unroll once more with the same shots to cover caching
+        prog.unroll(shots=shots)
+        assert len(prog.circuit) == n * shots * prog_length
+
         prog.roll()
         assert len(prog.circuit) == prog_length

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -843,7 +843,6 @@ class TestUnrolling:
     def test_unroll(self):
         """Test unrolling program."""
         n = 2
-        shots = 2
 
         prog = tdmprogram.TDMProgram(N=2)
         with prog.context([0] * n, [0] * n, [0] * n) as (p, q):
@@ -858,10 +857,33 @@ class TestUnrolling:
         prog.unroll()
         assert len(prog.circuit) == n * prog_length
 
+        prog.roll()
+        assert len(prog.circuit) == prog_length
+
+    def test_unroll_shots(self):
+        """Test unrolling program several times using different number of shots."""
+        n = 2
+        shots = 2
+
+        prog = tdmprogram.TDMProgram(N=2)
+        with prog.context([0] * n, [0] * n, [0] * n) as (p, q):
+            ops.Sgate(0.5643, 0) | q[1]
+            ops.BSgate(p[0]) | (q[1], q[0])
+            ops.Rgate(p[1]) | q[1]
+            ops.MeasureHomodyne(p[2]) | q[0]
+
+        prog_length = len(prog.circuit)
+        assert prog_length == 4
+
         prog.unroll(shots=shots)
         assert len(prog.circuit) == n * shots * prog_length
 
-        # unroll once more with the same shots to cover caching
+        # unroll once more with the same number of shots to cover caching
+        prog.unroll(shots=shots)
+        assert len(prog.circuit) == n * shots * prog_length
+
+        # unroll once more with a different number of shots
+        shots = 3
         prog.unroll(shots=shots)
         assert len(prog.circuit) == n * shots * prog_length
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -889,3 +889,28 @@ class TestUnrolling:
 
         prog.roll()
         assert len(prog.circuit) == prog_length
+
+    @pytest.mark.parametrize(
+        "space_unrolled, start_locked", [[True, True], [True, False], [False, True], [False, False]]
+    )
+    def test_locking_when_unrolling(self, space_unrolled, start_locked):
+        """Test that a locked program can be (un)rolled with the locking intact."""
+        prog = tdmprogram.TDMProgram(N=2)
+
+        with prog.context([0, 0], [0, 0], [0, 0]) as (p, q):
+            ops.Sgate(0.5643, 0) | q[1]
+            ops.BSgate(p[0]) | (q[1], q[0])
+            ops.Rgate(p[1]) | q[1]
+            ops.MeasureHomodyne(p[2]) | q[0]
+
+        if start_locked:
+            prog.lock()
+
+        assert prog.locked == start_locked
+
+        if space_unrolled:
+            prog.space_unroll()
+        else:
+            prog.unroll()
+
+        assert prog.locked == start_locked

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -835,3 +835,31 @@ class TestTDMValidation:
             CircuitError, match="Parameter has value '-999' while its valid range is "
         ):
             self.compile_test_program(device, args=args)
+
+
+class TestUnrolling:
+    """Test that (un)rolling programs work as expected."""
+
+    def test_unroll(self):
+        """Test unrolling program."""
+        n = 2
+        shots = 2
+
+        prog = tdmprogram.TDMProgram(N=2)
+        with prog.context([0] * n, [0] * n, [0] * n) as (p, q):
+            ops.Sgate(0.5643, 0) | q[1]
+            ops.BSgate(p[0]) | (q[1], q[0])
+            ops.Rgate(p[1]) | q[1]
+            ops.MeasureHomodyne(p[2]) | q[0]
+
+        prog_length = len(prog.circuit)
+        assert prog_length == 4
+
+        prog.unroll()
+        assert len(prog.circuit) == n * prog_length
+
+        prog.unroll(shots=shots)
+        assert len(prog.circuit) == n * shots * prog_length
+
+        prog.roll()
+        assert len(prog.circuit) == prog_length


### PR DESCRIPTION
**Context:**
When a program is compiled it is locked, and no further changes can be made to it. This means that a compiled program cannot be unrolled unless `Program.locked = False`.

**Description of the Change:**
`TDMProgram.unroll` and `TDMProgram.space_unroll` unlock the program before unrolling and, if it was locked before, locks it again.

**Benefits:**
Users no longer have to manually unlock programs before attempting to unroll them.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
