### PR TITLE
Update decomposition function

### DIFF
--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -612,7 +612,7 @@ def triangular(V, tol=1e-11):
             :math:`|VV^\dagger-I| \leq` tol
 
     Returns:
-        tuple[array]: returns a tuple of the form ``(tlist,np.diag(localV), None)``
+        tuple[array]: returns a tuple of the form ``(None,np.diag(localV), tlist)``
             where:
 
             * ``tlist``: list containing ``[n,m,theta,phi,n_size]`` of the T unitaries needed
@@ -630,7 +630,7 @@ def triangular(V, tol=1e-11):
             tlist.append(nullT(nsize - j - 1, nsize - i - 2, localV))
             localV = T(*tlist[-1]) @ localV
 
-    return list(reversed(tlist)), np.diag(localV), None
+    return None, np.diag(localV), tlist
 
 
 def M(n, sigma, delta, m):

--- a/strawberryfields/ops.py
+++ b/strawberryfields/ops.py
@@ -2664,26 +2664,29 @@ class Interferometer(Decomposition):
             decomp_fn = getattr(dec, mesh)
             BS1, R, BS2 = decomp_fn(self.p[0], tol=tol)
 
-            for n, m, theta, phi, _ in BS1:
-                theta = theta if np.abs(theta) >= _decomposition_tol else 0
-                phi = phi if np.abs(phi) >= _decomposition_tol else 0
 
-                if "symmetric" in mesh:
-                    # Mach-Zehnder interferometers
-                    cmds.append(
-                        Command(
-                            MZgate(np.mod(theta, 2 * np.pi), np.mod(phi, 2 * np.pi)),
-                            (reg[n], reg[m]),
+            if BS1 is not None:
+
+                for n, m, theta, phi, _ in BS1:
+                    theta = theta if np.abs(theta) >= _decomposition_tol else 0
+                    phi = phi if np.abs(phi) >= _decomposition_tol else 0
+
+                    if "symmetric" in mesh:
+                        # Mach-Zehnder interferometers
+                        cmds.append(
+                            Command(
+                                MZgate(np.mod(theta, 2 * np.pi), np.mod(phi, 2 * np.pi)),
+                                (reg[n], reg[m]),
+                            )
                         )
-                    )
 
-                else:
-                    # Clements style beamsplitters
-                    if not (drop_identity and phi == 0):
-                        cmds.append(Command(Rgate(phi), reg[n]))
+                    else:
+                        # Clements style beamsplitters
+                        if not (drop_identity and phi == 0):
+                            cmds.append(Command(Rgate(phi), reg[n]))
 
-                    if not (drop_identity and theta == 0):
-                        cmds.append(Command(BSgate(theta, 0), (reg[n], reg[m])))
+                        if not (drop_identity and theta == 0):
+                            cmds.append(Command(BSgate(theta, 0), (reg[n], reg[m])))
 
             for n, expphi in enumerate(R):
                 # local phase shifts

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -355,7 +355,7 @@ class TestTriangularDecomposition:
 
         qrec = np.diag(diags)
 
-        for i in tlist:
+        for i in reversed(tlist):
             qrec = dec.Ti(*i) @ qrec
 
         assert np.allclose(U, qrec, atol=tol, rtol=0)

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -351,7 +351,7 @@ class TestTriangularDecomposition:
         n = 20
         U = np.identity(n)
 
-        tlist, diags, _ = dec.triangular(U)
+        _, diags, tlist = dec.triangular(U)
 
         qrec = np.diag(diags)
 
@@ -373,7 +373,7 @@ class TestTriangularDecomposition:
         n = 20
         U = haar_measure(n)
 
-        tlist, diags, _ = dec.triangular(U)
+        _, diags, tlist = dec.triangular(U)
 
         qrec = np.diag(diags)
 

--- a/tests/frontend/test_interferometer_triangular.py
+++ b/tests/frontend/test_interferometer_triangular.py
@@ -1,0 +1,54 @@
+import strawberryfields as sf
+from strawberryfields.ops import *
+import numpy as np
+
+M = 4
+# Create a random complex matrix
+random_matrix = np.random.rand(M, M) + 1j * np.random.rand(M, M)
+
+# Perform QR decomposition to get a unitary matrix
+q, r = np.linalg.qr(random_matrix)
+
+# Normalize to ensure unitary property (q should already be unitary, but we'll double-check)
+unitary_matrix = q / np.linalg.norm(q, axis=0)
+
+
+boson_sampling_triangular = sf.Program(4)
+#initiate a starting state |1101>
+with boson_sampling_triangular.context as q:
+    # prepare the input fock states
+    Fock(1) | q[0]
+    Fock(1) | q[1]
+    Vac     | q[2]
+    Fock(1) | q[3]
+
+    # apply the triangular interferometer
+    Interferometer(unitary_matrix, mesh = 'triangular', tol = 1e-10) | q
+
+#run the simulation
+boson_sampling_triangular.compile(compiler="fock")
+eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": 5})
+results = eng.run(boson_sampling_triangular)
+# extract the joint Fock probabilities
+probs_triangular = results.state.all_fock_probs()
+
+#now try with mesh = 'rectangular'
+boson_sampling_rectangular = sf.Program(4)
+
+with boson_sampling_rectangular.context as q:
+    # prepare the input fock states
+    Fock(1) | q[0]
+    Fock(1) | q[1]
+    Vac     | q[2]
+    Fock(1) | q[3]
+
+    # apply the rectangular interferometer
+    Interferometer(unitary_matrix, mesh = 'rectangular', tol = 1e-10) | q
+    
+boson_sampling_rectangular.compile(compiler="fock")
+eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": 5})
+results = eng.run(boson_sampling_rectangular)
+# extract the joint Fock probabilities
+probs_rect = results.state.all_fock_probs()
+#all probabilities should be the same here! Sp the output should be True
+print(f"{np.allclose(probs_triangular, probs_rect)}")


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Ensure that code and tests are properly formatted, by running `make format` or `black -l 100
      <filename>` on any relevant files. You will need to have the Black code format installed: 
      `pip install black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Strawberry Fields source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint strawberryfields/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
During testing the interferometer Class I came across the problem that  Interferometer(unitary_matrix, mesh = 'triangular', tol = 1e-10)  and  Interferometer(unitary_matrix, mesh = 'rectangular_phase_end', tol = 1e-10) give different results when applied within the boson sampling. As the matrix we are starting with is the same that should not be (see also here: https://discuss.pennylane.ai/t/problems-in-understanding-sf-decompositions-triangular/7875/6 for more details and the discussion).


**Description of the Change:**
I changed the following things: 
the order of the return in the triangular decomposition from reversed(tlist), np,diag(localV), None to None, np,diag(localV), t_list so that in the Interferometer_decomposition function the order of application is first the diagonal (phase shifters) and then the T_i[0] to T_i[N]. 
Then I changed the interferometer_decompose method such that it checks if the BS1 from the Decomposition is None.
I also provided the minimal example as a test with which i tested the interferometer class. Now the results for both are the same as it should be. 

**Benefits:**

Fixed a problem with the triangular decomposition in the Interferometer.

**Possible Drawbacks:**
Since I changed the return of the triangular decomposition it might affect other functions. Maybe we should check that first!!

**Related GitHub Issues:**
Not a gitub Issue but here the form discussion I had:
https://discuss.pennylane.ai/t/problems-in-understanding-sf-decompositions-triangular/7875/6