### PR TITLE
Combine assert modes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * `Program.assert_number_of_modes` and `Program.assert_max_number_of_measurements` are combined
   into a single `assert_modes` method.
-  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
+  [(#709)](https://github.com/XanaduAI/strawberryfields/pull/709)
 
 ### Bug fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,18 +7,22 @@
 ### Improvements
 
 * A locked program can now be (un)rolled, and automatically restores the lock if there.
-[(#703)](https://github.com/XanaduAI/strawberryfields/pull/703)
+  [(#703)](https://github.com/XanaduAI/strawberryfields/pull/703)
 
 * Rolling and unrolling now only happens in place, and does no longer return the (un)rolled circuit.
-[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+  [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+
+* `Program.assert_number_of_modes` and `Program.assert_max_number_of_measurements` are combined
+  into a single `assert_modes` method.
+  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
 
 ### Bug fixes
 
 * Trying to unroll an already unrolled program with a different number of shots works as expected.
-[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+  [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
 
 * Fixed bug with vacuum modes missing.
-[(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
+  [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
 
 ### Documentation
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -478,7 +478,7 @@ class TDMProgram(Program):
                 )
 
             if device.modes is not None:
-                self.assert_number_of_modes(device)
+                self.assert_modes(device)
 
             # First check: the gates are in the correct order
             program_gates = [cmd.op.__class__.__name__ for cmd in self.rolled_circuit]
@@ -763,7 +763,17 @@ class TDMProgram(Program):
 
         self.append(cmd.op.__class__(*params), modes)
 
-    def assert_number_of_modes(self, device):
+    def assert_modes(self, device):
+        """Check that the number of modes in the program is valid.
+
+        .. note::
+
+            ``device.modes`` must be a dictionary containing the maximum number of allowed
+            measurements for the specified target.
+
+        Args:
+            device (.strawberryfields.DeviceSpec): device specification object to use
+        """
         if self.timebins > device.modes["temporal_max"]:
             raise CircuitError(
                 f"This program contains {self.timebins} temporal modes, but the device '{device.target}' "

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -390,7 +390,7 @@ class TestProgram:
         assert y.val is None
 
     def test_assert_number_of_modes(self):
-        """Check that the correct error is raised when calling `prog.assert_number_of_modes`
+        """Check that the correct error is raised when calling `prog.assert_modes`
         with the incorrect number of modes."""
         device_dict = {
             "target": "abc",
@@ -410,7 +410,7 @@ class TestProgram:
             program.CircuitError,
             match="program contains 3 modes, but the device 'abc' only supports a 2-mode program",
         ):
-            prog.assert_number_of_modes(device)
+            prog.assert_modes(device)
 
     @pytest.mark.parametrize(
         "measure_op, measure_name",
@@ -423,7 +423,7 @@ class TestProgram:
             (ops.MeasureHeterodyne(select=0), "heterodyne"),  # MeasureHeterodyne
         ],
     )
-    def test_assert_max_number_of_measurements(self, measure_op, measure_name):
+    def test_assert_modes_dict(self, measure_op, measure_name):
         """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
         with the incorrect number of measurements in the circuit."""
         # set maximum number of measurements to 2, and measure 3 in prog below
@@ -442,9 +442,9 @@ class TestProgram:
                 measure_op | reg
 
         with pytest.raises(program.CircuitError, match=f"contains 3 {measure_name} measurements"):
-            prog.assert_max_number_of_measurements(device)
+            prog.assert_modes(device)
 
-    def test_keyerror_assert_max_number_of_measurements(self):
+    def test_keyerror_assert_modes_dict(self):
         """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
         with an incorrect device spec modes entry."""
         # set maximum number of measurements to 2, and measure 3 in prog below
@@ -464,14 +464,14 @@ class TestProgram:
 
         match = "Expected keys for the maximum allowed number of PNR"
         with pytest.raises(KeyError, match=match):
-            prog.assert_max_number_of_measurements(device)
+            prog.assert_modes(device)
 
-    def test_assert_max_number_of_measurements_wrong_entry(self):
+    def test_assert_modes_dict_wrong_entry(self):
         """Check that the correct error is raised when calling `prog.assert_number_of_measurements`
         with the incorrect type of device spec mode entry."""
         device_dict = {
             "target": "simulon_gaussian",
-            "modes": 2,
+            "modes": "pnr",
             "layout": "",
             "gate_parameters": {},
             "compiler": ["gaussian"],
@@ -484,7 +484,7 @@ class TestProgram:
             ops.S2gate(0.6) | [q[1], q[2]]
 
         with pytest.raises(KeyError, match="Expected keys for the maximum allowed number of PNR"):
-            prog.assert_max_number_of_measurements(device)
+            prog.assert_modes(device)
 
     def test_has_post_selection(self):
         """Check that the ``has_post_selection`` property behaves as expected when it uses


### PR DESCRIPTION
**Context:**
There are two methods that check that a various number of mode parameters are within the allowed limit specified in the device specification. These can easily, and should, be combined into a single method.

**Description of the Change:**
`Program.assert_number_of_modes` and `program.assert_max_number_of_measurements` are combined into a single `assert_modes` method.

**Benefits:**
The logic is simplified.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None