### PR TITLE
fix the bug in thermal loss for gaussian backend

### DIFF
--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -439,7 +439,7 @@ class GaussianModes:
             raise ValueError("Cannot apply loss channel, mode does not exist")
 
         self.loss(T, k)
-        self.nmat += (1 - T) * nbar
+        self.nmat[k, k] += (1 - T) * nbar
 
     def init_thermal(self, population, mode):
         """Initializes a state of mode in a thermal state with the given population"""


### PR DESCRIPTION
**Context:** The thermal loss factor was added to the full nmatrix of the object in the backend, but it shouldn't be.

**Description of the Change:** Rewrite the thermal loss.

**Benefits:**

**Possible Drawbacks:** the variable "k" doesn't have a type hint so it is considered as int here, which may cause problems in the future.

**Related GitHub Issues:**
