### PR TITLE
Integer overflow protection flag

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Rolling and unrolling now only happens in place, and does no longer return the (un)rolled circuit.
 [(#702)](https://github.com/XanaduAI/strawberryfields/pull/702)
 
+* Job results can now be retrieved without converting integers to `np.int64` objects by setting
+  `integer_overflow_protection=False` (default `True`) when running a program via ``RemoteEngine.run()`.
+  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
+
 ### Bug fixes
 
 * Trying to unroll an already unrolled program with a different number of shots works as expected.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,7 +17,7 @@
   [(#709)](https://github.com/XanaduAI/strawberryfields/pull/709)
 
 * Job results can now be retrieved without converting integers to `np.int64` objects by setting
-  `integer_overflow_protection=False` (default `True`) when running a program via ``RemoteEngine.run()`.
+  `integer_overflow_protection=False` (default `True`) when running a program via `RemoteEngine.run()`.
   [(#712)](https://github.com/XanaduAI/strawberryfields/pull/712)
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * Job results can now be retrieved without converting integers to `np.int64` objects by setting
   `integer_overflow_protection=False` (default `True`) when running a program via ``RemoteEngine.run()`.
-  [(#XXX)](https://github.com/XanaduAI/strawberryfields/pull/XXX)
+  [(#712)](https://github.com/XanaduAI/strawberryfields/pull/712)
 
 ### Bug fixes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ toml==0.10.2
 typing-extensions==4.1.1
 urllib3==1.26.8
 quantum-xir==0.2.1
-xanadu-cloud-client==0.2.0
+xanadu-cloud-client==0.2.1

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -646,6 +646,11 @@ class RemoteEngine:
         Keyword Args:
             shots (Optional[int]): The number of shots for which to run the job. If this
                 argument is not provided, the shots are derived from the given ``program``.
+            integer_overflow_protection (Optional[bool]): Whether to enable the
+                conversion of integral job results into ``np.int64`` objects.
+                By default, integer overflow protection is enabled. For more
+                information, see `xcc.Job.get_result
+                <https://xanadu-cloud-client.readthedocs.io/en/stable/api/xcc.Job.html#xcc.Job.get_result>`_.
 
         Returns:
             strawberryfields.Result, None: the job result if successful, and ``None`` otherwise
@@ -683,7 +688,10 @@ class RemoteEngine:
 
         if job.status == "complete":
             self.log.info(f"The remote job {job.id} has been completed.")
-            return Result(job.result)
+
+            integer_overflow_protection = kwargs.get("integer_overflow_protection", True)
+            result = job.get_result(integer_overflow_protection=integer_overflow_protection)
+            return Result(result)
 
         message = f"The remote job {job.id} has failed with status {job.status}: {job.metadata}."
         self.log.info(message)

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -59,7 +59,7 @@ def job(connection, monkeypatch):
     result = {"output": [np.array([[1, 2], [3, 4]])], "foo": [np.array([5, 6])]}
 
     monkeypatch.setattr(xcc.Job, "submit", mock_return(job))
-    monkeypatch.setattr(xcc.Job, "result", result)
+    monkeypatch.setattr(xcc.Job, "get_result", mock_return(result))
     monkeypatch.setattr(xcc.Job, "clear", mock_return(None))
     monkeypatch.setattr(xcc.Job, "finished", finished)
     return job


### PR DESCRIPTION
**Context:**
To avoid overflow issues job results are automatically converted to `np.int64` objects. It can be of interest to keep the results as `np.int8` objects.

**Description of the Change:**
A flag `integer_overflow_protection` has been added to `RemoteEngine.run()` allowing users to return job results as `np.int8`.

**Benefits:**
* Job results can now be retrieved without converting integers to `np.int64` objects by setting `integer_overflow_protection=False` (default `True`) when running a program via `RemoteEngine.run()`.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
