### PR TITLE
Limit `Xstrict` validation to X-series compilers

### DIFF
--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -762,7 +762,7 @@ class RemoteEngine:
             self.log.info(msg)
             program = program.compile(device=device, **compile_options)
 
-        else:
+        elif program.compile_info[1][0] == "X":
             # validating program
             msg = (
                 f"Program previously compiled for {device.target} using {program.compile_info[1]}. "

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -284,7 +284,7 @@ class TestRemoteEngineIntegration:
         engine = sf.RemoteEngine("X8")
         device = engine.device
 
-        prog._compile_info = (device, device.compiler)
+        prog._compile_info = (device, device.compiler[0])
 
         compile_options = {"compiler": "Xunitary"}
         engine.run_async(prog, shots=10, compile_options=compile_options, recompile=True)
@@ -303,7 +303,7 @@ class TestRemoteEngineIntegration:
         engine = sf.RemoteEngine("X8")
         device = engine.device
 
-        prog._compile_info = (device, device.compiler)
+        prog._compile_info = (device, device.compiler[0])
 
         compile_options = {"compiler": "Xunitary"}
         engine.run(prog, shots=10, compile_options=compile_options, recompile=True)
@@ -326,7 +326,7 @@ class TestRemoteEngineIntegration:
         engine = sf.RemoteEngine("X8_01")
         device = engine.device
 
-        prog._compile_info = (device, device.compiler)
+        prog._compile_info = (device, device.compiler[0])
 
         engine.run_async(prog, shots=10)
 


### PR DESCRIPTION
**Context:**
If a compiler is used that it _not_ an X-series compiler (e.g., not Xcov or Xunitary), validation using Xstrict should not be used.

**Description of the Change:**
Validation using Xstrict is only performed when a program has been compiled using an X-series compiler.

**Benefits:**
Potential issues when running compiled programs are solved.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None