### PR TITLE
Increment Blackbird requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "numba",
     "numpy>=1.17.4",
     "python-dateutil>=2.8.0",
-    "quantum-blackbird>=0.3.0",
+    "quantum-blackbird>=0.4.0",
     "requests>=2.22.0",
     "scipy>=1.0.0",
     "sympy>=1.5",


### PR DESCRIPTION
**Context:**
Strawberry Fields requires Blackbird >= 0.4.0, but it's currently at >=0.3.0.

**Description of the Change:**
Increment Blackbird requirement to 0.4.0.

**Benefits:**
Less chance of something failing to an old version of Blackbird.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
