### PR TITLE
change the purity calculation for gaussian state

### DIFF
--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -1010,8 +1010,8 @@ class BaseGaussianState(BaseState):
         self._alpha /= np.sqrt(2 * self._hbar)
 
         self._pure = (
-            np.abs(np.linalg.det(self._cov) - (self._hbar / 2) ** (2 * self._modes))
-            < self.EQ_TOLERANCE
+            np.abs(np.linalg.det(self._cov)) / (self._hbar / 2) ** (2 * self._modes)
+            == 1.0
         )
 
         self._basis = "gaussian"


### PR DESCRIPTION
**Context:** The purity calculation for gaussian state depends on the precision in SF, however, in some cases, this value can be small but the tolerance is not enough small to detect it, hence, the state which should be mixed become a "pure" tag in the gaussian backend calculation.

**Description of the Change:** This PR fix the calculation from `a - b <tol` into `a/b == 1.0` as the condition.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
