### PR TITLE
Pin `protobuf<4.21.0`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,6 +9,7 @@ numba==0.53.1
 networkx==2.6.3
 numpy==1.19.2
 plotly==4.4.1
+protobuf<4.21.0  # remove when fix is released
 quantum-blackbird==0.4.0
 scipy==1.7.1
 scikit-learn==1.0.2


### PR DESCRIPTION
New version of `protobuf` is released causing the documentation to fail.
```
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/google/protobuf/descriptor.py:560: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```
The temporary hotfix is to pin `protobuf<4.21.0`. However, this should be considered temporary, and be undone if/when `protobuf` --- or more likely, our primary dependencies such as TensorFlow --- releases a bugfix.