### PR TITLE
Unrolling fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,10 @@
 * Fixed bug with vacuum modes missing.
 [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
 
+* Store correct rolled circuit before unrolling (fixes issue when rolled circuit has changed due to
+  e.g., compilation).
+  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 * Store correct rolled circuit before unrolling (fixes issue when rolled circuit has changed due to
   e.g., compilation).
-  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
+  [(#710)](https://github.com/XanaduAI/strawberryfields/pull/710)
 
 ### Documentation
 

--- a/strawberryfields/tdm/tdmprogram.py
+++ b/strawberryfields/tdm/tdmprogram.py
@@ -395,7 +395,7 @@ class TDMProgram(Program):
         self._spatial_modes = 0
         self._measured_modes = set()
 
-        self.rolled_circuit = None
+        self.rolled_circuit = []
         # `unrolled_circuit` contains the unrolled single-shot circuit, reusing previously measured
         # modes (doesn't work with Fock measurements)
         self.unrolled_circuit = None
@@ -599,6 +599,9 @@ class TDMProgram(Program):
 
     def roll(self):
         """Represent the program in a compressed way without unrolling the for loops."""
+        if not self.is_unrolled:
+            return
+
         self._unrolled_shots = None
         self.circuit = self.rolled_circuit
 
@@ -683,6 +686,11 @@ class TDMProgram(Program):
 
     def _unroll_program(self, shots, space):
         """Construct the unrolled program either using space-unrolling or with register shift."""
+        # self.circuit should always be rolled here, so we can store `self.rolled_circuit`
+        self.rolled_circuit = self.circuit
+        assert not self.is_unrolled
+
+        # reset the circuit which is to be recreated below
         self.circuit = []
 
         q = self.register


### PR DESCRIPTION
**Context:**
If a rolled circuit is compiled and then later unrolled and then re-rolled, the un-compiled circuit, which has previously been stored, is used instead of rolling the circuit back to the compiled version.

**Description of the Change:**
Store correct rolled circuit before unrolling (fixes issue when rolled circuit has changed due to e.g., compilation).

**Benefits:**
Circuits can now be: compiled -> unrolled -> rolled without being reverted to the pre-compiled version.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None