### PR TITLE
Uses scipy's Haar measure functions

### DIFF
--- a/strawberryfields/utils/random_numbers_matrices.py
+++ b/strawberryfields/utils/random_numbers_matrices.py
@@ -111,11 +111,5 @@ def random_interferometer(N, real=False):
         array: random :math:`N\times N` unitary distributed with the Haar measure
     """
     if real:
-        z = np.random.randn(N, N)
-    else:
-        z = randnc(N, N) / np.sqrt(2.0)
-    q, r = sp.linalg.qr(z)
-    d = np.diagonal(r)
-    ph = d / np.abs(d)
-    U = np.multiply(q, ph, q)
-    return U
+        return sp.stats.ortho_group.rvs(N)
+    return sp.stats.unitary_group.rvs(N)


### PR DESCRIPTION
Scipy implements the generation of Haar random unitary and orthogonal matrices, thus there is no need to implement them internally.