### PR TITLE
fixes broken scipy import

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 <h3>Bug fixes</h3>
 
+* Scipy>=1.0.0 is supported as a dependency and broken imports related to newer
+  scipy versions are fixed.
+  [(#756)](https://github.com/XanaduAI/strawberryfields/pull/756)
+
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,14 +37,14 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Strawberry Fields
         run: |
           pip install -r requirements-ci.txt
-          python3 setup.py bdist_wheel
+          python3 -m build --wheel
           pip install dist/strawberryfields*.whl
 
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Strawberry Fields
         run: |
           pip install -r requirements-ci.txt
-          python3 -m build --wheel
+          python3 setup.py bdist_wheel
           pip install dist/strawberryfields*.whl
 
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install -r requirements-ci.txt
           python3 setup.py bdist_wheel
-          pip install dist/StrawberryFields*.whl
+          pip install dist/strawberryfields*.whl
 
       - name: Run tests
         run: python3 -m pytest tests --cov=strawberryfields --cov-report=term-missing --cov-report=xml -p no:warnings --randomly-seed=42 --tb=native -m "$OPTIONS"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.8
   install:
       - requirements: doc/requirements.txt
       - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,22 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 sphinx:
   configuration: doc/conf.py
 
 python:
-    version: 3.8
-    install:
-        - requirements: doc/requirements.txt
-        - method: pip
-          path: .
-    system_packages: true
+  version: 3.8
+  install:
+      - requirements: doc/requirements.txt
+      - method: pip
+        path: .
+  system_packages: true
 
 build:
-    image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,5 @@
 version: 2
 
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.12"
-
 sphinx:
   configuration: doc/conf.py
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ python:
       - requirements: doc/requirements.txt
       - method: pip
         path: .
-  system_packages: true
 
 build:
   os: ubuntu-22.04

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ jinja2==3.0.3
 sphinx==2.2.2
 m2r2==0.3.1
 mistune==0.8.4
-numba==0.53.1
+numba==0.61.2
 networkx==2.6.3
 numpy==1.19.2
 plotly==4.4.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,3 +21,4 @@ tensorflow==2.6.3
 thewalrus==0.18.0
 toml==0.10.2
 xanadu-sphinx-theme==0.1.0
+setuptools

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,5 +10,6 @@ thewalrus>=0.17.0
 toml
 numba
 requests
+setuptools
 urllib3
 plotly

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "requests>=2.22.0",
     "scipy>=1.0.0",
     "sympy>=1.5",
-    "thewalrus>=0.18.0",
+    "thewalrus>=0.18.0,<0.20.0",
     "toml",
     "urllib3>=1.25.3",
     "quantum-xir>=0.1.1",

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 with open("strawberryfields/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
@@ -42,8 +41,13 @@ info = {
     "url": "https://github.com/XanaduAI/StrawberryFields",
     "license": "Apache License 2.0",
     "packages": find_packages(where="."),
-    "package_data": {"strawberryfields": ["backends/data/*", "apps/data/feature_data/*",
-                                          "apps/data/sample_data/*"]},
+    "package_data": {
+        "strawberryfields": [
+            "backends/data/*",
+            "apps/data/feature_data/*",
+            "apps/data/sample_data/*",
+        ]
+    },
     "include_package_data": True,
     "description": "Open source library for continuous-variable quantum computation",
     "long_description": open("README.md", encoding="utf-8").read(),
@@ -51,7 +55,10 @@ info = {
     "provides": ["strawberryfields"],
     "install_requires": requirements,
     "command_options": {
-        "build_sphinx": {"version": ("setup.py", version), "release": ("setup.py", version)}
+        "build_sphinx": {
+            "version": ("setup.py", version),
+            "release": ("setup.py", version),
+        }
     },
 }
 

--- a/strawberryfields/__init__.py
+++ b/strawberryfields/__init__.py
@@ -21,17 +21,16 @@ and backend components (all found within the :mod:`strawberryfields.backends` su
     :width: 90%
     :target: javascript:void(0);
 """
-from . import apps
+from . import apps, tdm
 from ._version import __version__
+from .device import Device
 from .engine import Engine, LocalEngine, RemoteEngine
 from .io import load, save
 from .parameters import par_funcs as math
+from .plot import plot_fock, plot_quad, plot_wigner
 from .program import Program
-from .tdm import TDMProgram
-from .plot import plot_wigner, plot_fock, plot_quad
-from . import tdm
-from .device import Device
 from .result import Result
+from .tdm import TDMProgram
 
 __all__ = [
     "Engine",
@@ -90,15 +89,16 @@ def about():
         TensorFlow version:        2.5.1
     """
     # pylint: disable=import-outside-toplevel
-    import sys
-    import platform
     import os
+    import platform
+    import sys
+
+    import blackbird
+    import networkx
     import numpy
     import scipy
     import sympy
-    import networkx
     import thewalrus
-    import blackbird
     import xcc
 
     # a QuTiP-style infobox

--- a/strawberryfields/_version.py
+++ b/strawberryfields/_version.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Version information.
-   Version number (major.minor.patch[-label])
+
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.24.0-dev"

--- a/strawberryfields/apps/__init__.py
+++ b/strawberryfields/apps/__init__.py
@@ -11,22 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This package contains the modules that make up the
-Strawberry Fields application layer.
+"""This package contains the modules that make up the Strawberry Fields application
+layer.
 
 .. currentmodule:: strawberryfields.apps
 .. autosummary::
     :toctree: api
 
-	clique
-	data
-	plot
-	points
-	qchem
-	sample
-	similarity
-	subgraph
-	train
+        clique
+        data
+        plot
+        points
+        qchem
+        sample
+        similarity
+        subgraph
+        train
 """
 
 import strawberryfields.apps.clique

--- a/strawberryfields/apps/data/__init__.py
+++ b/strawberryfields/apps/data/__init__.py
@@ -70,6 +70,15 @@ these datasets inherit.
 import strawberryfields.apps.data.feature
 import strawberryfields.apps.data.sample
 from strawberryfields.apps.data.feature import MUTAG, QM9MC, QM9Exact
-from strawberryfields.apps.data.sample import (Formic, Mutag0, Mutag1, Mutag2,
-                                               Mutag3, PHat, Planted, Pyrrole,
-                                               TaceAs, Water)
+from strawberryfields.apps.data.sample import (
+    Formic,
+    Mutag0,
+    Mutag1,
+    Mutag2,
+    Mutag3,
+    PHat,
+    Planted,
+    Pyrrole,
+    TaceAs,
+    Water,
+)

--- a/strawberryfields/apps/data/__init__.py
+++ b/strawberryfields/apps/data/__init__.py
@@ -67,22 +67,9 @@ these datasets inherit.
         feature
 """
 
-import strawberryfields.apps.data.sample
 import strawberryfields.apps.data.feature
-from strawberryfields.apps.data.sample import (
-    Planted,
-    TaceAs,
-    PHat,
-    Mutag0,
-    Mutag1,
-    Mutag2,
-    Mutag3,
-    Formic,
-    Water,
-    Pyrrole,
-)
-from strawberryfields.apps.data.feature import (
-    MUTAG,
-    QM9Exact,
-    QM9MC,
-)
+import strawberryfields.apps.data.sample
+from strawberryfields.apps.data.feature import MUTAG, QM9MC, QM9Exact
+from strawberryfields.apps.data.sample import (Formic, Mutag0, Mutag1, Mutag2,
+                                               Mutag3, PHat, Planted, Pyrrole,
+                                               TaceAs, Water)

--- a/strawberryfields/apps/data/feature.py
+++ b/strawberryfields/apps/data/feature.py
@@ -16,8 +16,9 @@ Submodule for feature vector datasets and their base classes.
 """
 # pylint: disable=unnecessary-pass
 from abc import ABC, abstractmethod
-import pkg_resources
+
 import numpy as np
+import pkg_resources
 
 DATA_PATH = pkg_resources.resource_filename("strawberryfields", "apps/data/feature_data") + "/"
 

--- a/strawberryfields/apps/data/sample.py
+++ b/strawberryfields/apps/data/sample.py
@@ -11,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""
-Submodule for sample datasets and their base classes.
-"""
+r"""Submodule for sample datasets and their base classes."""
 # pylint: disable=unnecessary-pass
 from abc import ABC, abstractmethod
 
-import pkg_resources
 import numpy as np
+import pkg_resources
 import scipy
 
 DATA_PATH = pkg_resources.resource_filename("strawberryfields", "apps/data/sample_data") + "/"
@@ -42,13 +40,15 @@ class SampleDataset(ABC):
     @property
     @abstractmethod
     def _data_filename(self) -> str:
-        """Base name of files containing the sample data stored in the ``./sample_data/`` directory.
+        """Base name of files containing the sample data stored in the
+        ``./sample_data/`` directory.
 
         Samples and corresponding adjacency matrix should both be provided as a
         ``scipy.sparse.csr_matrix`` saved in ``.npz`` format.
 
         For ``_data_filename = "example"``, the corresponding samples should be stored as
-        ``./sample_data/example.npz`` and the adjacency matrix as ``./sample_data/example_A.npz``."""
+        ``./sample_data/example.npz`` and the adjacency matrix as ``./sample_data/example_A.npz``.
+        """
         pass
 
     def __init__(self):

--- a/strawberryfields/apps/points.py
+++ b/strawberryfields/apps/points.py
@@ -51,7 +51,8 @@ function.
 
 import numpy as np
 import scipy
-from thewalrus.csamples import generate_thermal_samples, rescale_adjacency_matrix_thermal
+from thewalrus.csamples import (generate_thermal_samples,
+                                rescale_adjacency_matrix_thermal)
 
 
 def rbf_kernel(R: np.ndarray, sigma: float) -> np.ndarray:

--- a/strawberryfields/apps/points.py
+++ b/strawberryfields/apps/points.py
@@ -51,8 +51,7 @@ function.
 
 import numpy as np
 import scipy
-from thewalrus.csamples import (generate_thermal_samples,
-                                rescale_adjacency_matrix_thermal)
+from thewalrus.csamples import generate_thermal_samples, rescale_adjacency_matrix_thermal
 
 
 def rbf_kernel(R: np.ndarray, sigma: float) -> np.ndarray:

--- a/strawberryfields/apps/sample.py
+++ b/strawberryfields/apps/sample.py
@@ -107,8 +107,7 @@ import networkx as nx
 import numpy as np
 
 import strawberryfields as sf
-from strawberryfields.apps.qchem.vibronic import \
-    sample as vibronic  # pylint: disable=unused-import
+from strawberryfields.apps.qchem.vibronic import sample as vibronic  # pylint: disable=unused-import
 
 
 def sample(

--- a/strawberryfields/apps/sample.py
+++ b/strawberryfields/apps/sample.py
@@ -107,7 +107,8 @@ import networkx as nx
 import numpy as np
 
 import strawberryfields as sf
-from strawberryfields.apps.qchem.vibronic import sample as vibronic  # pylint: disable=unused-import
+from strawberryfields.apps.qchem.vibronic import \
+    sample as vibronic  # pylint: disable=unused-import
 
 
 def sample(

--- a/strawberryfields/apps/similarity.py
+++ b/strawberryfields/apps/similarity.py
@@ -125,10 +125,10 @@ from typing import Generator, Union
 import networkx as nx
 import numpy as np
 from scipy.special import factorial
+from sympy.utilities.iterables import multiset_permutations
 
 import strawberryfields as sf
 from strawberryfields.backends import BaseGaussianState
-from sympy.utilities.iterables import multiset_permutations
 
 
 def sample_to_orbit(sample: list) -> list:

--- a/strawberryfields/apps/train/__init__.py
+++ b/strawberryfields/apps/train/__init__.py
@@ -93,6 +93,10 @@ Related tutorials
 
 from strawberryfields.apps.train.cost import KL, Stochastic
 from strawberryfields.apps.train.embed import Exp, ExpFeatures
-from strawberryfields.apps.train.param import (VGBS, A_to_cov, prob_click,
-                                               prob_photon_sample,
-                                               rescale_adjacency)
+from strawberryfields.apps.train.param import (
+    VGBS,
+    A_to_cov,
+    prob_click,
+    prob_photon_sample,
+    rescale_adjacency,
+)

--- a/strawberryfields/apps/train/__init__.py
+++ b/strawberryfields/apps/train/__init__.py
@@ -93,10 +93,6 @@ Related tutorials
 
 from strawberryfields.apps.train.cost import KL, Stochastic
 from strawberryfields.apps.train.embed import Exp, ExpFeatures
-from strawberryfields.apps.train.param import (
-    VGBS,
-    A_to_cov,
-    prob_click,
-    prob_photon_sample,
-    rescale_adjacency,
-)
+from strawberryfields.apps.train.param import (VGBS, A_to_cov, prob_click,
+                                               prob_photon_sample,
+                                               rescale_adjacency)

--- a/strawberryfields/apps/train/__init__.py
+++ b/strawberryfields/apps/train/__init__.py
@@ -1,5 +1,4 @@
-r"""
-Tools for training variational GBS devices.
+r"""Tools for training variational GBS devices.
 
 .. currentmodule:: strawberryfields.apps.train
 
@@ -90,8 +89,8 @@ Related tutorials
 
     <div style='clear:both'></div>
     <br>
-
 """
+
 from strawberryfields.apps.train.cost import KL, Stochastic
 from strawberryfields.apps.train.embed import Exp, ExpFeatures
 from strawberryfields.apps.train.param import (

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -68,11 +68,12 @@ statevector backend API
 
 """
 
-from .base import BaseBackend, BaseFock, BaseGaussian, BaseBosonic, ModeMap
-from .gaussianbackend import GaussianBackend
-from .fockbackend import FockBackend
+from .base import BaseBackend, BaseBosonic, BaseFock, BaseGaussian, ModeMap
 from .bosonicbackend import BosonicBackend
-from .states import BaseState, BaseGaussianState, BaseFockState, BaseBosonicState
+from .fockbackend import FockBackend
+from .gaussianbackend import GaussianBackend
+from .states import (BaseBosonicState, BaseFockState, BaseGaussianState,
+                     BaseState)
 
 # There is no import for the TFBackend to avoid TensorFlow being a direct
 # requirement of SF through a chain of imports
@@ -109,7 +110,8 @@ def load_backend(name):
     if name == "tf":
         # treat the tensorflow backend differently, to
         # isolate the import of TensorFlow
-        from .tfbackend import TFBackend  # pylint: disable=import-outside-toplevel
+        from .tfbackend import \
+            TFBackend  # pylint: disable=import-outside-toplevel
 
         return TFBackend()
 

--- a/strawberryfields/backends/__init__.py
+++ b/strawberryfields/backends/__init__.py
@@ -72,8 +72,7 @@ from .base import BaseBackend, BaseBosonic, BaseFock, BaseGaussian, ModeMap
 from .bosonicbackend import BosonicBackend
 from .fockbackend import FockBackend
 from .gaussianbackend import GaussianBackend
-from .states import (BaseBosonicState, BaseFockState, BaseGaussianState,
-                     BaseState)
+from .states import BaseBosonicState, BaseFockState, BaseGaussianState, BaseState
 
 # There is no import for the TFBackend to avoid TensorFlow being a direct
 # requirement of SF through a chain of imports
@@ -110,8 +109,7 @@ def load_backend(name):
     if name == "tf":
         # treat the tensorflow backend differently, to
         # isolate the import of TensorFlow
-        from .tfbackend import \
-            TFBackend  # pylint: disable=import-outside-toplevel
+        from .tfbackend import TFBackend  # pylint: disable=import-outside-toplevel
 
         return TFBackend()
 

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -15,23 +15,21 @@
 
 """Bosonic backend"""
 import itertools as it
-from functools import reduce
 from collections.abc import Iterable
+from functools import reduce
 
 import numpy as np
-
-from scipy.special import comb
+import sympy
 from scipy.linalg import block_diag
-
+from scipy.special import comb
 from thewalrus.symplectic import xxpp_to_xpxp
 
 from strawberryfields.backends import BaseBosonic
-from strawberryfields.backends.states import BaseBosonicState
-
-from strawberryfields.backends.bosonicbackend.bosoniccircuit import BosonicModes
 from strawberryfields.backends.base import NotApplicableError
+from strawberryfields.backends.bosonicbackend.bosoniccircuit import \
+    BosonicModes
+from strawberryfields.backends.states import BaseBosonicState
 from strawberryfields.program_utils import CircuitError
-import sympy
 
 
 def kron_list(l):
@@ -102,16 +100,9 @@ class BosonicBackend(BaseBosonic):
             NotApplicableError: if an op in the program does not apply to the bosonic backend
             NotImplementedError: if an op in the program is not implemented in the bosonic backend
         """
-        from strawberryfields.ops import (
-            Bosonic,
-            Catstate,
-            DensityMatrix,
-            Fock,
-            GKP,
-            Ket,
-            MSgate,
-            _New_modes,
-        )
+        from strawberryfields.ops import (GKP, Bosonic, Catstate,
+                                          DensityMatrix, Fock, Ket, MSgate,
+                                          _New_modes)
 
         # If a circuit exists, initialize the circuit. This applies all non-Gaussian state-prep
         if prog.circuit:
@@ -190,15 +181,8 @@ class BosonicBackend(BaseBosonic):
             CircuitError: if any of the parameters for non-Gaussian state preparation
                 are symbolic
         """
-        from strawberryfields.ops import (
-            Bosonic,
-            Catstate,
-            DensityMatrix,
-            Fock,
-            GKP,
-            Ket,
-            _New_modes,
-        )
+        from strawberryfields.ops import (GKP, Bosonic, Catstate,
+                                          DensityMatrix, Fock, Ket, _New_modes)
 
         # _New_modes is what gets checked when New() is called in a program circuit.
         # It is included here since it could be used to instantiate a mode for non-Gaussian

--- a/strawberryfields/backends/bosonicbackend/backend.py
+++ b/strawberryfields/backends/bosonicbackend/backend.py
@@ -26,8 +26,7 @@ from thewalrus.symplectic import xxpp_to_xpxp
 
 from strawberryfields.backends import BaseBosonic
 from strawberryfields.backends.base import NotApplicableError
-from strawberryfields.backends.bosonicbackend.bosoniccircuit import \
-    BosonicModes
+from strawberryfields.backends.bosonicbackend.bosoniccircuit import BosonicModes
 from strawberryfields.backends.states import BaseBosonicState
 from strawberryfields.program_utils import CircuitError
 
@@ -100,9 +99,16 @@ class BosonicBackend(BaseBosonic):
             NotApplicableError: if an op in the program does not apply to the bosonic backend
             NotImplementedError: if an op in the program is not implemented in the bosonic backend
         """
-        from strawberryfields.ops import (GKP, Bosonic, Catstate,
-                                          DensityMatrix, Fock, Ket, MSgate,
-                                          _New_modes)
+        from strawberryfields.ops import (
+            GKP,
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            Ket,
+            MSgate,
+            _New_modes,
+        )
 
         # If a circuit exists, initialize the circuit. This applies all non-Gaussian state-prep
         if prog.circuit:
@@ -181,8 +187,15 @@ class BosonicBackend(BaseBosonic):
             CircuitError: if any of the parameters for non-Gaussian state preparation
                 are symbolic
         """
-        from strawberryfields.ops import (GKP, Bosonic, Catstate,
-                                          DensityMatrix, Fock, Ket, _New_modes)
+        from strawberryfields.ops import (
+            GKP,
+            Bosonic,
+            Catstate,
+            DensityMatrix,
+            Fock,
+            Ket,
+            _New_modes,
+        )
 
         # _New_modes is what gets checked when New() is called in a program circuit.
         # It is included here since it could be used to instantiate a mode for non-Gaussian

--- a/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
+++ b/strawberryfields/backends/bosonicbackend/bosoniccircuit.py
@@ -15,9 +15,10 @@
 """Bosonic circuit operations"""
 # pylint: disable=duplicate-code,attribute-defined-outside-init
 import itertools as it
+
 import numpy as np
-from scipy.linalg import block_diag
 import thewalrus.symplectic as symp
+from scipy.linalg import block_diag
 
 from strawberryfields.backends.bosonicbackend import ops
 

--- a/strawberryfields/backends/fockbackend/backend.py
+++ b/strawberryfields/backends/fockbackend/backend.py
@@ -16,6 +16,7 @@
 
 import string
 from cmath import phase
+
 import numpy as np
 
 from strawberryfields.backends import BaseFock, ModeMap

--- a/strawberryfields/backends/fockbackend/circuit.py
+++ b/strawberryfields/backends/fockbackend/circuit.py
@@ -16,14 +16,14 @@
 # pylint: disable=too-many-branches,too-many-locals,too-many-public-methods
 
 import copy
-import string
 import numbers
+import string
 from itertools import product
 
 import numpy as np
-from numpy import sqrt, pi
-from scipy.special import factorial as bang
 from numba import jit
+from numpy import pi, sqrt
+from scipy.special import factorial as bang
 
 from . import ops
 

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -21,19 +21,16 @@ import string
 from itertools import product
 
 import numpy as np
-from numpy import sqrt, sinh, cosh, tanh, array, exp
+from numpy import array, cosh, exp, sinh, sqrt, tanh
 from numpy.polynomial.hermite import hermval as H
-
-from scipy.special import factorial as fac
 from scipy.linalg import expm as matrixExp
-
-from thewalrus.fock_gradients import (
-    displacement as displacement_tw,
-    squeezing as squeezing_tw,
-    two_mode_squeezing as two_mode_squeezing_tw,
-    beamsplitter as beamsplitter_tw,
-    mzgate as mzgate_tw,
-)
+from scipy.special import factorial as fac
+from thewalrus.fock_gradients import beamsplitter as beamsplitter_tw
+from thewalrus.fock_gradients import displacement as displacement_tw
+from thewalrus.fock_gradients import mzgate as mzgate_tw
+from thewalrus.fock_gradients import squeezing as squeezing_tw
+from thewalrus.fock_gradients import \
+    two_mode_squeezing as two_mode_squeezing_tw
 
 def_type = np.complex128
 indices = string.ascii_lowercase

--- a/strawberryfields/backends/fockbackend/ops.py
+++ b/strawberryfields/backends/fockbackend/ops.py
@@ -29,8 +29,7 @@ from thewalrus.fock_gradients import beamsplitter as beamsplitter_tw
 from thewalrus.fock_gradients import displacement as displacement_tw
 from thewalrus.fock_gradients import mzgate as mzgate_tw
 from thewalrus.fock_gradients import squeezing as squeezing_tw
-from thewalrus.fock_gradients import \
-    two_mode_squeezing as two_mode_squeezing_tw
+from thewalrus.fock_gradients import two_mode_squeezing as two_mode_squeezing_tw
 
 def_type = np.complex128
 indices = string.ascii_lowercase

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -15,7 +15,8 @@
 """Gaussian backend"""
 import warnings
 
-from numpy import empty, concatenate, array, identity, sqrt, vstack, zeros_like, allclose, ix_
+from numpy import (allclose, array, concatenate, empty, identity, ix_, sqrt,
+                   vstack, zeros_like)
 from thewalrus.samples import hafnian_sample_state, torontonian_sample_state
 from thewalrus.symplectic import xxpp_to_xpxp
 

--- a/strawberryfields/backends/gaussianbackend/backend.py
+++ b/strawberryfields/backends/gaussianbackend/backend.py
@@ -15,8 +15,7 @@
 """Gaussian backend"""
 import warnings
 
-from numpy import (allclose, array, concatenate, empty, identity, ix_, sqrt,
-                   vstack, zeros_like)
+from numpy import allclose, array, concatenate, empty, identity, ix_, sqrt, vstack, zeros_like
 from thewalrus.samples import hafnian_sample_state, torontonian_sample_state
 from thewalrus.symplectic import xxpp_to_xpxp
 

--- a/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
+++ b/strawberryfields/backends/gaussianbackend/gaussiancircuit.py
@@ -15,7 +15,7 @@
 # pylint: disable=duplicate-code,attribute-defined-outside-init
 import numpy as np
 from thewalrus.quantum import Xmat
-from thewalrus.symplectic import xxpp_to_xpxp, xpxp_to_xxpp
+from thewalrus.symplectic import xpxp_to_xxpp, xxpp_to_xpxp
 
 from . import ops
 

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -40,6 +40,7 @@ indices = string.ascii_lowercase
 
 class BaseState(abc.ABC):
     r"""Abstract base class for the representation of quantum states."""
+
     # pylint: disable=too-many-public-methods
     EQ_TOLERANCE = 1e-10
 
@@ -1006,6 +1007,7 @@ class BaseGaussianState(BaseState):
         mode_names (Sequence): (optional) this argument contains a list providing mode names
             for each mode in the state
     """
+
     # pylint: disable=too-many-public-methods
 
     def __init__(self, state_data, num_modes, mode_names=None):
@@ -1443,6 +1445,7 @@ class BaseBosonicState(BaseState):
         mode_names (Sequence): (optional) this argument contains a list providing mode names
             for each mode in the state
     """
+
     # pylint: disable=too-many-public-methods
 
     def __init__(self, state_data, num_modes, num_weights, mode_names=None):

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -20,20 +20,20 @@ from itertools import chain
 
 import numpy as np
 import scipy.integrate
+import thewalrus.quantum as twq
 from scipy.linalg import block_diag
 from scipy.special import factorial
 from scipy.stats import multivariate_normal
+from thewalrus.symplectic import rotation as _R
+from thewalrus.symplectic import xpxp_to_xxpp
+
+import strawberryfields as sf
 
 try:
     simps = scipy.integrate.simpson
 except AttribueError:  # scipy<1.0.0
     simps = scipy.integrate.simps
 
-import thewalrus.quantum as twq
-from thewalrus.symplectic import rotation as _R
-from thewalrus.symplectic import xpxp_to_xxpp
-
-import strawberryfields as sf
 
 indices = string.ascii_lowercase
 

--- a/strawberryfields/backends/states.py
+++ b/strawberryfields/backends/states.py
@@ -31,7 +31,7 @@ import strawberryfields as sf
 
 try:
     simps = scipy.integrate.simpson
-except AttribueError:  # scipy<1.0.0
+except AttributeError:  # scipy<1.0.0
     simps = scipy.integrate.simps
 
 

--- a/strawberryfields/backends/tfbackend/backend.py
+++ b/strawberryfields/backends/tfbackend/backend.py
@@ -22,6 +22,7 @@ import numpy as np
 import tensorflow as tf
 
 from strawberryfields.backends import BaseFock, ModeMap
+
 from .circuit import Circuit
 from .ops import mix, partial_trace, reorder_modes
 from .states import FockStateTF

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -34,24 +34,23 @@ import numpy as np
 import tensorflow as tf
 from scipy.linalg import expm
 from scipy.special import factorial
+
 # only used for `conditional_state`; remove when working with `tf.einsum`
 from tensorflow.python.ops.special_math_ops import _einsum_v1
-from thewalrus._hermite_multidimensional import \
-    grad_hermite_multidimensional as grad_gaussian_gate_tw
-from thewalrus._hermite_multidimensional import \
-    hermite_multidimensional as gaussian_gate_tw
+from thewalrus._hermite_multidimensional import (
+    grad_hermite_multidimensional as grad_gaussian_gate_tw,
+)
+from thewalrus._hermite_multidimensional import hermite_multidimensional as gaussian_gate_tw
 from thewalrus.fock_gradients import beamsplitter as beamsplitter_tw
 from thewalrus.fock_gradients import displacement as displacement_tw
 from thewalrus.fock_gradients import grad_beamsplitter as grad_beamsplitter_tw
 from thewalrus.fock_gradients import grad_displacement as grad_displacement_tw
 from thewalrus.fock_gradients import grad_mzgate as grad_mzgate_tw
 from thewalrus.fock_gradients import grad_squeezing as grad_squeezing_tw
-from thewalrus.fock_gradients import \
-    grad_two_mode_squeezing as grad_two_mode_squeezing_tw
+from thewalrus.fock_gradients import grad_two_mode_squeezing as grad_two_mode_squeezing_tw
 from thewalrus.fock_gradients import mzgate as mzgate_tw
 from thewalrus.fock_gradients import squeezing as squeezing_tw
-from thewalrus.fock_gradients import \
-    two_mode_squeezing as two_mode_squeezing_tw
+from thewalrus.fock_gradients import two_mode_squeezing as two_mode_squeezing_tw
 from thewalrus.symplectic import is_symplectic, sympmat
 
 max_num_indices = len(indices)

--- a/strawberryfields/backends/tfbackend/ops.py
+++ b/strawberryfields/backends/tfbackend/ops.py
@@ -34,27 +34,24 @@ import numpy as np
 import tensorflow as tf
 from scipy.linalg import expm
 from scipy.special import factorial
-
 # only used for `conditional_state`; remove when working with `tf.einsum`
 from tensorflow.python.ops.special_math_ops import _einsum_v1
-from thewalrus._hermite_multidimensional import (
-    grad_hermite_multidimensional as grad_gaussian_gate_tw,
-)
-from thewalrus._hermite_multidimensional import (
-    hermite_multidimensional as gaussian_gate_tw,
-)
+from thewalrus._hermite_multidimensional import \
+    grad_hermite_multidimensional as grad_gaussian_gate_tw
+from thewalrus._hermite_multidimensional import \
+    hermite_multidimensional as gaussian_gate_tw
 from thewalrus.fock_gradients import beamsplitter as beamsplitter_tw
 from thewalrus.fock_gradients import displacement as displacement_tw
 from thewalrus.fock_gradients import grad_beamsplitter as grad_beamsplitter_tw
 from thewalrus.fock_gradients import grad_displacement as grad_displacement_tw
 from thewalrus.fock_gradients import grad_mzgate as grad_mzgate_tw
 from thewalrus.fock_gradients import grad_squeezing as grad_squeezing_tw
-from thewalrus.fock_gradients import (
-    grad_two_mode_squeezing as grad_two_mode_squeezing_tw,
-)
+from thewalrus.fock_gradients import \
+    grad_two_mode_squeezing as grad_two_mode_squeezing_tw
 from thewalrus.fock_gradients import mzgate as mzgate_tw
 from thewalrus.fock_gradients import squeezing as squeezing_tw
-from thewalrus.fock_gradients import two_mode_squeezing as two_mode_squeezing_tw
+from thewalrus.fock_gradients import \
+    two_mode_squeezing as two_mode_squeezing_tw
 from thewalrus.symplectic import is_symplectic, sympmat
 
 max_num_indices = len(indices)

--- a/strawberryfields/backends/tfbackend/states.py
+++ b/strawberryfields/backends/tfbackend/states.py
@@ -19,6 +19,7 @@ import tensorflow as tf
 from scipy.special import factorial
 
 from strawberryfields.backends.states import BaseFockState
+
 from .ops import ladder_ops, phase_shifter_matrix, reduced_density_matrix
 
 

--- a/strawberryfields/compilers/__init__.py
+++ b/strawberryfields/compilers/__init__.py
@@ -36,18 +36,18 @@ In particular, for each backend supported by Strawberry Fields the database cont
 corresponding Compiler instance with the same short name, used to validate Programs to be
 executed on that backend.
 """
+from .bosonic import Bosonic
 from .compiler import Compiler, Ranges
+from .fock import Fock
+from .gaussian import Gaussian
+from .gaussian_merge import GaussianMerge
+from .gaussian_unitary import GaussianUnitary
+from .gbs import GBS
+from .passive import Passive
+from .tdm import TD2, TDM, Borealis
 from .xcov import Xcov
 from .xstrict import Xstrict
 from .xunitary import Xunitary
-from .fock import Fock
-from .gaussian import Gaussian
-from .bosonic import Bosonic
-from .gbs import GBS
-from .gaussian_unitary import GaussianUnitary
-from .gaussian_merge import GaussianMerge
-from .passive import Passive
-from .tdm import TDM, TD2, Borealis
 
 compilers = (
     Fock,

--- a/strawberryfields/compilers/compiler.py
+++ b/strawberryfields/compilers/compiler.py
@@ -18,11 +18,11 @@
 """
 
 import abc
-import sympy as sym
-from typing import Sequence, Set, Dict, Optional
+from typing import Dict, Optional, Sequence, Set
 
-import networkx as nx
 import blackbird
+import networkx as nx
+import sympy as sym
 from blackbird.utils import to_DiGraph
 
 import strawberryfields.program_utils as pu

--- a/strawberryfields/compilers/compiler.py
+++ b/strawberryfields/compilers/compiler.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 # The module docstring is in strawberryfields/compiler/__init__.py
-"""
-**Module name:** :mod:`strawberryfields.compilers.compiler`
-"""
+"""**Module name:** :mod:`strawberryfields.compilers.compiler`"""
 
 import abc
 from typing import Dict, Optional, Sequence, Set
@@ -53,8 +51,8 @@ class Compiler(abc.ABC):
     @property
     @abc.abstractmethod
     def interactive(self) -> bool:
-        """Whether the circuits in the class can be executed interactively, that is,
-        the registers in the circuit are not reset between engine executions.
+        """Whether the circuits in the class can be executed interactively, that is, the
+        registers in the circuit are not reset between engine executions.
 
         Returns:
             bool: ``True`` if the circuit supports interactive use
@@ -63,8 +61,8 @@ class Compiler(abc.ABC):
     @property
     @abc.abstractmethod
     def primitives(self) -> Set[str]:
-        """The primitive set of quantum operations directly supported
-        by the circuit class.
+        """The primitive set of quantum operations directly supported by the circuit
+        class.
 
         Returns:
             set[str]: the names of the quantum primitives the circuit class supports
@@ -73,8 +71,8 @@ class Compiler(abc.ABC):
     @property
     @abc.abstractmethod
     def decompositions(self) -> Dict[str, Dict]:
-        """Quantum operations that are not quantum primitives for the
-        circuit class, but are supported via specified decompositions.
+        """Quantum operations that are not quantum primitives for the circuit class, but
+        are supported via specified decompositions.
 
         This should be of the form
 
@@ -94,8 +92,8 @@ class Compiler(abc.ABC):
 
     @property
     def graph(self) -> Optional[nx.DiGraph]:
-        """The allowed circuit topologies or connectivity of the class, modelled as a directed
-        acyclic graph.
+        """The allowed circuit topologies or connectivity of the class, modelled as a
+        directed acyclic graph.
 
         This property is optional; if arbitrary topologies are allowed in the circuit class,
         this will simply return ``None``.
@@ -164,7 +162,9 @@ class Compiler(abc.ABC):
         cls._layout = None
         cls._graph = None
 
-    def compile(self, seq: Sequence[pu.Command], registers: Sequence[pu.RegRef]) -> Sequence[pu.Command]:
+    def compile(
+        self, seq: Sequence[pu.Command], registers: Sequence[pu.RegRef]
+    ) -> Sequence[pu.Command]:
         """Class-specific circuit compilation method.
 
         If additional compilation logic is required, child classes can redefine this method.
@@ -199,7 +199,7 @@ class Compiler(abc.ABC):
             nx.set_node_attributes(circuit, mapping_modes, name="modes")
 
             def node_match(n1, n2):
-                """Returns True if both nodes have the same name and modes"""
+                """Returns True if both nodes have the same name and modes."""
                 return n1["name"] == n2["name"] and n1["modes"] == n2["modes"]
 
             GM = nx.algorithms.isomorphism.DiGraphMatcher(self.graph, circuit, node_match)
@@ -226,8 +226,8 @@ class Compiler(abc.ABC):
         return seq
 
     def decompose(self, seq: Sequence[pu.Command]) -> Sequence[pu.Command]:
-        """Recursively decompose all gates in a given sequence, as allowed
-        by the circuit specification.
+        """Recursively decompose all gates in a given sequence, as allowed by the
+        circuit specification.
 
         This method follows the directives defined in the
         :attr:`~.Compiler.primitives` and :attr:`~.Compiler.decompositions`
@@ -314,8 +314,9 @@ class Compiler(abc.ABC):
     def add_loss(self, program, device):
         """Adds realistic loss to circuit.
 
-        Child classes which are hardware compilers should override this method with device specific
-        loss added to the circuit."""
+        Child classes which are hardware compilers should override this method with
+        device specific loss added to the circuit.
+        """
         raise NotImplementedError
 
 

--- a/strawberryfields/compilers/compiler.py
+++ b/strawberryfields/compilers/compiler.py
@@ -26,7 +26,6 @@ import sympy as sym
 from blackbird.utils import to_DiGraph
 
 import strawberryfields.program_utils as pu
-from strawberryfields.program_utils import CircuitError, Command, RegRef
 
 
 class Compiler(abc.ABC):
@@ -147,7 +146,7 @@ class Compiler(abc.ABC):
         if cls._layout:
             # if the exact same circuit is set (apart from newlines) then return
             if cls._layout.replace("\n", "") != layout.replace("\n", ""):
-                raise CircuitError(
+                raise pu.CircuitError(
                     f"Circuit already set in compiler {cls.short_name}. Device layout incompatible "
                     "with compiler layout. Call the compiler's 'reset_circuit' method, or use a "
                     "different device layout."
@@ -165,20 +164,20 @@ class Compiler(abc.ABC):
         cls._layout = None
         cls._graph = None
 
-    def compile(self, seq: Sequence[Command], registers: Sequence[RegRef]) -> Sequence[Command]:
+    def compile(self, seq: Sequence[pu.Command], registers: Sequence[pu.RegRef]) -> Sequence[pu.Command]:
         """Class-specific circuit compilation method.
 
         If additional compilation logic is required, child classes can redefine this method.
 
         Args:
-            seq (Sequence[Command]): quantum circuit to modify
-            registers (Sequence[RegRef]): quantum registers
+            seq (Sequence[strawberryfields.program_utils.Command]): quantum circuit to modify
+            registers (Sequence[strawberryfields.program_utils.RegRef]): quantum registers
 
         Returns:
-            Sequence[Command]: modified circuit
+            Sequence[strawberryfields.program_utils.Command]: modified circuit
 
         Raises:
-            CircuitError: the given circuit cannot be validated to belong to this circuit class
+            strawberryfields.program_utils.CircuitError: the given circuit cannot be validated to belong to this circuit class
         """
         # registers is not used here, but may be used if the method is overwritten pylint: disable=unused-argument
         if self.graph is not None:
@@ -187,7 +186,7 @@ class Compiler(abc.ABC):
 
             # relabel the DAG nodes to integers, with attributes
             # specifying the operation name. This allows them to be
-            # compared, rather than using Command objects.
+            # compared, rather than using pu.Command objects.
             mapping_name, mapping_args, mapping_modes = {}, {}, {}
             for i, n in enumerate(DAG.nodes()):
                 mapping_name[i] = n.op.__class__.__name__
@@ -219,20 +218,20 @@ class Compiler(abc.ABC):
             for n1, n2 in GM.mapping.items():
                 for x, y in zip(G1nodes[n1]["args"], G2nodes[n2]["args"]):
                     if x != y and not (isinstance(x, sym.Symbol) or isinstance(y, sym.Expr)):
-                        raise CircuitError(
+                        raise pu.CircuitError(
                             "Program cannot be used with the compiler '{}' "
                             "due to incompatible parameter values.".format(self.short_name)
                         )
 
         return seq
 
-    def decompose(self, seq: Sequence[Command]) -> Sequence[Command]:
+    def decompose(self, seq: Sequence[pu.Command]) -> Sequence[pu.Command]:
         """Recursively decompose all gates in a given sequence, as allowed
         by the circuit specification.
 
         This method follows the directives defined in the
         :attr:`~.Compiler.primitives` and :attr:`~.Compiler.decompositions`
-        class attributes to determine whether a command should be decomposed.
+        class attributes to determine whether a strawberryfields.program_utils.Command should be decomposed.
 
         The order of precedence to determine whether decomposition
         should be applied is as follows.

--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -15,8 +15,14 @@
 canonical Symplectic form."""
 
 import numpy as np
-from thewalrus.symplectic import (beam_splitter, expand, interferometer,
-                                  rotation, squeezing, two_mode_squeezing)
+from thewalrus.symplectic import (
+    beam_splitter,
+    expand,
+    interferometer,
+    rotation,
+    squeezing,
+    two_mode_squeezing,
+)
 
 from strawberryfields import ops
 from strawberryfields.parameters import par_evaluate

--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -15,14 +15,8 @@
 canonical Symplectic form."""
 
 import numpy as np
-from thewalrus.symplectic import (
-    beam_splitter,
-    expand,
-    interferometer,
-    rotation,
-    squeezing,
-    two_mode_squeezing,
-)
+from thewalrus.symplectic import (beam_splitter, expand, interferometer,
+                                  rotation, squeezing, two_mode_squeezing)
 
 from strawberryfields import ops
 from strawberryfields.parameters import par_evaluate

--- a/strawberryfields/compilers/gaussian_unitary.py
+++ b/strawberryfields/compilers/gaussian_unitary.py
@@ -11,20 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This module contains a compiler to arrange a Gaussian quantum circuit into the canonical Symplectic form."""
+"""This module contains a compiler to arrange a Gaussian quantum circuit into the
+canonical Symplectic form."""
 
 import numpy as np
-from strawberryfields.program_utils import Command
-from strawberryfields import ops
-from strawberryfields.parameters import par_evaluate
 from thewalrus.symplectic import (
+    beam_splitter,
     expand,
+    interferometer,
     rotation,
     squeezing,
     two_mode_squeezing,
-    interferometer,
-    beam_splitter,
 )
+
+from strawberryfields import ops
+from strawberryfields.parameters import par_evaluate
+from strawberryfields.program_utils import Command
+
 from .compiler import Compiler
 
 
@@ -84,7 +87,8 @@ def _apply_symp_two_mode_gate(S_G, S, r, i, j):
 
 
 class GaussianUnitary(Compiler):
-    """Compiler to arrange a Gaussian quantum circuit into the canonical Symplectic form.
+    """Compiler to arrange a Gaussian quantum circuit into the canonical Symplectic
+    form.
 
     This compiler checks whether the circuit can be implemented as a sequence of
     Gaussian operations. If so, it arranges them in the canonical order with displacement at the end.
@@ -154,6 +158,7 @@ class GaussianUnitary(Compiler):
         "Zgate": {},
         "Fouriergate": {},
     }
+
     # pylint: disable=too-many-branches, too-many-statements
     def compile(self, seq, registers):
         """Try to arrange a quantum circuit into the canonical Symplectic form.
@@ -204,7 +209,10 @@ class GaussianUnitary(Compiler):
                     )
                 elif name == "Sgate":
                     Snet, rnet = _apply_symp_one_mode_gate(
-                        squeezing(params[0], params[1]), Snet, rnet, dict_indices[modes[0]]
+                        squeezing(params[0], params[1]),
+                        Snet,
+                        rnet,
+                        dict_indices[modes[0]],
                     )
                 elif name == "S2gate":
                     Snet, rnet = _apply_symp_two_mode_gate(
@@ -230,7 +238,9 @@ class GaussianUnitary(Compiler):
                         )
                     else:
                         S = expand(
-                            interferometer(U), [dict_indices[mode] for mode in modes], nmodes
+                            interferometer(U),
+                            [dict_indices[mode] for mode in modes],
+                            nmodes,
                         )
                         Snet = S @ Snet
                         rnet = S @ rnet
@@ -243,7 +253,11 @@ class GaussianUnitary(Compiler):
                         )
                     elif S_G.shape == (4, 4):
                         Snet, rnet = _apply_symp_two_mode_gate(
-                            S_G, Snet, rnet, dict_indices[modes[0]], dict_indices[modes[1]]
+                            S_G,
+                            Snet,
+                            rnet,
+                            dict_indices[modes[0]],
+                            dict_indices[modes[1]],
                         )
                     else:
                         S = expand(S_G, [dict_indices[mode] for mode in modes], nmodes)
@@ -274,7 +288,10 @@ class GaussianUnitary(Compiler):
                     exp_sigma = np.exp(1j * (params[0] + params[1]) / 2)
                     delta = (params[0] - params[1]) / 2
                     U = exp_sigma * np.array(
-                        [[np.sin(delta), np.cos(delta)], [np.cos(delta), -np.sin(delta)]]
+                        [
+                            [np.sin(delta), np.cos(delta)],
+                            [np.cos(delta), -np.sin(delta)],
+                        ]
                     )
                     Snet, rnet = _apply_symp_two_mode_gate(
                         interferometer(U),

--- a/strawberryfields/compilers/gbs.py
+++ b/strawberryfields/compilers/gbs.py
@@ -14,8 +14,7 @@
 """Compiler for the general Gaussian Boson Sampling class of circuits."""
 
 import strawberryfields.ops as ops
-from strawberryfields.program_utils import (CircuitError, Command,
-                                            group_operations)
+from strawberryfields.program_utils import CircuitError, Command, group_operations
 
 from .gaussian import Gaussian
 

--- a/strawberryfields/compilers/gbs.py
+++ b/strawberryfields/compilers/gbs.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Compiler for the general Gaussian Boson Sampling class of circuits."""
 
-from strawberryfields.program_utils import CircuitError, Command, group_operations
 import strawberryfields.ops as ops
+from strawberryfields.program_utils import (CircuitError, Command,
+                                            group_operations)
 
 from .gaussian import Gaussian
 

--- a/strawberryfields/compilers/passive.py
+++ b/strawberryfields/compilers/passive.py
@@ -11,18 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This module contains a compiler to reduce a sequence of passive gates into a single multimode linear passive operation"""
+"""This module contains a compiler to reduce a sequence of passive gates into a single
+multimode linear passive operation."""
 
 import numpy as np
-from strawberryfields.program_utils import Command
+
 from strawberryfields import ops
 from strawberryfields.parameters import par_evaluate
+from strawberryfields.program_utils import Command
 
 from .compiler import Compiler
 
 
 def _apply_one_mode_gate(G, T, i):
-    """In-place applies a one mode gate G into the process matrix T in mode i
+    """In-place applies a one mode gate G into the process matrix T in mode i.
 
     Args:
         G (complex or float): one mode gate
@@ -38,7 +40,7 @@ def _apply_one_mode_gate(G, T, i):
 
 
 def _apply_two_mode_gate(G, T, i, j):
-    """In-place applies a two mode gate G into the process matrix T in modes i and j
+    """In-place applies a two mode gate G into the process matrix T in modes i and j.
 
     Args:
         G (array): 2x2 matrix for two mode gate
@@ -76,7 +78,7 @@ def _beam_splitter_passive(theta, phi):
 
 
 class Passive(Compiler):
-    """Compiler to write a sequence of passive operations as a single passive operation
+    """Compiler to write a sequence of passive operations as a single passive operation.
 
     This compiler checks whether the circuit can be implemented as a sequence of
     passive operations. If so, it arranges them in a single matrix, T. It then returns an PassiveChannel
@@ -129,9 +131,10 @@ class Passive(Compiler):
     }
 
     decompositions = {}
+
     # pylint: disable=too-many-branches, too-many-statements
     def compile(self, seq, registers):
-        """Try to arrange a passive circuit into a single multimode passive operation
+        """Try to arrange a passive circuit into a single multimode passive operation.
 
         This method checks whether the circuit can be implemented as a sequence of passive gates.
         If the answer is yes it arranges them into a single operation.

--- a/strawberryfields/compilers/tdm.py
+++ b/strawberryfields/compilers/tdm.py
@@ -16,17 +16,17 @@
 import re
 from typing import List, Optional, Sequence
 
-import numpy as np
-
 import blackbird
+import numpy as np
 from blackbird.listener import is_ptype
 
 import strawberryfields.io as sio
-from strawberryfields.ops import BSgate, LossChannel, MeasureFock, Rgate, Operation, Sgate
 from strawberryfields.compilers.compiler import Compiler
-from strawberryfields.program_utils import CircuitError, Command
-from strawberryfields.parameters import FreeParameter
 from strawberryfields.logger import create_logger
+from strawberryfields.ops import (BSgate, LossChannel, MeasureFock, Operation,
+                                  Rgate, Sgate)
+from strawberryfields.parameters import FreeParameter
+from strawberryfields.program_utils import CircuitError, Command
 
 logger = create_logger(__name__)
 

--- a/strawberryfields/compilers/tdm.py
+++ b/strawberryfields/compilers/tdm.py
@@ -23,8 +23,7 @@ from blackbird.listener import is_ptype
 import strawberryfields.io as sio
 from strawberryfields.compilers.compiler import Compiler
 from strawberryfields.logger import create_logger
-from strawberryfields.ops import (BSgate, LossChannel, MeasureFock, Operation,
-                                  Rgate, Sgate)
+from strawberryfields.ops import BSgate, LossChannel, MeasureFock, Operation, Rgate, Sgate
 from strawberryfields.parameters import FreeParameter
 from strawberryfields.program_utils import CircuitError, Command
 

--- a/strawberryfields/compilers/xcov.py
+++ b/strawberryfields/compilers/xcov.py
@@ -20,13 +20,13 @@ from thewalrus.quantum import Amat
 from thewalrus.symplectic import expand
 
 import strawberryfields as sf
+import strawberryfields.ops as ops
 from strawberryfields.decompositions import takagi
 from strawberryfields.program_utils import CircuitError, Command
-import strawberryfields.ops as ops
 
 from .compiler import Compiler
-from .gbs import GBS
 from .gaussian_unitary import GaussianUnitary
+from .gbs import GBS
 
 
 class Xcov(Compiler):

--- a/strawberryfields/compilers/xunitary.py
+++ b/strawberryfields/compilers/xunitary.py
@@ -21,7 +21,8 @@ import numpy as np
 from thewalrus.symplectic import expand
 
 import strawberryfields.ops as ops
-from strawberryfields.program_utils import CircuitError, Command, group_operations
+from strawberryfields.program_utils import (CircuitError, Command,
+                                            group_operations)
 
 from .compiler import Compiler
 from .gaussian_unitary import GaussianUnitary

--- a/strawberryfields/compilers/xunitary.py
+++ b/strawberryfields/compilers/xunitary.py
@@ -14,24 +14,23 @@
 # pylint: disable=too-many-branches,too-many-statements
 """General interferometer compiler for the X class of circuits."""
 
-from collections import defaultdict
 import copy
+from collections import defaultdict
 
 import numpy as np
 from thewalrus.symplectic import expand
 
+import strawberryfields.ops as ops
 from strawberryfields.program_utils import CircuitError, Command, group_operations
 
-import strawberryfields.ops as ops
-
 from .compiler import Compiler
-from .gbs import GBS
 from .gaussian_unitary import GaussianUnitary
+from .gbs import GBS
 
 
 def list_duplicates(seq):
-    """Returns a generator representing the duplicated values in the sequence
-    mapped to the indices they appear at."""
+    """Returns a generator representing the duplicated values in the sequence mapped to
+    the indices they appear at."""
     tally = defaultdict(list)
     for i, item in enumerate(seq):
         tally[item].append(i)
@@ -78,6 +77,7 @@ class Xunitary(Compiler):
     >>> spec = eng.device_spec
     >>> prog.compile(device=spec, compiler="Xunitary")
     """
+
     short_name = "Xunitary"
     interactive = False
 
@@ -168,7 +168,10 @@ class Xunitary(Compiler):
                     phi = phi_new
 
                 i, j = mode
-                B.insert(indices[0], Command(ops.S2gate(r, phi), [registers[i], registers[j]]))
+                B.insert(
+                    indices[0],
+                    Command(ops.S2gate(r, phi), [registers[i], registers[j]]),
+                )
 
         meas_seq = [C[-1]]
         seq = GaussianUnitary().compile(C[:-1], registers)

--- a/strawberryfields/compilers/xunitary.py
+++ b/strawberryfields/compilers/xunitary.py
@@ -21,8 +21,7 @@ import numpy as np
 from thewalrus.symplectic import expand
 
 import strawberryfields.ops as ops
-from strawberryfields.program_utils import (CircuitError, Command,
-                                            group_operations)
+from strawberryfields.program_utils import CircuitError, Command, group_operations
 
 from .compiler import Compiler
 from .gaussian_unitary import GaussianUnitary

--- a/strawberryfields/decompositions.py
+++ b/strawberryfields/decompositions.py
@@ -16,11 +16,11 @@ This module implements common shared matrix decompositions that are
 used to perform gate decompositions.
 """
 
-from itertools import groupby
 from collections import defaultdict
+from itertools import groupby
 
 import numpy as np
-from scipy.linalg import block_diag, sqrtm, polar, schur
+from scipy.linalg import block_diag, polar, schur, sqrtm
 from thewalrus.quantum import adj_scaling
 from thewalrus.symplectic import sympmat, xpxp_to_xxpp
 

--- a/strawberryfields/device.py
+++ b/strawberryfields/device.py
@@ -15,13 +15,13 @@
 This module contains a class that represents a device on the Xanadu Cloud.
 """
 import re
-from typing import Generator, Iterable, Sequence, Mapping, Any, Optional
+from typing import Any, Generator, Iterable, Mapping, Optional, Sequence
 
 import blackbird
 from blackbird.error import BlackbirdSyntaxError
 
-from strawberryfields.io import to_program
 from strawberryfields.compilers import Ranges
+from strawberryfields.io import to_program
 
 
 class Device:

--- a/strawberryfields/engine.py
+++ b/strawberryfields/engine.py
@@ -27,15 +27,15 @@ import numpy as np
 import xcc
 
 from strawberryfields.device import Device
-from strawberryfields.result import Result
 from strawberryfields.io import to_blackbird
 from strawberryfields.logger import create_logger
 from strawberryfields.program import Program
+from strawberryfields.result import Result
 from strawberryfields.tdm import TDMProgram, reshape_samples
 
-from .backends import load_backend, BosonicBackend
-from .backends.base import BaseBackend, NotApplicableError
 from ._version import __version__
+from .backends import BosonicBackend, load_backend
+from .backends.base import BaseBackend, NotApplicableError
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
 __all__ = ["BaseEngine", "LocalEngine", "BosonicEngine"]

--- a/strawberryfields/io/__init__.py
+++ b/strawberryfields/io/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains functions for loading and saving Strawberry Fields :class:`~.Program` objects
+This module contains functions for loading and saving Strawberry Fields :class:`~.sfp.Program` objects
 and converting from/to Blackbird and XIR scripts to Strawberry Fields code.
 """
 import os
@@ -22,7 +22,7 @@ from typing import TextIO, Union
 import blackbird
 import xir
 
-from strawberryfields.program import Program
+import strawberryfields.program as sfp
 
 from .blackbird_io import from_blackbird, from_blackbird_to_tdm, to_blackbird
 from .utils import generate_code
@@ -32,14 +32,14 @@ from .xir_io import from_xir, from_xir_to_tdm, to_xir
 __all__ = ["to_blackbird", "to_xir", "to_program", "loads", "generate_code"]
 
 
-def to_program(prog: Union[blackbird.BlackbirdProgram, xir.Program]) -> Program:
+def to_program(prog: Union[blackbird.BlackbirdProgram, xir.Program]) -> sfp.Program:
     """Convert a Blackbird or an XIR program to a Strawberry Fields program.
 
     Args:
         prog (blackbird.BlackbirdProgram, xir.Program): the input program object
 
     Returns:
-        Program: corresponding Strawberry Fields program
+        sfp.Program: corresponding Strawberry Fields program
 
     Raises:
         ValueError: if the Blackbird program contains no quantum operations
@@ -63,7 +63,7 @@ def to_program(prog: Union[blackbird.BlackbirdProgram, xir.Program]) -> Program:
     raise TypeError(f"Cannot convert {type(prog)}' to Strawberry Fields Program")
 
 
-def save(f: Union[TextIO, str, Path], prog: Program, ir: str = "blackbird", **kwargs) -> None:
+def save(f: Union[TextIO, str, Path], prog: sfp.Program, ir: str = "blackbird", **kwargs) -> None:
     """Saves a quantum program to a Blackbird ``.xbb`` or an XIR ``.xir`` file.
 
     **Example:**
@@ -141,7 +141,7 @@ def save(f: Union[TextIO, str, Path], prog: Program, ir: str = "blackbird", **kw
             fid.close()
 
 
-def loads(s: str, ir: str = "blackbird") -> Program:
+def loads(s: str, ir: str = "blackbird") -> sfp.Program:
     """Load a quantum program from a string.
 
     Args:
@@ -149,7 +149,7 @@ def loads(s: str, ir: str = "blackbird") -> Program:
         ir (str): Intermediate representation language to use. Can be either "blackbird" or "xir".
 
     Returns:
-        prog (Program): Strawberry Fields program
+        prog (sfp.Program): Strawberry Fields program
 
     Raises:
         ValueError: if an invalid IR name is passed
@@ -165,7 +165,7 @@ def loads(s: str, ir: str = "blackbird") -> Program:
     return to_program(prog)
 
 
-def load(f: Union[TextIO, str, Path], ir: str = "blackbird") -> Program:
+def load(f: Union[TextIO, str, Path], ir: str = "blackbird") -> sfp.Program:
     """Load a quantum program from a Blackbird .xbb or an XIR .xir file.
 
     **Example:**
@@ -201,7 +201,7 @@ def load(f: Union[TextIO, str, Path], ir: str = "blackbird") -> Program:
         ir (str): Intermediate representation language to use. Can be either "blackbird" or "xir".
 
     Returns:
-        prog (Program): Strawberry Fields program
+        prog (sfp.Program): Strawberry Fields program
 
     Raises:
         ValueError: if file is not a string, pathlib.Path, or file-like object

--- a/strawberryfields/io/__init__.py
+++ b/strawberryfields/io/__init__.py
@@ -16,18 +16,17 @@ This module contains functions for loading and saving Strawberry Fields :class:`
 and converting from/to Blackbird and XIR scripts to Strawberry Fields code.
 """
 import os
-
-from typing import Union, TextIO
 from pathlib import Path
+from typing import TextIO, Union
 
-import xir
 import blackbird
+import xir
 
 from strawberryfields.program import Program
 
-from .blackbird_io import to_blackbird, from_blackbird, from_blackbird_to_tdm
-from .xir_io import to_xir, from_xir, from_xir_to_tdm
+from .blackbird_io import from_blackbird, from_blackbird_to_tdm, to_blackbird
 from .utils import generate_code
+from .xir_io import from_xir, from_xir_to_tdm, to_xir
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
 __all__ = ["to_blackbird", "to_xir", "to_program", "loads", "generate_code"]

--- a/strawberryfields/io/blackbird_io.py
+++ b/strawberryfields/io/blackbird_io.py
@@ -16,15 +16,14 @@ This module contains functions for loading and saving Strawberry Fields
 :class:`~.Program` objects from/to Blackbird scripts and Strawberry Fields
 code.
 """
+import blackbird
 # pylint: disable=protected-access,too-many-nested-blocks
 import numpy as np
 
-import blackbird
-
 import strawberryfields.parameters as sfpar
+from strawberryfields import ops
 from strawberryfields.program import Program
 from strawberryfields.tdm import TDMProgram, is_ptype
-from strawberryfields import ops
 
 
 def from_blackbird(bb: blackbird.BlackbirdProgram) -> Program:

--- a/strawberryfields/io/blackbird_io.py
+++ b/strawberryfields/io/blackbird_io.py
@@ -17,6 +17,7 @@ This module contains functions for loading and saving Strawberry Fields
 code.
 """
 import blackbird
+
 # pylint: disable=protected-access,too-many-nested-blocks
 import numpy as np
 

--- a/strawberryfields/io/utils.py
+++ b/strawberryfields/io/utils.py
@@ -14,8 +14,8 @@
 """Utility functions for the io module."""
 from __future__ import annotations
 
-from typing import List, Union
 from numbers import Number
+from typing import List, Union
 
 import numpy as np
 

--- a/strawberryfields/io/xir_io.py
+++ b/strawberryfields/io/xir_io.py
@@ -21,13 +21,12 @@ from decimal import Decimal
 from typing import Iterable, List, Sequence
 
 import numpy as np
-
 import xir
 
 import strawberryfields.parameters as sfpar
+from strawberryfields import ops
 from strawberryfields.program import Program
 from strawberryfields.tdm import TDMProgram, is_ptype
-from strawberryfields import ops
 
 
 def get_expanded_statements(prog: xir.Program) -> Sequence[xir.Statement]:

--- a/strawberryfields/parameters.py
+++ b/strawberryfields/parameters.py
@@ -95,10 +95,10 @@ What we cannot do at the moment:
 
 import collections.abc
 import functools
-import types
 import linecache
-import blackbird
+import types
 
+import blackbird
 import numpy as np
 import sympy
 import sympy.functions as sf

--- a/strawberryfields/plot.py
+++ b/strawberryfields/plot.py
@@ -16,7 +16,9 @@ This module provides tools to visualize the state in various interactive
 ways using Plot.ly.
 """
 from copy import copy, deepcopy
+
 import numpy as np
+
 from strawberryfields.backends.states import BaseGaussianState
 
 plotly_error = (

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -56,7 +56,7 @@ import networkx as nx
 
 import strawberryfields.circuitdrawer as sfcd
 import strawberryfields.program_utils as pu
-from strawberryfields.compilers import Compiler, compiler_db
+import strawberryfields.compilers
 
 from .parameters import FreeParameter, ParameterError
 from .program_utils import CircuitError, Command, RegRef, RegRefError, program_equivalence
@@ -680,10 +680,10 @@ class Program:
             raise ValueError("Either one or both of 'device' and 'compiler' must be specified")
 
         def _get_compiler(compiler_or_name):
-            if compiler_or_name in compiler_db:
-                return compiler_db[compiler_or_name]()
+            if compiler_or_name in strawberryfields.compilers.compiler_db:
+                return strawberryfields.compilers.compiler_db[compiler_or_name]()
 
-            if isinstance(compiler_or_name, Compiler):
+            if isinstance(compiler_or_name, strawberryfields.compilers.Compiler):
                 return compiler_or_name
 
             raise ValueError(f"Unknown compiler '{compiler_or_name}'.")
@@ -693,7 +693,7 @@ class Program:
 
             if compiler is None:
                 # get the default compiler from the device spec
-                compiler = compiler_db[device.default_compiler]()
+                compiler = strawberryfields.compilers.compiler_db[device.default_compiler]()
             else:
                 compiler = _get_compiler(compiler)
 

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -51,21 +51,16 @@ using the functions :func:`list_to_grid`, :func:`grid_to_DAG` and :func:`DAG_to_
 import copy
 import numbers
 import warnings
+
 import networkx as nx
 
 import strawberryfields.circuitdrawer as sfcd
-from strawberryfields.compilers import Compiler, compiler_db
 import strawberryfields.program_utils as pu
+from strawberryfields.compilers import Compiler, compiler_db
 
-from .program_utils import (
-    Command,
-    RegRef,
-    CircuitError,
-    RegRefError,
-    program_equivalence,
-)
 from .parameters import FreeParameter, ParameterError
-
+from .program_utils import (CircuitError, Command, RegRef, RegRefError,
+                            program_equivalence)
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
 __all__ = []

--- a/strawberryfields/program.py
+++ b/strawberryfields/program.py
@@ -59,8 +59,7 @@ import strawberryfields.program_utils as pu
 from strawberryfields.compilers import Compiler, compiler_db
 
 from .parameters import FreeParameter, ParameterError
-from .program_utils import (CircuitError, Command, RegRef, RegRefError,
-                            program_equivalence)
+from .program_utils import CircuitError, Command, RegRef, RegRefError, program_equivalence
 
 # for automodapi, do not include the classes that should appear under the top-level strawberryfields namespace
 __all__ = []

--- a/strawberryfields/program_utils.py
+++ b/strawberryfields/program_utils.py
@@ -18,15 +18,14 @@ within the :class:`~.Program` class.
 
 from collections.abc import Sequence
 
+import blackbird as bb
 import networkx as nx
 import numpy as np
+from blackbird.utils import TemplateError, match_template
 
-import blackbird as bb
 import strawberryfields.io as sfio
 
-from blackbird.utils import match_template, TemplateError
 from .parameters import MeasuredParameter, par_evaluate
-
 
 __all__ = [
     "Program_current_context",

--- a/strawberryfields/result.py
+++ b/strawberryfields/result.py
@@ -16,7 +16,7 @@ This module provides a class that represents the result of a quantum computation
 """
 
 import warnings
-from typing import Mapping, Optional, List
+from typing import List, Mapping, Optional
 
 import numpy as np
 

--- a/strawberryfields/tdm/__init__.py
+++ b/strawberryfields/tdm/__init__.py
@@ -16,7 +16,17 @@
 algorithms in Strawberry Fields."""
 
 from .program import TDMProgram, is_ptype, reshape_samples, shift_by
-from .utils import (borealis_gbs, full_compile, get_mode_indices,
-                    loop_phase_from_device, make_phases_compatible,
-                    make_squeezing_compatible, move_vac_modes, random_bs,
-                    random_r, to_args_dict, to_args_list, vacuum_padding)
+from .utils import (
+    borealis_gbs,
+    full_compile,
+    get_mode_indices,
+    loop_phase_from_device,
+    make_phases_compatible,
+    make_squeezing_compatible,
+    move_vac_modes,
+    random_bs,
+    random_r,
+    to_args_dict,
+    to_args_list,
+    vacuum_padding,
+)

--- a/strawberryfields/tdm/__init__.py
+++ b/strawberryfields/tdm/__init__.py
@@ -15,18 +15,8 @@
 """This package contains classes and functions for creating time-domain
 algorithms in Strawberry Fields."""
 
-from .program import TDMProgram, reshape_samples, is_ptype, shift_by
-from .utils import (
-    borealis_gbs,
-    full_compile,
-    get_mode_indices,
-    loop_phase_from_device,
-    make_phases_compatible,
-    make_squeezing_compatible,
-    move_vac_modes,
-    vacuum_padding,
-    random_r,
-    random_bs,
-    to_args_list,
-    to_args_dict,
-)
+from .program import TDMProgram, is_ptype, reshape_samples, shift_by
+from .utils import (borealis_gbs, full_compile, get_mode_indices,
+                    loop_phase_from_device, make_phases_compatible,
+                    make_squeezing_compatible, move_vac_modes, random_bs,
+                    random_r, to_args_dict, to_args_list, vacuum_padding)

--- a/strawberryfields/tdm/program.py
+++ b/strawberryfields/tdm/program.py
@@ -18,14 +18,15 @@ This module implements the :class:`.TDMProgram` class which acts as a representa
 # pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
 
 import itertools
-from operator import itemgetter
 from collections.abc import Iterable
 from functools import reduce
+from operator import itemgetter
 
 import numpy as np
+
 from strawberryfields import ops
+from strawberryfields.parameters import FreeParameter, par_is_symbolic
 from strawberryfields.program import Program
-from strawberryfields.parameters import par_is_symbolic, FreeParameter
 from strawberryfields.program_utils import CircuitError
 
 

--- a/strawberryfields/utils/decorators.py
+++ b/strawberryfields/utils/decorators.py
@@ -20,7 +20,6 @@ an operation itself within a :class:`~.Program` context.
 import collections
 from inspect import signature
 
-
 __all__ = [
     "operation",
 ]

--- a/strawberryfields/utils/program_functions.py
+++ b/strawberryfields/utils/program_functions.py
@@ -26,8 +26,8 @@ except ImportError:
 import numpy as np
 
 from strawberryfields.engine import LocalEngine
+from strawberryfields.ops import Channel, Gate, Ket
 from strawberryfields.program_utils import Command
-from strawberryfields.ops import Gate, Channel, Ket
 
 __all__ = [
     "is_unitary",

--- a/strawberryfields/utils/states.py
+++ b/strawberryfields/utils/states.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-This module defines and implements several utility functions allowing the
-calculation of various quantum states in either the Fock basis (a
-one-dimensional array indexed by Fock state) or the Gaussian basis (returning a
-vector of means and covariance matrix). These state calculations are NOT done
-in the simulators, but rather in NumPy.
+"""This module defines and implements several utility functions allowing the calculation
+of various quantum states in either the Fock basis (a one-dimensional array indexed by
+Fock state) or the Gaussian basis (returning a vector of means and covariance matrix).
+These state calculations are NOT done in the simulators, but rather in NumPy.
 
 These are useful for generating states for use in calculating the fidelity of
 simulations.
@@ -41,7 +39,7 @@ __all__ = [
 
 
 def squeezed_cov(r, phi, hbar=2):
-    r"""Returns the squeezed covariance matrix of a squeezed state
+    r"""Returns the squeezed covariance matrix of a squeezed state.
 
     Args:
         r (complex): the squeezing magnitude
@@ -59,7 +57,7 @@ def squeezed_cov(r, phi, hbar=2):
 
 
 def vacuum_state(basis="fock", fock_dim=5, hbar=2.0):
-    r"""Returns the vacuum state
+    r"""Returns the vacuum state.
 
     Args:
         basis (str): If 'fock', calculates the initial state
@@ -85,7 +83,7 @@ def vacuum_state(basis="fock", fock_dim=5, hbar=2.0):
 
 
 def coherent_state(r, phi, basis="fock", fock_dim=5, hbar=2.0):
-    r"""Returns the coherent state
+    r"""Returns the coherent state.
 
     This can be returned either in the Fock basis,
 
@@ -118,9 +116,7 @@ def coherent_state(r, phi, basis="fock", fock_dim=5, hbar=2.0):
     a = r * np.exp(1j * phi)
 
     if basis == "fock":
-        state = np.array(
-            [np.exp(-0.5 * r**2) * a**n / np.sqrt(fac(n)) for n in range(fock_dim)]
-        )
+        state = np.array([np.exp(-0.5 * r**2) * a**n / np.sqrt(fac(n)) for n in range(fock_dim)])
 
     elif basis == "gaussian":
         means = np.array([a.real, a.imag]) * np.sqrt(2 * hbar)
@@ -131,7 +127,7 @@ def coherent_state(r, phi, basis="fock", fock_dim=5, hbar=2.0):
 
 
 def squeezed_state(r, p, basis="fock", fock_dim=5, hbar=2.0):
-    r"""Returns the squeezed state
+    r"""Returns the squeezed state.
 
     This can be returned either in the Fock basis,
 
@@ -171,7 +167,7 @@ def squeezed_state(r, p, basis="fock", fock_dim=5, hbar=2.0):
     if basis == "fock":
 
         def ket(n):
-            """Squeezed state kets"""
+            """Squeezed state kets."""
             return (np.sqrt(fac(2 * n)) / (2**n * fac(n))) * (-np.exp(1j * phi) * np.tanh(r)) ** n
 
         state = np.array([ket(n // 2) if n % 2 == 0 else 0.0 for n in range(fock_dim)])
@@ -185,7 +181,7 @@ def squeezed_state(r, p, basis="fock", fock_dim=5, hbar=2.0):
 
 
 def displaced_squeezed_state(r_d, phi_d, r_s, phi_s, basis="fock", fock_dim=5, hbar=2.0):
-    r"""Returns the squeezed coherent state
+    r"""Returns the squeezed coherent state.
 
     This can be returned either in the Fock basis,
 
@@ -264,7 +260,7 @@ def displaced_squeezed_state(r_d, phi_d, r_s, phi_s, basis="fock", fock_dim=5, h
 
 
 def fock_state(n, fock_dim=5):
-    r"""Returns the Fock state
+    r"""Returns the Fock state.
 
     Args:
         n (int): the occupation number
@@ -278,7 +274,7 @@ def fock_state(n, fock_dim=5):
 
 
 def cat_state(a, phi=0, p=0, fock_dim=5):
-    r"""Returns the cat state
+    r"""Returns the cat state.
 
     .. math::
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -15,7 +15,6 @@
 Test fixtures and shared functions for Strawberry Fields API tests
 """
 import pytest
-
 import xcc
 
 from strawberryfields import Program, ops

--- a/tests/api/test_devicespec.py
+++ b/tests/api/test_devicespec.py
@@ -18,8 +18,8 @@ import inspect
 
 import pytest
 
-from strawberryfields.device import Device
 from strawberryfields.compilers import Ranges
+from strawberryfields.device import Device
 
 pytestmark = pytest.mark.api
 

--- a/tests/api/test_remote_engine.py
+++ b/tests/api/test_remote_engine.py
@@ -24,8 +24,8 @@ import xcc
 
 import strawberryfields as sf
 from strawberryfields.device import Device
-from strawberryfields.result import Result
 from strawberryfields.engine import RemoteEngine
+from strawberryfields.result import Result
 
 from .conftest import mock_return
 

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -16,8 +16,8 @@ Unit tests for strawberryfields.result
 """
 import numpy as np
 import pytest
-from strawberryfields.backends.states import BaseGaussianState
 
+from strawberryfields.backends.states import BaseGaussianState
 from strawberryfields.result import Result
 
 pytestmark = pytest.mark.api

--- a/tests/apps/conftest.py
+++ b/tests/apps/conftest.py
@@ -14,8 +14,8 @@
 r"""
 conftest.py file for use in pytest
 """
-import numpy as np
 import networkx as nx
+import numpy as np
 import pytest
 
 pytestmark = pytest.mark.apps

--- a/tests/apps/test_points.py
+++ b/tests/apps/test_points.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 r"""Tests for the the point process functions"""
 
-import pytest
 import numpy as np
-from strawberryfields.apps.points import rbf_kernel, sample
+import pytest
 
+from strawberryfields.apps.points import rbf_kernel, sample
 
 pytestmark = pytest.mark.apps
 

--- a/tests/apps/test_similarity.py
+++ b/tests/apps/test_similarity.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""
-Unit tests for strawberryfields.apps.similarity
-"""
+r"""Unit tests for strawberryfields.apps.similarity."""
 # pylint: disable=no-self-use,unused-argument,too-many-arguments
 import itertools
 from collections import Counter
@@ -49,9 +47,12 @@ all_events = {
 
 @pytest.mark.parametrize("dim", [3, 4, 5])
 def test_sample_to_orbit(dim):
-    """Test if function ``similarity.sample_to_orbit`` correctly returns the original orbit after
-    taking all permutations over the orbit. The starting orbits are all orbits for a fixed photon
-    number ``dim``."""
+    """Test if function ``similarity.sample_to_orbit`` correctly returns the original
+    orbit after taking all permutations over the orbit.
+
+    The starting orbits are all orbits for a fixed photon
+    number ``dim``.
+    """
     orb = all_orbits[dim]
     checks = []
     for o in orb:
@@ -73,12 +74,16 @@ class TestOrbits:
         assert all([sum(o) == dim for o in similarity.orbits(dim)])
 
     def test_orbit_sorted(self, dim):
-        """Test if function generates orbits that are lists sorted in descending order."""
+        """Test if function generates orbits that are lists sorted in descending
+        order."""
         assert all([o == sorted(o, reverse=True) for o in similarity.orbits(dim)])
 
     def test_orbits(self, dim):
-        """Test if function returns all the integer partitions of 5. This test does not
-        require ``similarity.orbits`` to return the orbits in any specified order."""
+        """Test if function returns all the integer partitions of 5.
+
+        This test does not
+        require ``similarity.orbits`` to return the orbits in any specified order.
+        """
         partition = all_orbits[dim]
         orb = similarity.orbits(dim)
 
@@ -88,10 +93,13 @@ class TestOrbits:
 @pytest.mark.parametrize("dim", [3, 4, 5])
 @pytest.mark.parametrize("max_count_per_mode", [1, 2])
 def test_sample_to_event(dim, max_count_per_mode):
-    """Test if function ``similarity.sample_to_event`` gives the correct set of events when
-    applied to all orbits with a fixed number of photons ``dim``. This test ensures that orbits
+    """Test if function ``similarity.sample_to_event`` gives the correct set of events
+    when applied to all orbits with a fixed number of photons ``dim``.
+
+    This test ensures that orbits
     exceeding the ``max_count_per_mode`` value are attributed the ``None`` event and that orbits
-    not exceeding the ``max_count_per_mode`` are attributed the event ``dim``."""
+    not exceeding the ``max_count_per_mode`` are attributed the event ``dim``.
+    """
     orb = all_orbits[dim]
     target_events = all_events[(dim, max_count_per_mode)]
     ev = [similarity.sample_to_event(o, max_count_per_mode) for o in orb]
@@ -103,24 +111,27 @@ class TestOrbitToSample:
     """Tests for the function ``strawberryfields.apps.similarity.orbit_to_sample``"""
 
     def test_low_modes(self):
-        """Test if function raises a ``ValueError`` if fed an argument for ``modes`` that does
-        not exceed the length of the input orbit."""
+        """Test if function raises a ``ValueError`` if fed an argument for ``modes``
+        that does not exceed the length of the input orbit."""
         with pytest.raises(ValueError, match="Number of modes cannot"):
             similarity.orbit_to_sample([1, 2, 3], 2)
 
     @pytest.mark.parametrize("orb_dim", [3, 4, 5])
     @pytest.mark.parametrize("modes_dim", [6, 7])
     def test_sample_length(self, orb_dim, modes_dim):
-        """Test if function returns a sample that is of correct length ``modes_dim`` when fed a
-        collision-free event of ``orb_dim`` photons."""
+        """Test if function returns a sample that is of correct length ``modes_dim``
+        when fed a collision-free event of ``orb_dim`` photons."""
         samp = similarity.orbit_to_sample(all_orbits[orb_dim][0], modes_dim)
         assert len(samp) == modes_dim
 
     def test_sample_composition(self):
-        """Test if function returns a sample that corresponds to the input orbit. Input orbits
+        """Test if function returns a sample that corresponds to the input orbit.
+
+        Input orbits
         are orbits from ``all_orbits_cumulative``, i.e., all orbits from 3-5 photons. This test
         checks if a sample corresponds to an orbit by counting the occurrence of elements in the
-        sample and comparing to a count of elements in the orbit."""
+        sample and comparing to a count of elements in the orbit.
+        """
         modes = 5
 
         all_orbits_zeros = [
@@ -151,14 +162,15 @@ class TestEventToSample:
     """Tests for the function ``strawberryfields.apps.similarity.event_to_sample``"""
 
     def test_low_count(self):
-        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is
+        negative."""
         with pytest.raises(ValueError, match="Maximum number of photons"):
             similarity.event_to_sample(2, -1, 5)
 
     def test_high_photon(self):
-        """Test if function raises a ``ValueError`` if ``photon_number`` is so high that it
-        cannot correspond to a sample given the constraints of ``max_count_per_mode`` and
-        ``modes``"""
+        """Test if function raises a ``ValueError`` if ``photon_number`` is so high that
+        it cannot correspond to a sample given the constraints of ``max_count_per_mode``
+        and ``modes``"""
         with pytest.raises(ValueError, match="No valid samples can be generated."):
             similarity.event_to_sample(5, 1, 4)
 
@@ -182,7 +194,8 @@ class TestEventToSample:
     @pytest.mark.parametrize("modes_dim", [10, 11])
     @pytest.mark.parametrize("count", [3, 4])
     def test_sample_max_count(self, photon_num, modes_dim, count):
-        """Test if function returns a sample that has maximum element not exceeding ``count``."""
+        """Test if function returns a sample that has maximum element not exceeding
+        ``count``."""
         samp = similarity.event_to_sample(photon_num, count, modes_dim)
         assert max(samp) <= count
 
@@ -200,8 +213,8 @@ orbits = [
 
 @pytest.mark.parametrize("orbit, max_photon, expected", orbits)
 def test_orbit_cardinality(orbit, max_photon, expected):
-    """Test if function ``strawberryfields.apps.similarity.orbit_cardinality`` returns the
-    correct number of samples for some hard-coded examples."""
+    """Test if function ``strawberryfields.apps.similarity.orbit_cardinality`` returns
+    the correct number of samples for some hard-coded examples."""
 
     assert np.allclose(similarity.orbit_cardinality(list(orbit), max_photon), expected)
 
@@ -218,8 +231,8 @@ events = [
 
 @pytest.mark.parametrize("photons, max_count, modes, expected", events)
 def test_event_cardinality(photons, max_count, modes, expected):
-    """Test if function ``strawberryfields.apps.similarity.event_cardinality`` returns the
-    correct number of samples for some hard-coded examples."""
+    """Test if function ``strawberryfields.apps.similarity.event_cardinality`` returns
+    the correct number of samples for some hard-coded examples."""
 
     assert similarity.event_cardinality(photons, max_count, modes) == expected
 
@@ -267,15 +280,15 @@ class TestProbOrbitExact:
     """Tests for the function ``strawberryfields.apps.similarity.prob_orbit_exact``"""
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.prob_orbit_exact(g, [1, 1, 1, 1], n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -283,8 +296,8 @@ class TestProbOrbitExact:
             similarity.prob_orbit_exact(g, [1, 1, 1, 1], loss=2)
 
     def test_prob_vacuum_orbit(self):
-        """Tests if the function gives the right probability for the empty orbit when the GBS
-        device has been configured to have zero mean photon number."""
+        """Tests if the function gives the right probability for the empty orbit when
+        the GBS device has been configured to have zero mean photon number."""
         graph = nx.complete_graph(5)
         assert similarity.prob_orbit_exact(graph, [], 0) == 1.0
 
@@ -295,10 +308,13 @@ class TestProbOrbitExact:
         assert similarity.prob_orbit_exact(graph, [k]) == 0.0
 
     def test_correct_result_returned(self, monkeypatch):
-        """Tests if the call to _get_state function is performed correctly and probabilities over all
-        permutations of the given orbit are summed correctly. The test monkeypatches the fock_prob
-        function so that the probability is the same for each sample permutation and
-        is equal to 1/8. For a 4-mode graph, [1, 1] has 6 possible permutations."""
+        """Tests if the call to _get_state function is performed correctly and
+        probabilities over all permutations of the given orbit are summed correctly.
+
+        The test monkeypatches the fock_prob function so that the probability is the
+        same for each sample permutation and is equal to 1/8. For a 4-mode graph, [1, 1]
+        has 6 possible permutations.
+        """
         graph = nx.complete_graph(4)
         with monkeypatch.context() as m:
             m.setattr(
@@ -308,8 +324,7 @@ class TestProbOrbitExact:
             assert similarity.prob_orbit_exact(graph, [1, 1]) == 6 / 8
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         g = nx.complete_graph(3)
 
         p = similarity.prob_orbit_exact(g, [1, 1], 2)
@@ -326,15 +341,15 @@ class TestProbEventExact:
     """Tests for the function ``strawberryfields.apps.similarity.prob_event_exact``"""
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.prob_event_exact(g, 2, 2, n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -342,13 +357,15 @@ class TestProbEventExact:
             similarity.prob_event_exact(g, 2, 2, loss=2)
 
     def test_invalid_photon_number(self):
-        """Test if function raises a ``ValueError`` when a photon number below zero is specified"""
+        """Test if function raises a ``ValueError`` when a photon number below zero is
+        specified."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Photon number must not be below zero"):
             similarity.prob_event_exact(g, -1, 2)
 
     def test_low_count(self):
-        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is
+        negative."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Maximum number of photons per mode must be non-negative"
@@ -356,8 +373,9 @@ class TestProbEventExact:
             similarity.prob_event_exact(g, 2, max_count_per_mode=-1)
 
     def test_prob_vacuum_event(self):
-        """Tests if the function gives the right probability for an event with zero photons when
-        the GBS device has been configured to have zero mean photon number."""
+        """Tests if the function gives the right probability for an event with zero
+        photons when the GBS device has been configured to have zero mean photon
+        number."""
         graph = nx.complete_graph(5)
         assert similarity.prob_event_exact(graph, 0, 0, 0) == 1.0
 
@@ -369,11 +387,15 @@ class TestProbEventExact:
         assert similarity.prob_event_exact(graph, k, nmax) == 0.0
 
     def test_correct_result_returned(self, monkeypatch):
-        """Tests if the call to _get_state function is performed correctly and probabilities over all
-        constituent orbits of the given event are summed correctly. The test monkeypatches the fock_prob
+        """Tests if the call to _get_state function is performed correctly and
+        probabilities over all constituent orbits of the given event are summed
+        correctly.
+
+        The test monkeypatches the fock_prob
         function so that the probability is the same for each sample permutation of all constituent orbits
         and is equal to 1/8. For a 4-mode graph, an event with ``photon_number = 2``, and
-        ``max_count_per_mode = 1`` contains orbit [1, 1] which has 6 possible sample permutations."""
+        ``max_count_per_mode = 1`` contains orbit [1, 1] which has 6 possible sample permutations.
+        """
         graph = nx.complete_graph(4)
         with monkeypatch.context() as m:
             m.setattr(
@@ -383,8 +405,7 @@ class TestProbEventExact:
             assert similarity.prob_event_exact(graph, 2, 1) == 6 / 8
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         graph = nx.complete_graph(4)
         p1 = similarity.prob_event_exact(graph, 2, 2, 1)
         p2 = similarity.prob_event_exact(graph, 2, 1, 1)
@@ -399,22 +420,22 @@ class TestProbOrbitMC:
     """Tests for the function ``strawberryfields.apps.similarity.prob_orbit_mc``"""
 
     def test_invalid_samples(self):
-        """Test if function raises a ``ValueError`` when a number of samples less than one is
-        requested."""
+        """Test if function raises a ``ValueError`` when a number of samples less than
+        one is requested."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Number of samples must be at least one"):
             similarity.prob_orbit_mc(g, [1, 1, 1, 1], samples=0)
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.prob_orbit_mc(g, [1, 1, 1, 1], n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -422,9 +443,12 @@ class TestProbOrbitMC:
             similarity.prob_orbit_mc(g, [1, 1, 1, 1], loss=2)
 
     def test_mean_computation_orbit(self, monkeypatch):
-        """Tests if the calculation of the sample mean is performed correctly. The test
-        monkeypatches the fock_prob function so that the probability is the same for each sample and
-        is equal to 1/5, i.e., one over the cardinality of the orbit [1,1,1,1] for 5 modes."""
+        """Tests if the calculation of the sample mean is performed correctly.
+
+        The test monkeypatches the fock_prob function so that the probability is the
+        same for each sample and is equal to 1/5, i.e., one over the cardinality of the
+        orbit [1,1,1,1] for 5 modes.
+        """
         graph = nx.complete_graph(5)
         with monkeypatch.context() as m:
             m.setattr(
@@ -440,8 +464,8 @@ class TestProbOrbitMC:
         assert similarity.prob_orbit_mc(graph, [k]) == 0.0
 
     def test_prob_vacuum_orbit(self):
-        """Tests if the function gives the right probability for the empty orbit when the GBS
-        device has been configured to have zero mean photon number."""
+        """Tests if the function gives the right probability for the empty orbit when
+        the GBS device has been configured to have zero mean photon number."""
         graph = nx.complete_graph(5)
         assert similarity.prob_orbit_mc(graph, [], 0) == 1.0
 
@@ -451,8 +475,7 @@ class TestProbOrbitMC:
         assert similarity.prob_orbit_mc(graph, [1, 1, 1, 1], samples=1, loss=1) == 0.0
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         g = nx.complete_graph(3)
 
         assert np.allclose(similarity.prob_orbit_mc(g, [1, 1], 2), 0.2422152682538481)
@@ -463,22 +486,22 @@ class TestProbEventMC:
     """Tests for the function ``strawberryfields.apps.similarity.prob_event_mc``"""
 
     def test_invalid_samples(self):
-        """Test if function raises a ``ValueError`` when a number of samples less than one is
-        requested."""
+        """Test if function raises a ``ValueError`` when a number of samples less than
+        one is requested."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Number of samples must be at least one"):
             similarity.prob_event_mc(g, 2, 2, samples=0)
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.prob_event_mc(g, 2, 2, n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -486,13 +509,15 @@ class TestProbEventMC:
             similarity.prob_event_mc(g, 2, 2, loss=2)
 
     def test_invalid_photon_number(self):
-        """Test if function raises a ``ValueError`` when a photon number below zero is specified"""
+        """Test if function raises a ``ValueError`` when a photon number below zero is
+        specified."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Photon number must not be below zero"):
             similarity.prob_event_mc(g, -1, 2)
 
     def test_low_count(self):
-        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is
+        negative."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Maximum number of photons per mode must be non-negative"
@@ -500,16 +525,19 @@ class TestProbEventMC:
             similarity.prob_event_mc(g, 2, max_count_per_mode=-1)
 
     def test_prob_vacuum_event(self):
-        """Tests if the function gives the right probability for an event with zero photons when
-        the GBS device has been configured to have zero mean photon number."""
+        """Tests if the function gives the right probability for an event with zero
+        photons when the GBS device has been configured to have zero mean photon
+        number."""
         graph = nx.complete_graph(5)
         assert similarity.prob_event_mc(graph, 0, 0, 0) == 1.0
 
     def test_mean_computation_event(self, monkeypatch):
-        """Tests if the calculation of the sample mean is performed correctly. The test
-        monkeypatches the fock_prob function so that the probability is the same for each sample
-        and is equal to 1/216, i.e., one over the number of samples in the event with 5 modes,
-        6 photons, and max 3 photons per mode."""
+        """Tests if the calculation of the sample mean is performed correctly.
+
+        The test monkeypatches the fock_prob function so that the probability is the
+        same for each sample and is equal to 1/216, i.e., one over the number of samples
+        in the event with 5 modes, 6 photons, and max 3 photons per mode.
+        """
         graph = nx.complete_graph(6)
         with monkeypatch.context() as m:
             m.setattr(
@@ -531,8 +559,7 @@ class TestProbEventMC:
         assert similarity.prob_event_mc(graph, 6, 3, samples=1, loss=1) == 0.0
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         g = nx.complete_graph(4)
         p = similarity.prob_event_mc(g, 2, 1, 4)
         assert np.allclose(p, 0.2108778117852639)
@@ -542,7 +569,8 @@ class TestProbEventMC:
 
 
 class TestFeatureVectorOrbits:
-    """Tests for the function ``strawberryfields.apps.graph.similarity.feature_vector_orbits``"""
+    """Tests for the function
+    ``strawberryfields.apps.graph.similarity.feature_vector_orbits``"""
 
     def test_invalid_orbits_list(self):
         """Test if function raises a ``ValueError`` when the list of orbits is empty."""
@@ -558,15 +586,15 @@ class TestFeatureVectorOrbits:
             similarity.feature_vector_orbits(graph, [[-1, 1]])
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.feature_vector_orbits(g, [[1, 1], [2]], n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -574,16 +602,19 @@ class TestFeatureVectorOrbits:
             similarity.feature_vector_orbits(g, [[1, 1], [2]], loss=2)
 
     def test_calls_exact_for_zero_samples(self):
-        """Test if function calls the exact function for zero samples"""
+        """Test if function calls the exact function for zero samples."""
         g = nx.complete_graph(5)
         assert similarity.feature_vector_orbits(
             g, [[1, 1]], samples=0
         ) == similarity.prob_orbit_exact(g, [1, 1])
 
     def test_correct_vector_returned(self, monkeypatch):
-        """Test if function correctly constructs the feature vector. The ``prob_orbit_exact``
+        """Test if function correctly constructs the feature vector.
+
+        The ``prob_orbit_exact``
         and ``prob_orbit_mc`` function called within ``feature_vector_orbits`` are
-        monkeypatched to return hard-coded outputs that depend only on the orbit."""
+        monkeypatched to return hard-coded outputs that depend only on the orbit.
+        """
 
         with monkeypatch.context() as m:
             m.setattr(
@@ -604,11 +635,13 @@ class TestFeatureVectorOrbits:
                 lambda _graph, orbit, n_mean, loss: 0.5 * (1.0 / sum(orbit)),
             )
             graph = nx.complete_graph(8)
-            assert similarity.feature_vector_orbits(graph, [[1, 1], [2, 1, 1]]) == [0.25, 0.125]
+            assert similarity.feature_vector_orbits(graph, [[1, 1], [2, 1, 1]]) == [
+                0.25,
+                0.125,
+            ]
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         graph = nx.complete_graph(4)
         p = similarity.feature_vector_orbits(graph, [[1, 1], [2, 1, 1]], 2)
         assert np.allclose(p, [0.22918531118334962, 0.06509669127495163])
@@ -618,11 +651,12 @@ class TestFeatureVectorOrbits:
 
 
 class TestFeatureVectorEvents:
-    """Tests for the function ``strawberryfields.apps.graph.similarity.feature_vector_events``"""
+    """Tests for the function
+    ``strawberryfields.apps.graph.similarity.feature_vector_events``"""
 
     def test_invalid_event_photon_numbers(self):
-        """Test if function raises a ``ValueError`` when the list of event photons numbers
-        is empty."""
+        """Test if function raises a ``ValueError`` when the list of event photons
+        numbers is empty."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="List of photon numbers must have at least one element"
@@ -630,15 +664,15 @@ class TestFeatureVectorEvents:
             similarity.feature_vector_events(g, [], 1)
 
     def test_invalid_n_mean(self):
-        """Test if function raises a ``ValueError`` when the mean photon number is specified to
-        be negative."""
+        """Test if function raises a ``ValueError`` when the mean photon number is
+        specified to be negative."""
         g = nx.complete_graph(5)
         with pytest.raises(ValueError, match="Mean photon number must be non-negative"):
             similarity.feature_vector_events(g, [2, 4], 2, n_mean=-1)
 
     def test_invalid_loss(self):
-        """Test if function raises a ``ValueError`` when the loss parameter is specified outside
-        of range."""
+        """Test if function raises a ``ValueError`` when the loss parameter is specified
+        outside of range."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Loss parameter must take a value between zero and one"
@@ -646,14 +680,15 @@ class TestFeatureVectorEvents:
             similarity.feature_vector_events(g, [2, 4], 2, loss=2)
 
     def test_bad_event_photon_numbers(self):
-        """Test if function raises a ``ValueError`` when input a minimum photon number that is
-        below zero."""
+        """Test if function raises a ``ValueError`` when input a minimum photon number
+        that is below zero."""
         with pytest.raises(ValueError, match="Cannot request events with photon number below zero"):
             graph = nx.complete_graph(5)
             similarity.feature_vector_events(graph, [-1, 4], 2)
 
     def test_low_count(self):
-        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is
+        negative."""
         g = nx.complete_graph(5)
         with pytest.raises(
             ValueError, match="Maximum number of photons per mode must be non-negative"
@@ -661,16 +696,19 @@ class TestFeatureVectorEvents:
             similarity.feature_vector_events(g, [2, 4], max_count_per_mode=-1)
 
     def test_calls_exact_for_zero_samples(self):
-        """Test if function calls the exact function for zero samples"""
+        """Test if function calls the exact function for zero samples."""
         g = nx.complete_graph(5)
         assert similarity.feature_vector_events(
             g, [2], 1, samples=0
         ) == similarity.prob_event_exact(g, 2, 1)
 
     def test_correct_vector_returned(self, monkeypatch):
-        """Test if function correctly constructs the feature vector. The ``prob_event_exact``
+        """Test if function correctly constructs the feature vector.
+
+        The ``prob_event_exact``
         and ``prob_event_mc`` function called within ``feature_vector_events`` are
-        monkeypatched to return hard-coded outputs that depend only on the orbit."""
+        monkeypatched to return hard-coded outputs that depend only on the orbit.
+        """
 
         with monkeypatch.context() as m:
             m.setattr(
@@ -692,11 +730,14 @@ class TestFeatureVectorEvents:
                 lambda _graph, photons, max_count, n_mean, loss: 0.5 * (1.0 / photons),
             )
             g = nx.complete_graph(8)
-            assert similarity.feature_vector_events(g, [2, 4, 8], 1) == [0.25, 0.125, 0.0625]
+            assert similarity.feature_vector_events(g, [2, 4, 8], 1) == [
+                0.25,
+                0.125,
+                0.0625,
+            ]
 
     def test_known_result(self):
-        """Tests if the probability for known cases is correctly
-        reproduced."""
+        """Tests if the probability for known cases is correctly reproduced."""
         g = nx.complete_graph(4)
         p = similarity.feature_vector_events(g, [2, 4], 2, 4)
         assert np.allclose(p, [0.21087781178526066, 0.11998024483275889])
@@ -708,7 +749,8 @@ class TestFeatureVectorEvents:
 
 
 class TestFeatureVectorOrbitsSampling:
-    """Tests for the function ``strawberryfields.apps.graph.similarity.feature_vector_orbits_sampling``"""
+    """Tests for the function
+    ``strawberryfields.apps.graph.similarity.feature_vector_orbits_sampling``"""
 
     def test_invalid_orbits_list(self):
         """Test if function raises a ``ValueError`` when the list of orbits is empty."""
@@ -722,11 +764,14 @@ class TestFeatureVectorOrbitsSampling:
             similarity.feature_vector_orbits_sampling([[1, 1, 0], [1, 0, 1]], [[-1, 1]])
 
     def test_correct_vector_returned(self, monkeypatch):
-        """Test if function correctly constructs the feature vector corresponding to some hard
-        coded samples. This test uses a set of samples, corresponding orbits, and resultant
+        """Test if function correctly constructs the feature vector corresponding to
+        some hard coded samples.
+
+        This test uses a set of samples, corresponding orbits, and resultant
         feature vector to test against the output of ``feature_vector_orbits_sampling``. The
         ``sample_to_orbit`` function called within ``feature_vector_orbits_sampling`` is
-        monkeypatched to return the hard coded events corresponding to the samples."""
+        monkeypatched to return the hard coded events corresponding to the samples.
+        """
         samples_orbits_mapping = {
             (1, 1, 0, 0, 0): [1, 1],
             (1, 1, 1, 0, 0): [1, 1, 1],
@@ -750,35 +795,40 @@ class TestFeatureVectorOrbitsSampling:
 
 
 class TestFeatureVectorEventsSampling:
-    """Tests for the function ``strawberryfields.apps.graph.similarity.feature_vector_events_sampling``"""
+    """Tests for the function
+    ``strawberryfields.apps.graph.similarity.feature_vector_events_sampling``"""
 
     def test_invalid_event_photon_numbers(self):
-        """Test if function raises a ``ValueError`` when the list of event photons numbers
-        is empty."""
+        """Test if function raises a ``ValueError`` when the list of event photons
+        numbers is empty."""
         with pytest.raises(
             ValueError, match="List of photon numbers must have at least one element"
         ):
             similarity.feature_vector_events_sampling([[1, 1, 0], [1, 0, 1]], [], 1)
 
     def test_bad_event_photon_numbers(self):
-        """Test if function raises a ``ValueError`` when input a minimum photon number that is
-        below zero."""
+        """Test if function raises a ``ValueError`` when input a minimum photon number
+        that is below zero."""
         with pytest.raises(ValueError, match="Cannot request events with photon number below zero"):
             similarity.feature_vector_events_sampling([[1, 1, 0], [1, 0, 1]], [-1, 4], 1)
 
     def test_low_count(self):
-        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is negative."""
+        """Test if function raises a ``ValueError`` if ``max_count_per_mode`` is
+        negative."""
         with pytest.raises(
             ValueError, match="Maximum number of photons per mode must be non-negative"
         ):
             similarity.feature_vector_events_sampling([[1, 1, 0], [1, 0, 1]], [2, 4], -1)
 
     def test_correct_vector_returned(self, monkeypatch):
-        """Test if function correctly constructs the feature vector corresponding to some hard
-        coded samples. This test uses a set of samples, corresponding events, and resultant
+        """Test if function correctly constructs the feature vector corresponding to
+        some hard coded samples.
+
+        This test uses a set of samples, corresponding events, and resultant
         feature vector to test against the output of ``feature_vector_events_sampling``. The
         ``sample_to_event`` function called within ``feature_vector_events_sampling`` is
-        monkeypatched to return the hard coded events corresponding to the samples."""
+        monkeypatched to return the hard coded events corresponding to the samples.
+        """
         samples_events_mapping = {  # max_count_per_mode = 1
             (1, 1, 0, 0, 0): 2,
             (1, 1, 1, 0, 0): 3,

--- a/tests/apps/train/test_embed.py
+++ b/tests/apps/train/test_embed.py
@@ -17,6 +17,7 @@ Unit tests for strawberryfields.apps.train.embed
 # pylint: disable=no-self-use,unused-argument
 import numpy as np
 import pytest
+
 from strawberryfields.apps.train import embed
 
 pytestmark = pytest.mark.apps

--- a/tests/backend/test_beamsplitter_operation.py
+++ b/tests/backend/test_beamsplitter_operation.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 r"""
 Unit tests for beamsplitter operations
 Convention: The beamsplitter operation transforms
@@ -23,11 +22,9 @@ Equivalently, we have t:=\cos(\theta) (t assumed real) and r:=\exp{i\phi}\sin(\t
 
 import itertools as it
 
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial
-
 
 T_VALUES = np.linspace(-0.2, 1.0, 3, dtype=np.float64)
 PHASE_R = np.linspace(0, 2 * np.pi, 3, endpoint=False, dtype=np.float64)
@@ -42,8 +39,8 @@ class TestRepresentationIndependent:
     @pytest.mark.parametrize("t", T_VALUES)
     @pytest.mark.parametrize("r_phi", PHASE_R)
     def test_vacuum_beamsplitter(self, setup_backend, t, r_phi, tol):
-        """Tests beamsplitter operation in some limiting cases where the output
-        should be the vacuum in both modes."""
+        """Tests beamsplitter operation in some limiting cases where the output should
+        be the vacuum in both modes."""
         backend = setup_backend(2)
 
         backend.beamsplitter(np.arccos(t), r_phi, 0, 1)
@@ -53,11 +50,13 @@ class TestRepresentationIndependent:
     @pytest.mark.parametrize("mag_alpha", MAG_ALPHAS[1:])
     @pytest.mark.parametrize("r_phi", PHASE_R)
     def test_coherent_vacuum_interfered(self, setup_backend, t, mag_alpha, r_phi, tol):
-        r"""Tests if a range of beamsplitter output states (formed from a coherent state interfering with vacuum)
-        have the correct fidelity with the expected coherent states outputs.
-        |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out>
-        and for each output mode,
-        |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>"""
+        r"""Tests if a range of beamsplitter output states (formed from a coherent state
+        interfering with vacuum) have the correct fidelity with the expected coherent
+        states outputs.
+
+        |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out> and for each
+        output mode, |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>
+        """
         phase_alpha = np.pi / 5
         alpha = mag_alpha * np.exp(1j * phase_alpha)
         r = np.exp(1j * r_phi) * np.sqrt(1.0 - np.abs(t) ** 2)
@@ -95,11 +94,12 @@ class TestFockRepresentation:
     def test_coherent_vacuum_interfered_fock_elements(
         self, setup_backend, mag_alpha, t, r_phi, cutoff, pure, tol
     ):
-        r"""Tests if a range of beamsplitter output states (formed from a coherent state interfering with vacuum)
-        have the correct Fock basis elements.
-        |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out>
-        and for each output mode,
-        |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>"""
+        r"""Tests if a range of beamsplitter output states (formed from a coherent state
+        interfering with vacuum) have the correct Fock basis elements.
+
+        |\psi_in> = |\alpha>|0> --> |t \alpha>|r \alpha> = |\psi_out> and for each
+        output mode, |\gamma> = exp(-0.5 |\gamma|^2) \sum_n \gamma^n / \sqrt{n!} |n>
+        """
 
         phase_alpha = np.pi / 5
         alpha = mag_alpha * np.exp(1j * phase_alpha)
@@ -119,12 +119,8 @@ class TestFockRepresentation:
         alpha_outB = r * alpha
 
         n = np.arange(cutoff)
-        ref_stateA = (
-            np.exp(-0.5 * np.abs(alpha_outA) ** 2) * alpha_outA**n / np.sqrt(factorial(n))
-        )
-        ref_stateB = (
-            np.exp(-0.5 * np.abs(alpha_outB) ** 2) * alpha_outB**n / np.sqrt(factorial(n))
-        )
+        ref_stateA = np.exp(-0.5 * np.abs(alpha_outA) ** 2) * alpha_outA**n / np.sqrt(factorial(n))
+        ref_stateB = np.exp(-0.5 * np.abs(alpha_outB) ** 2) * alpha_outB**n / np.sqrt(factorial(n))
 
         ref_state = np.einsum("i,j->ij", ref_stateA, ref_stateB)
 
@@ -167,12 +163,8 @@ class TestModeSubsets:
         alpha_outB = r * alpha
 
         n = np.arange(cutoff)
-        ref_stateA = (
-            np.exp(-0.5 * np.abs(alpha_outA) ** 2) * alpha_outA**n / np.sqrt(factorial(n))
-        )
-        ref_stateB = (
-            np.exp(-0.5 * np.abs(alpha_outB) ** 2) * alpha_outB**n / np.sqrt(factorial(n))
-        )
+        ref_stateA = np.exp(-0.5 * np.abs(alpha_outA) ** 2) * alpha_outA**n / np.sqrt(factorial(n))
+        ref_stateB = np.exp(-0.5 * np.abs(alpha_outB) ** 2) * alpha_outB**n / np.sqrt(factorial(n))
 
         numer_state = state.reduced_dm(list(modes))
 

--- a/tests/backend/test_bosonic_backend.py
+++ b/tests/backend/test_bosonic_backend.py
@@ -17,10 +17,11 @@ Unit tests for backends.bosonicbackend.backend.py.
 """
 
 import numpy as np
-import strawberryfields as sf
-import strawberryfields.backends.bosonicbackend.backend as bosonic
 import pytest
 import sympy
+
+import strawberryfields as sf
+import strawberryfields.backends.bosonicbackend.backend as bosonic
 
 pytestmark = pytest.mark.bosonic
 

--- a/tests/backend/test_displaced_squeezed_state_preparation.py
+++ b/tests/backend/test_displaced_squeezed_state_preparation.py
@@ -14,9 +14,8 @@
 
 r"""Unit tests for operations that prepare squeezed coherent states"""
 
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial
 
 MAG_ALPHAS = np.linspace(0.1, 0.5, 2)

--- a/tests/backend/test_displacement_operation.py
+++ b/tests/backend/test_displacement_operation.py
@@ -18,12 +18,10 @@ Convention: The displacement unitary is fixed to be
 U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
 where \hat{a}^\dagger is the photon creation operator.
 """
+import numpy as np
 # pylint: disable=too-many-arguments
 import pytest
-
-import numpy as np
 from scipy.special import factorial as fac
-
 
 MAG_ALPHAS = np.linspace(0, 0.8, 4)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)

--- a/tests/backend/test_displacement_operation.py
+++ b/tests/backend/test_displacement_operation.py
@@ -19,6 +19,7 @@ U(\alpha) = \exp(alpha \hat{a}^\dagger - \alpha^* \hat{a})
 where \hat{a}^\dagger is the photon creation operator.
 """
 import numpy as np
+
 # pylint: disable=too-many-arguments
 import pytest
 from scipy.special import factorial as fac

--- a/tests/backend/test_fock_measurement.py
+++ b/tests/backend/test_fock_measurement.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 r"""Unit tests for measurements in the Fock basis"""
-import pytest
-
 import numpy as np
-
+import pytest
 
 NUM_REPEATS = 50
 

--- a/tests/backend/test_gaussian_cptp.py
+++ b/tests/backend/test_gaussian_cptp.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+r"""Unit test for Gaussian CPTP map."""
 
-r"""Unit test for Gaussian CPTP map
-"""
-
-
-import pytest
 
 import numpy as np
+import pytest
 
 LOSS_TS = np.linspace(0.0, 1, 3, endpoint=True)
 DISPS = np.linspace(0.0, 5, 3, endpoint=True)

--- a/tests/backend/test_gaussian_gates.py
+++ b/tests/backend/test_gaussian_gates.py
@@ -22,11 +22,14 @@ from thewalrus.symplectic import sympmat
 
 tf = pytest.importorskip("tensorflow")
 
-from strawberryfields.backends.tfbackend.ops import (choi_trick, gaussian_gate,
-                                                     gaussian_gate_matrix,
-                                                     n_mode_gate,
-                                                     single_mode_gate,
-                                                     two_mode_gate)
+from strawberryfields.backends.tfbackend.ops import (
+    choi_trick,
+    gaussian_gate,
+    gaussian_gate_matrix,
+    n_mode_gate,
+    single_mode_gate,
+    two_mode_gate,
+)
 
 
 @pytest.mark.backends("tf", "fock")

--- a/tests/backend/test_gaussian_gates.py
+++ b/tests/backend/test_gaussian_gates.py
@@ -14,22 +14,19 @@
 
 r"""Unit tests for Gaussian gate"""
 
-import pytest
 import numpy as np
+import pytest
 from scipy.stats import unitary_group
 from thewalrus.quantum.fock_tensors import fock_tensor
 from thewalrus.symplectic import sympmat
 
 tf = pytest.importorskip("tensorflow")
 
-from strawberryfields.backends.tfbackend.ops import (
-    choi_trick,
-    n_mode_gate,
-    single_mode_gate,
-    two_mode_gate,
-    gaussian_gate,
-    gaussian_gate_matrix,
-)
+from strawberryfields.backends.tfbackend.ops import (choi_trick, gaussian_gate,
+                                                     gaussian_gate_matrix,
+                                                     n_mode_gate,
+                                                     single_mode_gate,
+                                                     two_mode_gate)
 
 
 @pytest.mark.backends("tf", "fock")

--- a/tests/backend/test_heterodyne.py
+++ b/tests/backend/test_heterodyne.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for heterodyne measurements."""
-import pytest
-
 import numpy as np
+import pytest
 
 mag_alphas = np.linspace(0, 0.8, 4)
 phase_alphas = np.linspace(0, 2 * np.pi, 7, endpoint=False)

--- a/tests/backend/test_homodyne.py
+++ b/tests/backend/test_homodyne.py
@@ -15,7 +15,6 @@
 r"""Unit tests for homodyne measurements."""
 import numpy as np
 
-
 N_MEAS = 300  # number of homodyne measurements to perform
 NUM_STDS = 10.0
 std_10 = NUM_STDS / np.sqrt(N_MEAS)

--- a/tests/backend/test_is_vacuum.py
+++ b/tests/backend/test_is_vacuum.py
@@ -16,10 +16,8 @@
 Unit tests for the is_vacuum() check.
 """
 
-import pytest
-
 import numpy as np
-
+import pytest
 
 MAG_ALPHAS = np.linspace(0, 0.8, 3)
 

--- a/tests/backend/test_loss_channel.py
+++ b/tests/backend/test_loss_channel.py
@@ -11,16 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+r"""Unit tests for the loss channel.
 
-r"""Unit tests for the loss channel
 Convention: The loss channel N(T) has the action
 N(T){|n><m|} = \sum_{l=0}^{min(m,n)} ((1-T)/T) ^ l * T^((n+m)/2) / l! * \sqrt(n!m!/((n-l)!(m-l)!))n-l><m-l|
 """
 
 
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial
 
 LOSS_TS = np.linspace(0.0, 1.0, 3, endpoint=True)
@@ -58,8 +57,8 @@ class TestRepresentationIndependent:
 # thermal loss channels.
 @pytest.mark.backends("gaussian", "bosonic")
 class TestThermalLossChannel:
-    """Tests that make use of the Gaussian representation to test
-    thermal loss channels."""
+    """Tests that make use of the Gaussian representation to test thermal loss
+    channels."""
 
     @pytest.mark.parametrize("T", LOSS_TS)
     def test_thermal_loss_channel_with_vacuum(self, T, setup_backend, pure, tol):
@@ -113,7 +112,7 @@ class TestThermalLossChannel:
     @pytest.mark.parametrize("T", LOSS_TS)
     @pytest.mark.parametrize("nbar", MAG_ALPHAS)
     def test_thermal_loss_channel_on_squeezed_state(self, nbar, T, setup_backend, pure, tol, hbar):
-        """Tests thermal loss channel on a squeezed state"""
+        """Tests thermal loss channel on a squeezed state."""
         backend = setup_backend(1)
         r = 0.432
         backend.squeeze(r, 0, 0)
@@ -188,7 +187,8 @@ class TestFockRepresentation:
     def test_loss_channel_on_coherent_states(
         self, setup_backend, T, mag_alpha, phase_alpha, cutoff, tol
     ):
-        """Tests various loss channels on coherent states (result should be coherent state with amplitude weighted by sqrt(T)."""
+        """Tests various loss channels on coherent states (result should be coherent
+        state with amplitude weighted by sqrt(T)."""
 
         rootT_alpha = np.sqrt(T) * mag_alpha * np.exp(1j * phase_alpha)
 
@@ -202,8 +202,6 @@ class TestFockRepresentation:
         else:
             numer_state = s.dm()
         n = np.arange(cutoff)
-        ref_state = (
-            np.exp(-0.5 * np.abs(rootT_alpha) ** 2) * rootT_alpha**n / np.sqrt(factorial(n))
-        )
+        ref_state = np.exp(-0.5 * np.abs(rootT_alpha) ** 2) * rootT_alpha**n / np.sqrt(factorial(n))
         ref_state = np.outer(ref_state, np.conj(ref_state))
         assert np.allclose(numer_state, ref_state, atol=tol, rtol=0.0)

--- a/tests/backend/test_mbsqueeze_operation.py
+++ b/tests/backend/test_mbsqueeze_operation.py
@@ -15,6 +15,7 @@ r"""
 Unit tests for mbsqueezing operation in the bosonic backend.
 """
 import numpy as np
+
 # pylint: disable=too-many-arguments
 import pytest
 

--- a/tests/backend/test_mbsqueeze_operation.py
+++ b/tests/backend/test_mbsqueeze_operation.py
@@ -14,11 +14,9 @@
 r"""
 Unit tests for mbsqueezing operation in the bosonic backend.
 """
+import numpy as np
 # pylint: disable=too-many-arguments
 import pytest
-
-import numpy as np
-
 
 PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 MAG = np.linspace(0.0, 1, 5, endpoint=False)

--- a/tests/backend/test_modes.py
+++ b/tests/backend/test_modes.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 r"""Unit tests for add_mode and del_mode functions"""
-import pytest
-
 import numpy as np
+import pytest
 
 NUM_REPEATS = 10
 

--- a/tests/backend/test_multimode_state_preparations.py
+++ b/tests/backend/test_multimode_state_preparations.py
@@ -11,16 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Tests for various multi mode state preparation operations"""
+r"""Tests for various multi mode state preparation operations."""
 import itertools
 
+import numpy as np
 import pytest
 
-import numpy as np
-
 from strawberryfields import ops
-from strawberryfields.utils import random_covariance, displaced_squeezed_state
-
+from strawberryfields.utils import displaced_squeezed_state, random_covariance
 
 MAG_ALPHAS = np.linspace(0, 0.8, 3)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 3, endpoint=False)
@@ -29,10 +27,10 @@ NBARS = np.linspace(0, 5)
 
 @pytest.mark.backends("tf", "fock")
 class TestFockBasisMultimode:
-    """Testing preparing multimode states on the Fock backends"""
+    """Testing preparing multimode states on the Fock backends."""
 
     def test_multimode_ket_mode_permutations(self, setup_backend, pure, cutoff, tol):
-        """Test multimode ket preparation when modes are permuted"""
+        """Test multimode ket preparation when modes are permuted."""
         backend = setup_backend(4)
 
         random_ket0 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(-1, 1, cutoff)
@@ -53,7 +51,7 @@ class TestFockBasisMultimode:
     def test_compare_single_mode_and_multimode_ket_preparation(
         self, setup_backend, batch_size, pure, cutoff, tol
     ):
-        """Test single and multimode ket preparation"""
+        """Test single and multimode ket preparation."""
         backend = setup_backend(4)
 
         random_ket0 = np.random.uniform(-1, 1, cutoff) + 1j * np.random.uniform(-1, 1, cutoff)
@@ -93,8 +91,8 @@ class TestFockBasisMultimode:
     def test_compare_single_mode_and_multimode_dm_preparation(
         self, setup_backend, batch_size, pure, cutoff, tol
     ):
-        """Compare the results of a successive single mode preparations
-        and a multi mode preparation of a product state."""
+        """Compare the results of a successive single mode preparations and a multi mode
+        preparation of a product state."""
         backend = setup_backend(4)
         random_rho0 = np.random.normal(size=[cutoff] * 2) + 1j * np.random.normal(size=[cutoff] * 2)
         random_rho0 = np.dot(random_rho0.conj().T, random_rho0)
@@ -185,7 +183,8 @@ class TestFockBasisMultimode:
     def test_prepare_multimode_random_product_dm_state_on_different_modes(
         self, setup_backend, batch_size, pure, cutoff, tol
     ):
-        """Tests if a random multi mode dm state is correctly prepared on different modes."""
+        """Tests if a random multi mode dm state is correctly prepared on different
+        modes."""
         backend = setup_backend(4)
         N = 4
 
@@ -221,8 +220,8 @@ class TestFockBasisMultimode:
             assert np.all(random_rho.shape == dm.shape)
 
     def test_fast_state_prep_on_all_modes(self, setup_backend, batch_size, pure, cutoff, tol):
-        """Tests if a random multi mode ket state is correctly prepared with
-        the shortcut method on all modes."""
+        """Tests if a random multi mode ket state is correctly prepared with the
+        shortcut method on all modes."""
         backend = setup_backend(4)
         N = 4
         random_ket = np.random.normal(size=[cutoff] * N) + 1j * np.random.normal(size=[cutoff] * N)
@@ -244,7 +243,7 @@ class TestGaussianMultimode:
     """Tests for simulators that use the Gaussian representation."""
 
     def test_singlemode_gaussian_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test single mode Gaussian state preparation"""
+        """Test single mode Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -277,7 +276,7 @@ class TestGaussianMultimode:
             assert np.allclose(state.cov(), ex_V, atol=tol, rtol=0)
 
     def test_multimode_gaussian_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test multimode Gaussian state preparation"""
+        """Test multimode Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -310,7 +309,7 @@ class TestGaussianMultimode:
             assert np.allclose(state.cov(), ex_V, atol=tol, rtol=0)
 
     def test_full_mode_squeezed_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test full register Gaussian state preparation"""
+        """Test full register Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -327,7 +326,7 @@ class TestGaussianMultimode:
         assert np.allclose(state.cov(), cov * hbar / 2, atol=tol, rtol=0)
 
     def test_multimode_gaussian_random_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test multimode Gaussian state preparation on a random state"""
+        """Test multimode Gaussian state preparation on a random state."""
         N = 4
         backend = setup_backend(N)
 
@@ -409,12 +408,13 @@ def from_xp(n):
 @pytest.mark.backends("bosonic")
 class TestBosonicMultimode:
     """Tests for simulators that use the Bosonic representation.
-    This is the same test as TestGaussianMultimode, taking into
-    account the different basis ordering of the means and covs for
-    the bosonic backend."""
+
+    This is the same test as TestGaussianMultimode, taking into account the different
+    basis ordering of the means and covs for the bosonic backend.
+    """
 
     def test_singlemode_gaussian_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test single mode Gaussian state preparation"""
+        """Test single mode Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -447,7 +447,7 @@ class TestBosonicMultimode:
             assert np.allclose(state.covs(), np.array([ex_V]), atol=tol, rtol=0)
 
     def test_multimode_gaussian_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test multimode Gaussian state preparation"""
+        """Test multimode Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -468,10 +468,16 @@ class TestBosonicMultimode:
         # test Gaussian state is correct
         state = backend.state([1, 3])
         assert np.allclose(
-            state.means(), np.array([means[from_xp(2)]]) * np.sqrt(hbar / 2), atol=tol, rtol=0
+            state.means(),
+            np.array([means[from_xp(2)]]) * np.sqrt(hbar / 2),
+            atol=tol,
+            rtol=0,
         )
         assert np.allclose(
-            state.covs(), np.array([cov[from_xp(2), :][:, from_xp(2)]]) * hbar / 2, atol=tol, rtol=0
+            state.covs(),
+            np.array([cov[from_xp(2), :][:, from_xp(2)]]) * hbar / 2,
+            atol=tol,
+            rtol=0,
         )
 
         # test that displaced squeezed states are unchanged
@@ -482,11 +488,14 @@ class TestBosonicMultimode:
             state = backend.state([i])
             assert np.allclose(state.means(), np.array([ex_means[from_xp(1)]]), atol=tol, rtol=0)
             assert np.allclose(
-                state.covs(), np.array([ex_V[from_xp(1), :][:, from_xp(1)]]), atol=tol, rtol=0
+                state.covs(),
+                np.array([ex_V[from_xp(1), :][:, from_xp(1)]]),
+                atol=tol,
+                rtol=0,
             )
 
     def test_full_mode_squeezed_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test full register Gaussian state preparation"""
+        """Test full register Gaussian state preparation."""
         N = 4
         backend = setup_backend(N)
 
@@ -500,14 +509,20 @@ class TestBosonicMultimode:
         # test Gaussian state is correct
         state = backend.state()
         assert np.allclose(
-            state.means(), np.array([means[from_xp(4)]]) * np.sqrt(hbar / 2), atol=tol, rtol=0
+            state.means(),
+            np.array([means[from_xp(4)]]) * np.sqrt(hbar / 2),
+            atol=tol,
+            rtol=0,
         )
         assert np.allclose(
-            state.covs(), np.array([cov[from_xp(4), :][:, from_xp(4)]]) * hbar / 2, atol=tol, rtol=0
+            state.covs(),
+            np.array([cov[from_xp(4), :][:, from_xp(4)]]) * hbar / 2,
+            atol=tol,
+            rtol=0,
         )
 
     def test_multimode_gaussian_random_state(self, setup_backend, batch_size, pure, tol, hbar):
-        """Test multimode Gaussian state preparation on a random state"""
+        """Test multimode Gaussian state preparation on a random state."""
         N = 4
         backend = setup_backend(N)
 
@@ -522,16 +537,23 @@ class TestBosonicMultimode:
         # test Gaussian state is correct
         state = backend.state()
         assert np.allclose(
-            state.means(), np.array([means[from_xp(N)]]) * np.sqrt(hbar / 2), atol=tol, rtol=0
+            state.means(),
+            np.array([means[from_xp(N)]]) * np.sqrt(hbar / 2),
+            atol=tol,
+            rtol=0,
         )
         assert np.allclose(
-            state.covs(), np.array([cov[from_xp(N), :][:, from_xp(N)]]) * hbar / 2, atol=tol, rtol=0
+            state.covs(),
+            np.array([cov[from_xp(N), :][:, from_xp(N)]]) * hbar / 2,
+            atol=tol,
+            rtol=0,
         )
 
     def test_multimode_gaussian_random_state_with_replacement(
         self, setup_backend, batch_size, pure, tol, hbar
     ):
-        """Test multimode Gaussian state preparation on a random state with replacement"""
+        """Test multimode Gaussian state preparation on a random state with
+        replacement."""
         N = 4
         backend = setup_backend(N)
 
@@ -591,7 +613,10 @@ class TestBosonicMultimode:
         ex_cov[rows, cols] = cov2[rows2, cols2]
 
         assert np.allclose(
-            state.means(), np.array([ex_means[from_xp(4)]]) * np.sqrt(hbar / 2), atol=tol, rtol=0
+            state.means(),
+            np.array([ex_means[from_xp(4)]]) * np.sqrt(hbar / 2),
+            atol=tol,
+            rtol=0,
         )
         assert np.allclose(
             state.covs(),

--- a/tests/backend/test_mzgate_operation.py
+++ b/tests/backend/test_mzgate_operation.py
@@ -16,9 +16,8 @@ r"""
 Unit tests for Mach-Zehnder Interferometer operations
 """
 
-import pytest
-
 import numpy as np
+import pytest
 
 PHI_IN = np.linspace(0, 2 * np.pi, 4, endpoint=False, dtype=np.float64)
 PHI_EX = np.linspace(0, 2 * np.pi, 4, endpoint=False, dtype=np.float64)

--- a/tests/backend/test_nongaussian_gates.py
+++ b/tests/backend/test_nongaussian_gates.py
@@ -14,10 +14,8 @@
 
 r"""Unit tests for non-Gaussian gates"""
 
-import pytest
-
 import numpy as np
-
+import pytest
 from scipy.linalg import expm
 
 KAPPAS = np.linspace(0, 2 * np.pi, 7)

--- a/tests/backend/test_postselection.py
+++ b/tests/backend/test_postselection.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""tests for backend postselection"""
-import pytest
-
 import numpy as np
+import pytest
 
 
 def test_homodyne(setup_backend, tol):

--- a/tests/backend/test_rotation_operation.py
+++ b/tests/backend/test_rotation_operation.py
@@ -18,9 +18,8 @@ U(\theta) = \exp(i * \theta \hat{n})
 where \hat{n} is the number operator. For positive \theta, this corresponds
 to a clockwise rotation of the state in phase space."""
 
-import pytest
-
 import numpy as np
+import pytest
 
 SHIFT_THETAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)
 

--- a/tests/backend/test_squeeze_operation.py
+++ b/tests/backend/test_squeeze_operation.py
@@ -17,12 +17,11 @@ Convention: The squeezing unitary is fixed to be
 U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
 where \hat{a} is the photon annihilation operator.
 """
+import numpy as np
 # pylint: disable=too-many-arguments
 import pytest
-
-import numpy as np
-from scipy.special import factorial as fac, gammaln as lg
-
+from scipy.special import factorial as fac
+from scipy.special import gammaln as lg
 
 PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 MAG = np.linspace(0.0, 0.2, 5, endpoint=False)

--- a/tests/backend/test_squeeze_operation.py
+++ b/tests/backend/test_squeeze_operation.py
@@ -18,6 +18,7 @@ U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
 where \hat{a} is the photon annihilation operator.
 """
 import numpy as np
+
 # pylint: disable=too-many-arguments
 import pytest
 from scipy.special import factorial as fac

--- a/tests/backend/test_squeezed_state_preparation.py
+++ b/tests/backend/test_squeezed_state_preparation.py
@@ -17,11 +17,9 @@ Convention: The squeezing unitary is fixed to be
 U(z) = \exp(0.5 (z^* \hat{a}^2 - z (\hat{a^\dagger}^2)))
 where \hat{a} is the photon annihilation operator."""
 
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial
-
 
 SQZ_R = np.linspace(0.0, 0.1, 5)
 SQZ_THETA = np.linspace(0, 2 * np.pi, 3, endpoint=False)

--- a/tests/backend/test_state_preparations.py
+++ b/tests/backend/test_state_preparations.py
@@ -14,10 +14,8 @@
 
 r"""Unit tests for various state preparation operations"""
 
-import pytest
-
 import numpy as np
-
+import pytest
 
 MAG_ALPHAS = np.linspace(0, 0.8, 4)
 PHASE_ALPHAS = np.linspace(0, 2 * np.pi, 7, endpoint=False)

--- a/tests/backend/test_states.py
+++ b/tests/backend/test_states.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the states.py submodule"""
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial as fac
 
-from strawberryfields import backends
-from strawberryfields import utils
-
+from strawberryfields import backends, utils
 
 a = 0.3 + 0.1j
 r = 0.23

--- a/tests/backend/test_states_polyquad.py
+++ b/tests/backend/test_states_polyquad.py
@@ -11,19 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Unit tests for the poly_quad_expectations method in the states.py submodule"""
-import pytest
-
+r"""Unit tests for the poly_quad_expectations method in the states.py submodule."""
 import numpy as np
+import pytest
 from scipy.stats import multivariate_normal
-from scipy.integrate import simps
-from scipy.linalg import block_diag
 
+try:
+    simps = scipy.integrate.simpson
+except AttribueError:  # scipy<1.0.0
+    simps = scipy.integrate.simps
+from scipy.linalg import block_diag
 from thewalrus.symplectic import rotation as R
 from thewalrus.symplectic import xpxp_to_xxpp
 
-from strawberryfields import backends
-from strawberryfields import utils
+from strawberryfields import backends, utils
 
 # some tests require a higher cutoff for accuracy
 CUTOFF = 12
@@ -36,11 +37,11 @@ qphi = 0.78
 
 @pytest.mark.backends("fock", "gaussian")
 class TestSingleModePolyQuadratureExpectations:
-    """Test single mode poly_quad_expectation methods"""
+    """Test single mode poly_quad_expectation methods."""
 
     @pytest.fixture
     def gaussian_state(self, hbar):
-        """A test Gaussian state to use in testing"""
+        """A test Gaussian state to use in testing."""
         # quadrature rotation
 
         # construct the expected vector of means and covariance matrix
@@ -51,8 +52,8 @@ class TestSingleModePolyQuadratureExpectations:
 
     @pytest.fixture
     def sample_normal_expectations(self, gaussian_state):
-        """Returns the expectation value E(f) and the variance var(f)
-        for some normal distribution X~N(mu, cov).
+        """Returns the expectation value E(f) and the variance var(f) for some normal
+        distribution X~N(mu, cov).
 
         Args:
             mu (array): means vector
@@ -65,7 +66,7 @@ class TestSingleModePolyQuadratureExpectations:
         """
 
         def _sample(func, correction=0, mu=None, cov=None):
-            """wrapped function"""
+            """Wrapped function."""
             if mu is None:
                 mu = gaussian_state[0]
 
@@ -219,11 +220,13 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(mean, mean_expected, atol=tol, rtol=0)
 
         # var(ax+bp) = a**2 var(x)+b**2 var(p)+2ab cov(x,p)
-        var_expected = cov[0, 0] * d[0] ** 2 + cov[1, 1] * d[3] ** 2 + 2 * d[0] * d[3] * cov[0, 1]
+        var_expected = (
+            cov[0, 0] * d[0] ** 2 + cov[1, 1] * d[3] ** 2 + 2 * d[0] * d[3] * cov[0, 1]
+        )
         assert np.allclose(var, var_expected, atol=tol, rtol=0)
 
     def test_n_thermal(self, setup_backend, tol, hbar, pure):
-        """Test expectation and variance of the number operator on a thermal state"""
+        """Test expectation and variance of the number operator on a thermal state."""
         backend = setup_backend(3)
         backend.reset(cutoff_dim=CUTOFF, pure=pure)
 
@@ -243,7 +246,7 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(var, nbar * (nbar + 1), atol=tol, rtol=0)
 
     def test_n_squeeze(self, setup_backend, tol, hbar, pure):
-        """Test expectation and variance of the number operator on a squeezed state"""
+        """Test expectation and variance of the number operator on a squeezed state."""
         backend = setup_backend(3)
         backend.reset(cutoff_dim=CUTOFF, pure=pure)
 
@@ -307,7 +310,7 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(var, var_ex, atol=tol, rtol=0)
 
     def test_xp_vacuum(self, setup_backend, tol, sample_normal_expectations, hbar):
-        """Test that the correct result is returned for E(xp) on the vacuum state"""
+        """Test that the correct result is returned for E(xp) on the vacuum state."""
         backend = setup_backend(3)
 
         # set quadratic coefficient
@@ -333,7 +336,8 @@ class TestSingleModePolyQuadratureExpectations:
     def test_xp_displaced_squeezed(
         self, setup_backend, tol, pure, sample_normal_expectations, hbar
     ):
-        """Test that the correct result is returned for E(xp) on a displaced squeezed state"""
+        """Test that the correct result is returned for E(xp) on a displaced squeezed
+        state."""
         backend = setup_backend(3)
         backend.reset(cutoff_dim=CUTOFF, pure=pure)
 
@@ -356,8 +360,11 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(mean, mean_ex, atol=tol, rtol=0)
         assert np.allclose(var, var_ex, atol=tol, rtol=0)
 
-    def test_arbitrary_quadratic(self, setup_backend, tol, pure, sample_normal_expectations, hbar):
-        """Test that the correct result is returned for E(c0 x^2 + c1 p^2 + c2 xp + c3 x + c4 p + k) on a displaced squeezed state"""
+    def test_arbitrary_quadratic(
+        self, setup_backend, tol, pure, sample_normal_expectations, hbar
+    ):
+        """Test that the correct result is returned for E(c0 x^2 + c1 p^2 + c2 xp + c3 x
+        + c4 p + k) on a displaced squeezed state."""
         backend = setup_backend(3)
         backend.reset(cutoff_dim=CUTOFF, pure=pure)
 
@@ -396,10 +403,11 @@ class TestSingleModePolyQuadratureExpectations:
 
 @pytest.mark.backends("fock", "gaussian")
 class TestMultiModePolyQuadratureExpectations:
-    """Test multi mode poly_quad_expectation methods"""
+    """Test multi mode poly_quad_expectation methods."""
 
     def test_three_mode_arbitrary(self, setup_backend, pure, hbar, tol):
-        """Test that the correct result is returned for an arbitrary quadratic polynomial"""
+        """Test that the correct result is returned for an arbitrary quadratic
+        polynomial."""
         backend = setup_backend(3)
         # increase the cutoff to 7 for accuracy
         backend.reset(cutoff_dim=7, pure=pure)
@@ -413,7 +421,9 @@ class TestMultiModePolyQuadratureExpectations:
                       [ 0.7020327 ,  0.20772833,  0.51704656,  0.77103581,  0.2383589 ,-0.96494418]])
 
         # fmt:on
-        d = np.array([0.71785224, -0.80064627, 0.08799823, 0.76189805, 0.99665321, -0.60777437])
+        d = np.array(
+            [0.71785224, -0.80064627, 0.08799823, 0.76189805, 0.99665321, -0.60777437]
+        )
         k = 0.123
 
         a_list = [0.044 + 0.023j, 0.0432 + 0.123j, -0.12 + 0.04j]
@@ -425,8 +435,12 @@ class TestMultiModePolyQuadratureExpectations:
 
         # squeeze and displace each mode
         for i, (a_, r_, phi_) in enumerate(zip(a_list, r_list, phi_list)):
-            backend.prepare_displaced_squeezed_state(np.abs(a_), np.angle(a_), r_, phi_, i)
-            mu[2 * i : 2 * i + 2] = R(qphi).T @ np.array([a_.real, a_.imag]) * np.sqrt(2 * hbar)
+            backend.prepare_displaced_squeezed_state(
+                np.abs(a_), np.angle(a_), r_, phi_, i
+            )
+            mu[2 * i : 2 * i + 2] = (
+                R(qphi).T @ np.array([a_.real, a_.imag]) * np.sqrt(2 * hbar)
+            )
             cov[2 * i : 2 * i + 2, 2 * i : 2 * i + 2] = (
                 R(qphi).T @ utils.squeezed_cov(r_, phi_, hbar=hbar) @ R(qphi)
             )

--- a/tests/backend/test_states_polyquad.py
+++ b/tests/backend/test_states_polyquad.py
@@ -18,7 +18,7 @@ from scipy.stats import multivariate_normal
 
 try:
     simps = scipy.integrate.simpson
-except AttribueError:  # scipy<1.0.0
+except AttributeError:  # scipy<1.0.0
     simps = scipy.integrate.simps
 from scipy.linalg import block_diag
 from thewalrus.symplectic import rotation as R

--- a/tests/backend/test_states_polyquad.py
+++ b/tests/backend/test_states_polyquad.py
@@ -220,9 +220,7 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(mean, mean_expected, atol=tol, rtol=0)
 
         # var(ax+bp) = a**2 var(x)+b**2 var(p)+2ab cov(x,p)
-        var_expected = (
-            cov[0, 0] * d[0] ** 2 + cov[1, 1] * d[3] ** 2 + 2 * d[0] * d[3] * cov[0, 1]
-        )
+        var_expected = cov[0, 0] * d[0] ** 2 + cov[1, 1] * d[3] ** 2 + 2 * d[0] * d[3] * cov[0, 1]
         assert np.allclose(var, var_expected, atol=tol, rtol=0)
 
     def test_n_thermal(self, setup_backend, tol, hbar, pure):
@@ -360,9 +358,7 @@ class TestSingleModePolyQuadratureExpectations:
         assert np.allclose(mean, mean_ex, atol=tol, rtol=0)
         assert np.allclose(var, var_ex, atol=tol, rtol=0)
 
-    def test_arbitrary_quadratic(
-        self, setup_backend, tol, pure, sample_normal_expectations, hbar
-    ):
+    def test_arbitrary_quadratic(self, setup_backend, tol, pure, sample_normal_expectations, hbar):
         """Test that the correct result is returned for E(c0 x^2 + c1 p^2 + c2 xp + c3 x
         + c4 p + k) on a displaced squeezed state."""
         backend = setup_backend(3)
@@ -421,9 +417,7 @@ class TestMultiModePolyQuadratureExpectations:
                       [ 0.7020327 ,  0.20772833,  0.51704656,  0.77103581,  0.2383589 ,-0.96494418]])
 
         # fmt:on
-        d = np.array(
-            [0.71785224, -0.80064627, 0.08799823, 0.76189805, 0.99665321, -0.60777437]
-        )
+        d = np.array([0.71785224, -0.80064627, 0.08799823, 0.76189805, 0.99665321, -0.60777437])
         k = 0.123
 
         a_list = [0.044 + 0.023j, 0.0432 + 0.123j, -0.12 + 0.04j]
@@ -435,12 +429,8 @@ class TestMultiModePolyQuadratureExpectations:
 
         # squeeze and displace each mode
         for i, (a_, r_, phi_) in enumerate(zip(a_list, r_list, phi_list)):
-            backend.prepare_displaced_squeezed_state(
-                np.abs(a_), np.angle(a_), r_, phi_, i
-            )
-            mu[2 * i : 2 * i + 2] = (
-                R(qphi).T @ np.array([a_.real, a_.imag]) * np.sqrt(2 * hbar)
-            )
+            backend.prepare_displaced_squeezed_state(np.abs(a_), np.angle(a_), r_, phi_, i)
+            mu[2 * i : 2 * i + 2] = R(qphi).T @ np.array([a_.real, a_.imag]) * np.sqrt(2 * hbar)
             cov[2 * i : 2 * i + 2, 2 * i : 2 * i + 2] = (
                 R(qphi).T @ utils.squeezed_cov(r_, phi_, hbar=hbar) @ R(qphi)
             )

--- a/tests/backend/test_states_probabilities.py
+++ b/tests/backend/test_states_probabilities.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the states.py fock probabilities methods"""
-import pytest
-
 import numpy as np
+import pytest
 from scipy.special import factorial as fac
 
 try:

--- a/tests/backend/test_states_wigner.py
+++ b/tests/backend/test_states_wigner.py
@@ -11,17 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Unit tests for the states.py Wigner method"""
-import pytest
-
+r"""Unit tests for the states.py Wigner method."""
 import numpy as np
+import pytest
 from scipy.stats import multivariate_normal
-
 from thewalrus.symplectic import rotation as rotm
 
-from strawberryfields import backends
-from strawberryfields import utils
-
+from strawberryfields import backends, utils
 
 A = 0.3 + 0.1j
 R = 0.23
@@ -41,20 +37,19 @@ GRID[:, :, 1] = P
 
 @pytest.fixture(autouse=True)
 def skip_if_batched(batch_size):
-    """Skip this test if in batch mode"""
+    """Skip this test if in batch mode."""
     if batch_size is not None:
         pytest.skip("Wigner tests skipped in batch mode")
 
 
 def wigner(GRID, mu, cov):
-    """Generate the PDF distribution of a normal distribution"""
+    """Generate the PDF distribution of a normal distribution."""
     mvn = multivariate_normal(mu, cov, allow_singular=True)
     return mvn.pdf(GRID)
 
 
 def test_vacuum(setup_backend, hbar, tol):
-    """Test Wigner function for a Vacuum state is a standard
-    normal Gaussian"""
+    """Test Wigner function for a Vacuum state is a standard normal Gaussian."""
     backend = setup_backend(1)
     state = backend.state()
     W = state.wigner(0, XVEC, XVEC)
@@ -68,8 +63,8 @@ def test_vacuum(setup_backend, hbar, tol):
 
 
 def test_vacuum_one_point(setup_backend, hbar, tol):
-    """Test Wigner function for a Vacuum state is a standard
-    normal Gaussian at a single point"""
+    """Test Wigner function for a Vacuum state is a standard normal Gaussian at a single
+    point."""
     backend = setup_backend(1)
     state = backend.state()
     vec = np.array([0])
@@ -89,8 +84,8 @@ def test_vacuum_one_point(setup_backend, hbar, tol):
 
 
 def test_squeezed_coherent(setup_backend, hbar, tol):
-    """Test Wigner function for a squeezed coherent state
-    matches the analytic result"""
+    """Test Wigner function for a squeezed coherent state matches the analytic
+    result."""
     backend = setup_backend(1)
     backend.prepare_coherent_state(np.abs(A), np.angle(A), 0)
     backend.squeeze(R, PHI, 0)
@@ -110,8 +105,8 @@ def test_squeezed_coherent(setup_backend, hbar, tol):
 
 
 def test_two_mode_squeezed(setup_backend, hbar, tol):
-    """Test Wigner function for a two mode squeezed state
-    matches the analytic result"""
+    """Test Wigner function for a two mode squeezed state matches the analytic
+    result."""
     backend = setup_backend(2)
     backend.prepare_squeezed_state(R, 0, 0)
     backend.prepare_squeezed_state(-R, 0, 1)
@@ -133,8 +128,7 @@ def test_two_mode_squeezed(setup_backend, hbar, tol):
 
 
 def fock_1_state_quad(setup_backend, hbar, tol):
-    """Test the quadrature probability distribution
-    functions for the |1> Fock state"""
+    """Test the quadrature probability distribution functions for the |1> Fock state."""
     backend = setup_backend(1)
     backend.prepare_fock_state(1, 0)
 
@@ -145,9 +139,7 @@ def fock_1_state_quad(setup_backend, hbar, tol):
 
     # Exact probability distribution
     def exact(a):
-        return (
-            0.5 * np.sqrt(1 / (np.pi * hbar)) * np.exp(-1 * (a**2) / hbar) * (4 / hbar) * (a**2)
-        )
+        return 0.5 * np.sqrt(1 / (np.pi * hbar)) * np.exp(-1 * (a**2) / hbar) * (4 / hbar) * (a**2)
 
     exact_x = np.array([exact(x) for x in XVEC])
     exact_p = np.array([exact(p) for p in XVEC])
@@ -157,8 +149,7 @@ def fock_1_state_quad(setup_backend, hbar, tol):
 
 
 def vacuum_state_quad(setup_backend, hbar, tol):
-    """Test the quadrature probability distribution
-    functions for the vacuum state"""
+    """Test the quadrature probability distribution functions for the vacuum state."""
     backend = setup_backend(1)
     backend.prepare_vacuum_state(0)
 
@@ -179,8 +170,8 @@ def vacuum_state_quad(setup_backend, hbar, tol):
 
 
 def coherent_state_quad(setup_backend, hbar, tol):
-    """Test the quadrature probability distribution
-    functions for the coherent state with alpha = 1"""
+    """Test the quadrature probability distribution functions for the coherent state
+    with alpha = 1."""
     backend = setup_backend(1)
     backend.prepare_coherent_state(1, 0)
 

--- a/tests/backend/test_tf_ops.py
+++ b/tests/backend/test_tf_ops.py
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Tests for the file tfbackend/ops.py"""
-
-import pytest
+r"""Tests for the file tfbackend/ops.py."""
 
 import numpy as np
+import pytest
 
 tf = pytest.importorskip("tensorflow", minversion="2.0")
 
@@ -24,12 +23,12 @@ from strawberryfields.backends.tfbackend.ops import reduced_density_matrix
 
 @pytest.mark.backends("tf")
 class TestTFOps:
-    """Testing for tfbackend/ops.py"""
+    """Testing for tfbackend/ops.py."""
 
     @pytest.mark.parametrize("num_modes", [2, 3, 4])
     def test_reduced_density_matrix_fock_states(self, num_modes, setup_backend, cutoff, tol):
         """Test the reduced_density_matrix returns the correct reduced density matrices
-        when prepared with initial fock states"""
+        when prepared with initial fock states."""
 
         zero_photon_state = np.zeros([cutoff])
         zero_photon_state[0] = 1.0
@@ -67,7 +66,8 @@ class TestTFOps:
         ],
     )
     def test_reduced_density_matrix_multiple_modes(self, setup_backend, cutoff, modes, einstr, tol):
-        """Test that reduced_density_matrix returns the correct reduced density matrices."""
+        """Test that reduced_density_matrix returns the correct reduced density
+        matrices."""
         state = np.zeros([cutoff, cutoff, cutoff])
         state[0, 0, 0] = 1 / np.sqrt(2)
         state[1, 1, 1] = 1 / np.sqrt(2)

--- a/tests/backend/test_threshold_measurement.py
+++ b/tests/backend/test_threshold_measurement.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 r"""Unit tests for measurements in the Fock basis"""
-import pytest
-
 import numpy as np
-
+import pytest
 
 NUM_REPEATS = 50
 

--- a/tests/backend/test_twomode_squeezing_operation.py
+++ b/tests/backend/test_twomode_squeezing_operation.py
@@ -20,9 +20,8 @@ where \hat{a} is the photon annihilation operator.
 # pylint: disable=too-many-arguments
 import itertools as it
 
-import pytest
 import numpy as np
-
+import pytest
 
 PHASE = np.linspace(0, 2 * np.pi, 3, endpoint=False)
 MAG = np.linspace(0.0, 0.2, 5, endpoint=False)

--- a/tests/bosonic_files/test_backend_bosoniccircuit.py
+++ b/tests/bosonic_files/test_backend_bosoniccircuit.py
@@ -17,8 +17,9 @@ Unit tests for backends.bosonicbackend.bosoniccircuit.py.
 """
 
 import numpy as np
-import strawberryfields.backends.bosonicbackend.bosoniccircuit as circuit
 import pytest
+
+import strawberryfields.backends.bosonicbackend.bosoniccircuit as circuit
 
 pytestmark = pytest.mark.bosonic
 

--- a/tests/bosonic_files/test_backend_ops.py
+++ b/tests/bosonic_files/test_backend_ops.py
@@ -16,9 +16,9 @@ r"""
 Unit tests for backends.bosonicbackend.ops.py .
 """
 
+import numpy as np
 import pytest
 
-import numpy as np
 import strawberryfields.backends.bosonicbackend.ops as ops
 
 pytestmark = pytest.mark.bosonic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,17 +16,17 @@ Default parameters, environment variables, fixtures, and common routines for the
 """
 # pylint: disable=redefined-outer-name
 import os
-import pytest
 
 import numpy as np
+import pytest
 
 import strawberryfields as sf
-from strawberryfields.engine import LocalEngine
-from strawberryfields.program import Program
 from strawberryfields.backends.base import BaseBackend
+from strawberryfields.backends.bosonicbackend import BosonicBackend
 from strawberryfields.backends.fockbackend import FockBackend
 from strawberryfields.backends.gaussianbackend import GaussianBackend
-from strawberryfields.backends.bosonicbackend import BosonicBackend
+from strawberryfields.engine import LocalEngine
+from strawberryfields.program import Program
 
 try:
     import tensorflow as tf

--- a/tests/frontend/compilers/conftest.py
+++ b/tests/frontend/compilers/conftest.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import inspect
 
-import numpy as np
 import networkx as nx
+import numpy as np
 
 from strawberryfields.device import Device
 from strawberryfields.parameters import par_evaluate

--- a/tests/frontend/compilers/test_compiler.py
+++ b/tests/frontend/compilers/test_compiler.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the CircuitSpec class"""
+import inspect
+
 import pytest
 import sympy
-import inspect
 
 from strawberryfields.compilers.compiler import Compiler
 from strawberryfields.program_utils import CircuitError
-
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_gaussianmerge.py
+++ b/tests/frontend/compilers/test_gaussianmerge.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 r"""Unit tests for the GaussianMerge class"""
 
-import pytest
 import numpy as np
+import pytest
 
 import strawberryfields as sf
 import strawberryfields.ops as ops

--- a/tests/frontend/compilers/test_gaussianunitary.py
+++ b/tests/frontend/compilers/test_gaussianunitary.py
@@ -20,7 +20,9 @@ from thewalrus.symplectic import expand, interferometer
 import strawberryfields as sf
 import strawberryfields.ops as ops
 from strawberryfields.compilers.gaussian_unitary import (
-    _apply_symp_one_mode_gate, _apply_symp_two_mode_gate)
+    _apply_symp_one_mode_gate,
+    _apply_symp_two_mode_gate,
+)
 from strawberryfields.utils import random_symplectic
 
 pytestmark = pytest.mark.frontend

--- a/tests/frontend/compilers/test_gaussianunitary.py
+++ b/tests/frontend/compilers/test_gaussianunitary.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 r"""Unit tests for the GaussianUnitary class"""
 
-import pytest
 import numpy as np
+import pytest
+from thewalrus.symplectic import expand, interferometer
 
 import strawberryfields as sf
 import strawberryfields.ops as ops
-from strawberryfields.utils import random_symplectic
 from strawberryfields.compilers.gaussian_unitary import (
-    _apply_symp_one_mode_gate,
-    _apply_symp_two_mode_gate,
-)
-from thewalrus.symplectic import expand, interferometer
+    _apply_symp_one_mode_gate, _apply_symp_two_mode_gate)
+from strawberryfields.utils import random_symplectic
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_passive.py
+++ b/tests/frontend/compilers/test_passive.py
@@ -20,9 +20,11 @@ from thewalrus.symplectic import interferometer
 
 import strawberryfields as sf
 import strawberryfields.ops as ops
-from strawberryfields.compilers.passive import (_apply_one_mode_gate,
-                                                _apply_two_mode_gate,
-                                                _beam_splitter_passive)
+from strawberryfields.compilers.passive import (
+    _apply_one_mode_gate,
+    _apply_two_mode_gate,
+    _beam_splitter_passive,
+)
 from strawberryfields.utils import random_symplectic
 
 pytestmark = pytest.mark.frontend

--- a/tests/frontend/compilers/test_passive.py
+++ b/tests/frontend/compilers/test_passive.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 r"""Unit tests for the GaussianUnitary class"""
 
-import pytest
 import numpy as np
+import pytest
+from scipy.stats import unitary_group
+from thewalrus.symplectic import interferometer
 
 import strawberryfields as sf
 import strawberryfields.ops as ops
+from strawberryfields.compilers.passive import (_apply_one_mode_gate,
+                                                _apply_two_mode_gate,
+                                                _beam_splitter_passive)
 from strawberryfields.utils import random_symplectic
-from strawberryfields.compilers.passive import (
-    _apply_one_mode_gate,
-    _apply_two_mode_gate,
-    _beam_splitter_passive,
-)
-
-from scipy.stats import unitary_group
-
-from thewalrus.symplectic import interferometer
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_tdm.py
+++ b/tests/frontend/compilers/test_tdm.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the Xcov compiler"""
+import copy
 import inspect
 import logging
-import pytest
-import copy
 
 import numpy as np
+import pytest
+from conftest import borealis_device
 
 import strawberryfields as sf
-from strawberryfields.compilers import compiler_db
 from strawberryfields import Device, TDMProgram, ops
+from strawberryfields.compilers import compiler_db
 from strawberryfields.program_utils import CircuitError
-from strawberryfields.tdm.utils import borealis_gbs, get_mode_indices, random_bs, random_r
-
-from conftest import borealis_device
+from strawberryfields.tdm.utils import (borealis_gbs, get_mode_indices,
+                                        random_bs, random_r)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_tdm.py
+++ b/tests/frontend/compilers/test_tdm.py
@@ -24,8 +24,7 @@ import strawberryfields as sf
 from strawberryfields import Device, TDMProgram, ops
 from strawberryfields.compilers import compiler_db
 from strawberryfields.program_utils import CircuitError
-from strawberryfields.tdm.utils import (borealis_gbs, get_mode_indices,
-                                        random_bs, random_r)
+from strawberryfields.tdm.utils import borealis_gbs, get_mode_indices, random_bs, random_r
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_xcov.py
+++ b/tests/frontend/compilers/test_xcov.py
@@ -11,23 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Unit tests for the Xcov compiler"""
+r"""Unit tests for the Xcov compiler."""
 import textwrap
 
-import pytest
-import numpy as np
-
 import blackbird
+import numpy as np
+import pytest
+from thewalrus.symplectic import expand, two_mode_squeezing
 
 import strawberryfields as sf
 import strawberryfields.ops as ops
-
-from strawberryfields.program_utils import CircuitError, program_equivalence
-from strawberryfields.io import to_program
-from strawberryfields.utils import random_interferometer
 from strawberryfields.compilers import Compiler
-
-from thewalrus.symplectic import two_mode_squeezing, expand
+from strawberryfields.io import to_program
+from strawberryfields.program_utils import CircuitError, program_equivalence
+from strawberryfields.utils import random_interferometer
 
 pytestmark = pytest.mark.frontend
 
@@ -37,8 +34,7 @@ SQ_AMPLITUDE = 1
 
 
 class DummyCircuit(Compiler):
-    """Dummy circuit used to instantiate
-    the abstract base class"""
+    """Dummy circuit used to instantiate the abstract base class."""
 
     modes = 8
     remote = False
@@ -91,10 +87,10 @@ X8_CIRCUIT = textwrap.dedent(
 
 
 class TestXCompilation:
-    """Tests for compilation using the X8_01 circuit specification"""
+    """Tests for compilation using the X8_01 circuit specification."""
 
     def test_exact_template(self, tol):
-        """Test compilation works for the exact circuit"""
+        """Test compilation works for the exact circuit."""
         bb = blackbird.loads(X8_CIRCUIT)
         bb = bb(
             squeezing_amplitude_0=SQ_AMPLITUDE,
@@ -130,7 +126,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_not_all_modes_measured(self, num_pairs):
-        """Test exceptions raised if not all modes are measured"""
+        """Test exceptions raised if not all modes are measured."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         with prog.context as q:
@@ -144,8 +140,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_no_s2gates(self, num_pairs, tol):
-        """Test identity S2gates are inserted when no S2gates
-        are provided."""
+        """Test identity S2gates are inserted when no S2gates are provided."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -169,8 +164,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_missing_s2gates(self, num_pairs, tol):
-        """Test identity S2gates are inserted when some (but not all)
-        S2gates are included."""
+        """Test identity S2gates are inserted when some (but not all) S2gates are
+        included."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         assert num_pairs > 3
@@ -198,7 +193,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_incorrect_s2gate_modes(self, num_pairs):
-        """Test exceptions raised if S2gates do not appear on correct modes"""
+        """Test exceptions raised if S2gates do not appear on correct modes."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         n_modes = 2 * num_pairs
@@ -220,7 +215,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_s2gate_repeated_modes_half_squeezing(self, num_pairs):
-        """Test that squeezing gates are correctly merged"""
+        """Test that squeezing gates are correctly merged."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -238,8 +233,7 @@ class TestXCompilation:
         assert np.allclose(res.circuit[0].op.p[0], SQ_AMPLITUDE)
 
     def test_gates_compile(self):
-        """Test that combinations of MZgates, Rgates, and BSgates
-        correctly compile."""
+        """Test that combinations of MZgates, Rgates, and BSgates correctly compile."""
         prog = sf.Program(8)
 
         def unitary(q):
@@ -260,7 +254,7 @@ class TestXCompilation:
         prog.compile(compiler="Xcov")
 
     def test_no_unitary(self, tol):
-        """Test compilation works with no unitary provided"""
+        """Test compilation works with no unitary provided."""
         prog = sf.Program(8)
 
         with prog.context as q:
@@ -332,8 +326,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4])
     def test_interferometers(self, num_pairs, tol):
-        """Test that the compilation correctly decomposes the interferometer using
-        the rectangular_symmetric mesh"""
+        """Test that the compilation correctly decomposes the interferometer using the
+        rectangular_symmetric mesh."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -383,8 +377,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_unitary_too_large(self, num_pairs):
-        """Test exception raised if the unitary is applied to more
-        than just modes [0, 1, 2, 3, ..., num_pairs-1] and [num_pairs, num_pairs+1, ..., 2*num_pairs-1]."""
+        """Test exception raised if the unitary is applied to more than just modes [0,
+        1, 2, 3, ..., num_pairs-1] and [num_pairs, num_pairs+1, ..., 2*num_pairs-1]."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(2 * num_pairs)
 
@@ -398,7 +392,7 @@ class TestXCompilation:
             res = prog.compile(compiler="Xcov")
 
     def test_error_odd_number_modes(self):
-        """Test that an error is raised if the number of modes provided is odd"""
+        """Test that an error is raised if the number of modes provided is odd."""
         prog = sf.Program(5)
 
         with pytest.raises(
@@ -407,8 +401,8 @@ class TestXCompilation:
             res = prog.compile(compiler="Xcov")
 
     def test_symplectic_smaller_than_program(self):
-        """Test that compilation correctly works if the provided gates act only
-        on a subset of program modes"""
+        """Test that compilation correctly works if the provided gates act only on a
+        subset of program modes."""
         prog = sf.Program(4)
 
         with prog.context as q:
@@ -426,7 +420,8 @@ class TestXCompilation:
         assert c.op.p[0].shape == (8, 8)
 
     def test_identity_program(self, tol):
-        """Test that compilation correctly works if the gate consists only of measurements"""
+        """Test that compilation correctly works if the gate consists only of
+        measurements."""
         prog = sf.Program(4)
 
         with prog.context as q:
@@ -442,7 +437,7 @@ class TestXCompilation:
         assert not res.circuit
 
     def test_nothing_happens_and_nothing_crashes(self):
-        """Test that even a program that does nothing compiles correctly"""
+        """Test that even a program that does nothing compiles correctly."""
         n_modes = 4
         squeezing_amplitudes = [0] * n_modes
         unitary = np.identity(n_modes)

--- a/tests/frontend/compilers/test_xstrict.py
+++ b/tests/frontend/compilers/test_xstrict.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 r"""Unit tests for the Xstrict compiler"""
 import pytest
+from conftest import X8_device, generate_X8_params
 
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.program_utils import program_equivalence
-
-from conftest import X8_device, generate_X8_params
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/compilers/test_xunitary.py
+++ b/tests/frontend/compilers/test_xunitary.py
@@ -11,24 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Unit tests for the Xunitary compiler"""
+r"""Unit tests for the Xunitary compiler."""
 import textwrap
 
-import pytest
-import numpy as np
-import networkx as nx
-
 import blackbird
+import networkx as nx
+import numpy as np
+import pytest
+from thewalrus.symplectic import expand, two_mode_squeezing
 
 import strawberryfields as sf
 import strawberryfields.ops as ops
-
-from strawberryfields.program_utils import CircuitError, program_equivalence
-from strawberryfields.io import to_program
-from strawberryfields.utils import random_interferometer
 from strawberryfields.compilers import Compiler
-
-from thewalrus.symplectic import two_mode_squeezing, expand
+from strawberryfields.io import to_program
+from strawberryfields.program_utils import CircuitError, program_equivalence
+from strawberryfields.utils import random_interferometer
 
 pytestmark = pytest.mark.frontend
 
@@ -38,8 +35,7 @@ SQ_AMPLITUDE = 1
 
 
 class DummyCircuit(Compiler):
-    """Dummy circuit used to instantiate
-    the abstract base class"""
+    """Dummy circuit used to instantiate the abstract base class."""
 
     modes = 8
     remote = False
@@ -92,10 +88,10 @@ X8_CIRCUIT = textwrap.dedent(
 
 
 class TestXCompilation:
-    """Tests for compilation using the X8_01 circuit specification"""
+    """Tests for compilation using the X8_01 circuit specification."""
 
     def test_exact_template(self, tol):
-        """Test compilation works for the exact circuit"""
+        """Test compilation works for the exact circuit."""
         bb = blackbird.loads(X8_CIRCUIT)
         bb = bb(
             squeezing_amplitude_0=SQ_AMPLITUDE,
@@ -130,7 +126,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_not_all_modes_measured(self, num_pairs):
-        """Test exceptions raised if not all modes are measured"""
+        """Test exceptions raised if not all modes are measured."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         with prog.context as q:
@@ -144,8 +140,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_no_s2gates(self, num_pairs, tol):
-        """Test identity S2gates are inserted when no S2gates
-        are provided."""
+        """Test identity S2gates are inserted when no S2gates are provided."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -171,8 +166,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_missing_s2gates(self, num_pairs, tol):
-        """Test identity S2gates are inserted when some (but not all)
-        S2gates are included."""
+        """Test identity S2gates are inserted when some (but not all) S2gates are
+        included."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         assert num_pairs > 3
@@ -200,7 +195,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_incorrect_s2gate_modes(self, num_pairs):
-        """Test exceptions raised if S2gates do not appear on correct modes"""
+        """Test exceptions raised if S2gates do not appear on correct modes."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
         n_modes = 2 * num_pairs
@@ -217,7 +212,7 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_s2gate_repeated_modes_half_squeezing(self, num_pairs):
-        """Test that squeezing gates are correctly merged"""
+        """Test that squeezing gates are correctly merged."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -237,7 +232,7 @@ class TestXCompilation:
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_s2gate_repeated_modes_wrong_phase(self, num_pairs):
         """Test that an error is raised if there is an attempt to merge squeezing gates
-        with different phase values"""
+        with different phase values."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -255,8 +250,7 @@ class TestXCompilation:
             prog.compile(compiler="Xunitary")
 
     def test_gates_compile(self):
-        """Test that combinations of MZgates, Rgates, and BSgates
-        correctly compile."""
+        """Test that combinations of MZgates, Rgates, and BSgates correctly compile."""
         prog = sf.Program(8)
 
         def unitary(q):
@@ -277,7 +271,7 @@ class TestXCompilation:
         prog.compile(compiler="Xunitary")
 
     def test_no_unitary(self, tol):
-        """Test compilation works with no unitary provided"""
+        """Test compilation works with no unitary provided."""
         prog = sf.Program(8)
 
         with prog.context as q:
@@ -349,8 +343,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4])
     def test_interferometers(self, num_pairs, tol):
-        """Test that the compilation correctly decomposes the interferometer using
-        the rectangular_symmetric mesh"""
+        """Test that the compilation correctly decomposes the interferometer using the
+        rectangular_symmetric mesh."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(num_pairs)
 
@@ -400,8 +394,8 @@ class TestXCompilation:
 
     @pytest.mark.parametrize("num_pairs", [4, 5, 6, 7])
     def test_unitary_too_large(self, num_pairs):
-        """Test exception raised if the unitary is applied to more
-        than just modes [0, 1, 2, 3, ..., num_pairs-1] and [num_pairs, num_pairs+1, ..., 2*num_pairs-1]."""
+        """Test exception raised if the unitary is applied to more than just modes [0,
+        1, 2, 3, ..., num_pairs-1] and [num_pairs, num_pairs+1, ..., 2*num_pairs-1]."""
         prog = sf.Program(2 * num_pairs)
         U = random_interferometer(2 * num_pairs)
 
@@ -415,16 +409,17 @@ class TestXCompilation:
             res = prog.compile(compiler="Xunitary")
 
     def test_odd_number_of_modes(self):
-        """Test error is raised when xstrict is called with odd number of modes"""
+        """Test error is raised when xstrict is called with odd number of modes."""
         prog = sf.Program(1)
 
         with pytest.raises(
-            CircuitError, match="The X series only supports programs with an even number of modes."
+            CircuitError,
+            match="The X series only supports programs with an even number of modes.",
         ):
             res = prog.compile(compiler="Xunitary")
 
     def test_operation_before_squeezing(self):
-        """Test error is raised when an operation is passed before the S2gates"""
+        """Test error is raised when an operation is passed before the S2gates."""
         prog = sf.Program(2)
         with prog.context as q:
             ops.BSgate() | (q[0], q[1])
@@ -435,7 +430,8 @@ class TestXCompilation:
             prog.compile(compiler="Xunitary")
 
     def test_identity_program(self, tol):
-        """Test that compilation correctly works if the gate consists only of measurements"""
+        """Test that compilation correctly works if the gate consists only of
+        measurements."""
         prog = sf.Program(4)
 
         with prog.context as q:

--- a/tests/frontend/io/test_io.py
+++ b/tests/frontend/io/test_io.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the IO module"""
-import pytest
 import textwrap
 
-import numpy as np
 import blackbird
+import numpy as np
+import pytest
 
 import strawberryfields as sf
-from strawberryfields import ops
-from strawberryfields import io
+from strawberryfields import io, ops
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/io/test_io_blackbird.py
+++ b/tests/frontend/io/test_io_blackbird.py
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the Blackbird IO module"""
-import pytest
 import textwrap
 
-import numpy as np
 import blackbird
+import numpy as np
+import pytest
 
 import strawberryfields as sf
-from strawberryfields import ops
-from strawberryfields import io
+from strawberryfields import io, ops
+from strawberryfields.parameters import FreeParameter, MeasuredParameter
+from strawberryfields.parameters import par_funcs as pf
+from strawberryfields.parameters import par_is_symbolic
 from strawberryfields.program import Program
 from strawberryfields.tdm import TDMProgram
-from strawberryfields.parameters import (
-    MeasuredParameter,
-    FreeParameter,
-    par_is_symbolic,
-    par_funcs as pf,
-)
-
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/io/test_io_xir.py
+++ b/tests/frontend/io/test_io_xir.py
@@ -12,25 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the XIR IO module"""
-import pytest
 import inspect
 from decimal import Decimal
 
 import numpy as np
+import pytest
 import xir
 
-from strawberryfields.io.xir_io import _listr
-
 import strawberryfields as sf
-from strawberryfields import ops
-from strawberryfields import io
+from strawberryfields import io, ops
+from strawberryfields.io.xir_io import _listr
+from strawberryfields.parameters import FreeParameter
+from strawberryfields.parameters import par_funcs as pf
 from strawberryfields.program import Program
 from strawberryfields.tdm import TDMProgram
-from strawberryfields.parameters import (
-    par_funcs as pf,
-    FreeParameter,
-)
-
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_about.py
+++ b/tests/frontend/test_about.py
@@ -14,10 +14,11 @@
 """
 Unit tests for top-level Strawberry Fields functions.
 """
-import pytest
 import re
-import strawberryfields as sf
 
+import pytest
+
+import strawberryfields as sf
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_circuitdrawer.py
+++ b/tests/frontend/test_circuitdrawer.py
@@ -25,9 +25,11 @@ pytestmark = pytest.mark.frontend
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.circuitdrawer import Circuit as CircuitDrawer
-from strawberryfields.circuitdrawer import (ModeMismatchException,
-                                            NotDrawableException,
-                                            UnsupportedGateException)
+from strawberryfields.circuitdrawer import (
+    ModeMismatchException,
+    NotDrawableException,
+    UnsupportedGateException,
+)
 
 LINE_RETURN = "\n"
 WIRE_TERMINATOR = r"\\" + "\n"

--- a/tests/frontend/test_circuitdrawer.py
+++ b/tests/frontend/test_circuitdrawer.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the circuit drawer"""
-import sys
-import os
 import datetime
 import difflib
+import os
+import sys
 from textwrap import dedent
 
 import pytest
@@ -24,14 +24,10 @@ pytestmark = pytest.mark.frontend
 
 import strawberryfields as sf
 from strawberryfields import ops
-
 from strawberryfields.circuitdrawer import Circuit as CircuitDrawer
-from strawberryfields.circuitdrawer import (
-    UnsupportedGateException,
-    NotDrawableException,
-    ModeMismatchException,
-)
-
+from strawberryfields.circuitdrawer import (ModeMismatchException,
+                                            NotDrawableException,
+                                            UnsupportedGateException)
 
 LINE_RETURN = "\n"
 WIRE_TERMINATOR = r"\\" + "\n"

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -14,14 +14,15 @@
 r"""Unit tests for the Strawberry Fields decompositions module"""
 import pytest
 
-from strawberryfields.utils.random_numbers_matrices import random_interferometer
+from strawberryfields.utils.random_numbers_matrices import \
+    random_interferometer
 
 pytestmark = pytest.mark.frontend
 
 import networkx as nx
 import numpy as np
 import scipy as sp
-from scipy.linalg import qr, block_diag
+from scipy.linalg import block_diag, qr
 
 from strawberryfields import decompositions as dec
 from strawberryfields.utils import random_interferometer as haar_measure

--- a/tests/frontend/test_decompositions.py
+++ b/tests/frontend/test_decompositions.py
@@ -14,8 +14,7 @@
 r"""Unit tests for the Strawberry Fields decompositions module"""
 import pytest
 
-from strawberryfields.utils.random_numbers_matrices import \
-    random_interferometer
+from strawberryfields.utils.random_numbers_matrices import random_interferometer
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_engine.py
+++ b/tests/frontend/test_engine.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for engine.py"""
-import pytest
 import numpy as np
+import pytest
 
 tf = pytest.importorskip("tensorflow", minversion="2.0")
 import strawberryfields as sf

--- a/tests/frontend/test_logger.py
+++ b/tests/frontend/test_logger.py
@@ -45,9 +45,12 @@ https://github.com/pallets/flask/blob/master/tests/test_logging.py
 """
 
 import logging
+
 import pytest
+
 import strawberryfields.engine as engine
-from strawberryfields.logger import logging_handler_defined, default_handler, create_logger
+from strawberryfields.logger import (create_logger, default_handler,
+                                     logging_handler_defined)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_logger.py
+++ b/tests/frontend/test_logger.py
@@ -49,8 +49,7 @@ import logging
 import pytest
 
 import strawberryfields.engine as engine
-from strawberryfields.logger import (create_logger, default_handler,
-                                     logging_handler_defined)
+from strawberryfields.logger import create_logger, default_handler, logging_handler_defined
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_ops_channel.py
+++ b/tests/frontend/test_ops_channel.py
@@ -19,10 +19,8 @@ pytestmark = pytest.mark.frontend
 import numpy as np
 
 import strawberryfields as sf
-
-from strawberryfields import ops
+from strawberryfields import ops, utils
 from strawberryfields.program_utils import MergeFailure
-from strawberryfields import utils
 
 a = np.random.random()
 b = np.random.random()

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -23,8 +23,7 @@ import strawberryfields as sf
 from strawberryfields import decompositions as dec
 from strawberryfields import ops
 from strawberryfields.parameters import FreeParameter, par_evaluate
-from strawberryfields.utils import (random_covariance, random_interferometer,
-                                    random_symplectic)
+from strawberryfields.utils import random_covariance, random_interferometer, random_symplectic
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_ops_decompositions.py
+++ b/tests/frontend/test_ops_decompositions.py
@@ -15,17 +15,16 @@
 # pylint: disable=no-self-use
 
 r"""Unit tests for the Strawberry Fields decompositions within the ops module"""
-import pytest
-
 import numpy as np
+import pytest
 from thewalrus.quantum import Amat
 
 import strawberryfields as sf
-from strawberryfields.parameters import par_evaluate, FreeParameter
 from strawberryfields import decompositions as dec
-from strawberryfields.utils import random_interferometer, random_symplectic, random_covariance
 from strawberryfields import ops
-
+from strawberryfields.parameters import FreeParameter, par_evaluate
+from strawberryfields.utils import (random_covariance, random_interferometer,
+                                    random_symplectic)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_ops_gate.py
+++ b/tests/frontend/test_ops_gate.py
@@ -19,13 +19,10 @@ pytestmark = pytest.mark.frontend
 import numpy as np
 
 import strawberryfields.program_utils as pu
-
-from strawberryfields import Engine
-from strawberryfields import ops
+from strawberryfields import Engine, ops
+from strawberryfields.parameters import par_evaluate
 from strawberryfields.program import Program
 from strawberryfields.program_utils import MergeFailure, RegRefError
-from strawberryfields.parameters import par_evaluate
-
 
 A = np.random.random()
 B = np.random.random()

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -21,8 +21,7 @@ import numpy as np
 import strawberryfields.program_utils as pu
 from strawberryfields import ops, utils
 from strawberryfields.program import Program
-from strawberryfields.program_utils import (CircuitError, MergeFailure,
-                                            RegRefError)
+from strawberryfields.program_utils import CircuitError, MergeFailure, RegRefError
 
 a = np.random.random()
 b = np.random.random()

--- a/tests/frontend/test_ops_metaoperation.py
+++ b/tests/frontend/test_ops_metaoperation.py
@@ -19,11 +19,10 @@ pytestmark = pytest.mark.frontend
 import numpy as np
 
 import strawberryfields.program_utils as pu
-from strawberryfields import ops
+from strawberryfields import ops, utils
 from strawberryfields.program import Program
-from strawberryfields.program_utils import MergeFailure, RegRefError, CircuitError
-from strawberryfields import utils
-
+from strawberryfields.program_utils import (CircuitError, MergeFailure,
+                                            RegRefError)
 
 a = np.random.random()
 b = np.random.random()

--- a/tests/frontend/test_ops_preparation.py
+++ b/tests/frontend/test_ops_preparation.py
@@ -18,10 +18,9 @@ pytestmark = pytest.mark.frontend
 
 import numpy as np
 
-from strawberryfields import ops
+from strawberryfields import ops, utils
 from strawberryfields.program import Program
 from strawberryfields.program_utils import MergeFailure, RegRefError
-from strawberryfields import utils
 
 
 @pytest.mark.parametrize(

--- a/tests/frontend/test_parameters.py
+++ b/tests/frontend/test_parameters.py
@@ -17,11 +17,14 @@ import numpy as np
 import pytest
 
 import strawberryfields as sf
-from strawberryfields.parameters import (FreeParameter, MeasuredParameter,
-                                         ParameterError, par_evaluate)
+from strawberryfields.parameters import (
+    FreeParameter,
+    MeasuredParameter,
+    ParameterError,
+    par_evaluate,
+)
 from strawberryfields.parameters import par_funcs as pf
-from strawberryfields.parameters import (par_is_symbolic, par_regref_deps,
-                                         par_str)
+from strawberryfields.parameters import par_is_symbolic, par_regref_deps, par_str
 from strawberryfields.program_utils import RegRef
 
 pytestmark = pytest.mark.frontend

--- a/tests/frontend/test_parameters.py
+++ b/tests/frontend/test_parameters.py
@@ -13,22 +13,16 @@
 # limitations under the License.
 """Unit tests for the parameters.py module."""
 
-import pytest
 import numpy as np
+import pytest
 
 import strawberryfields as sf
-from strawberryfields.parameters import (
-    par_is_symbolic,
-    par_regref_deps,
-    par_str,
-    par_evaluate,
-    MeasuredParameter,
-    FreeParameter,
-    par_funcs as pf,
-    ParameterError,
-)
+from strawberryfields.parameters import (FreeParameter, MeasuredParameter,
+                                         ParameterError, par_evaluate)
+from strawberryfields.parameters import par_funcs as pf
+from strawberryfields.parameters import (par_is_symbolic, par_regref_deps,
+                                         par_str)
 from strawberryfields.program_utils import RegRef
-
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_post_processing.py
+++ b/tests/frontend/test_post_processing.py
@@ -19,13 +19,11 @@ import pytest
 
 import strawberryfields as sf
 from strawberryfields.ops import *
-from strawberryfields.utils.post_processing import (
-    samples_expectation,
-    samples_variance,
-    all_fock_probs_pnr,
-    _check_modes,
-    _check_samples,
-)
+from strawberryfields.utils.post_processing import (_check_modes,
+                                                    _check_samples,
+                                                    all_fock_probs_pnr,
+                                                    samples_expectation,
+                                                    samples_variance)
 
 # pylint: disable=bad-continuation,no-self-use,pointless-statement
 

--- a/tests/frontend/test_post_processing.py
+++ b/tests/frontend/test_post_processing.py
@@ -19,11 +19,13 @@ import pytest
 
 import strawberryfields as sf
 from strawberryfields.ops import *
-from strawberryfields.utils.post_processing import (_check_modes,
-                                                    _check_samples,
-                                                    all_fock_probs_pnr,
-                                                    samples_expectation,
-                                                    samples_variance)
+from strawberryfields.utils.post_processing import (
+    _check_modes,
+    _check_samples,
+    all_fock_probs_pnr,
+    samples_expectation,
+    samples_variance,
+)
 
 # pylint: disable=bad-continuation,no-self-use,pointless-statement
 

--- a/tests/frontend/test_program.py
+++ b/tests/frontend/test_program.py
@@ -13,22 +13,19 @@
 # limitations under the License.
 r"""Unit tests for program.py"""
 import textwrap
+
 import pytest
 
 pytestmark = pytest.mark.frontend
 
+import blackbird as bb
 import numpy as np
 
 import strawberryfields as sf
-
-from strawberryfields import program
-from strawberryfields import ops
-from strawberryfields.parameters import ParameterError, FreeParameter
+from strawberryfields import ops, program
 from strawberryfields.compilers.compiler import Compiler
+from strawberryfields.parameters import FreeParameter, ParameterError
 from strawberryfields.program_utils import validate_gate_parameters
-
-import blackbird as bb
-
 
 A = np.random.random()
 

--- a/tests/frontend/test_sf_plot.py
+++ b/tests/frontend/test_sf_plot.py
@@ -23,8 +23,12 @@ from scipy.special import factorial as fac
 
 import strawberryfields as sf
 from strawberryfields.ops import BSgate, MeasureFock, Sgate, Vac
-from strawberryfields.plot import (barchart_default, generate_fock_chart,
-                                   generate_quad_chart, plot_wigner)
+from strawberryfields.plot import (
+    barchart_default,
+    generate_fock_chart,
+    generate_quad_chart,
+    plot_wigner,
+)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_sf_plot.py
+++ b/tests/frontend/test_sf_plot.py
@@ -14,20 +14,17 @@
 r"""
 Unit tests for strawberryfields.plot
 """
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
 import plotly.io as pio
 import pytest
 from scipy.special import factorial as fac
 
 import strawberryfields as sf
 from strawberryfields.ops import BSgate, MeasureFock, Sgate, Vac
-from strawberryfields.plot import (
-    plot_wigner,
-    generate_fock_chart,
-    generate_quad_chart,
-    barchart_default,
-)
+from strawberryfields.plot import (barchart_default, generate_fock_chart,
+                                   generate_quad_chart, plot_wigner)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_space_unroll.py
+++ b/tests/frontend/test_space_unroll.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 r"""Unit tests for space_unroll in tdm/program.py"""
 
-import pytest
 import numpy as np
-import strawberryfields as sf
-from strawberryfields.tdm import get_mode_indices
-from strawberryfields.ops import Sgate, Rgate, BSgate
-from thewalrus.symplectic import reduced_state
+import pytest
 from thewalrus.quantum import is_pure_cov
+from thewalrus.symplectic import reduced_state
+
+import strawberryfields as sf
+from strawberryfields.ops import BSgate, Rgate, Sgate
+from strawberryfields.tdm import get_mode_indices
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_tdm_utils.py
+++ b/tests/frontend/test_tdm_utils.py
@@ -13,29 +13,23 @@
 # limitations under the License.
 r"""Unit tests for tdm/program.py"""
 import copy
-import pytest
 import inspect
 
 import numpy as np
+import pytest
+from thewalrus.quantum import photon_number_covmat, photon_number_mean_vector
 
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends.states import BaseGaussianState
 from strawberryfields.device import Device
-from strawberryfields.tdm import (
-    borealis_gbs,
-    get_mode_indices,
-    loop_phase_from_device,
-    make_phases_compatible,
-    make_squeezing_compatible,
-    random_bs,
-    random_r,
-    to_args_dict,
-    to_args_list,
-    vacuum_padding,
-)
+from strawberryfields.tdm import (borealis_gbs, get_mode_indices,
+                                  loop_phase_from_device,
+                                  make_phases_compatible,
+                                  make_squeezing_compatible, random_bs,
+                                  random_r, to_args_dict, to_args_list,
+                                  vacuum_padding)
 from strawberryfields.tdm.utils import full_compile, to_args_list
-from thewalrus.quantum import photon_number_covmat, photon_number_mean_vector
 
 pi = np.pi
 

--- a/tests/frontend/test_tdm_utils.py
+++ b/tests/frontend/test_tdm_utils.py
@@ -23,12 +23,18 @@ import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends.states import BaseGaussianState
 from strawberryfields.device import Device
-from strawberryfields.tdm import (borealis_gbs, get_mode_indices,
-                                  loop_phase_from_device,
-                                  make_phases_compatible,
-                                  make_squeezing_compatible, random_bs,
-                                  random_r, to_args_dict, to_args_list,
-                                  vacuum_padding)
+from strawberryfields.tdm import (
+    borealis_gbs,
+    get_mode_indices,
+    loop_phase_from_device,
+    make_phases_compatible,
+    make_squeezing_compatible,
+    random_bs,
+    random_r,
+    to_args_dict,
+    to_args_list,
+    vacuum_padding,
+)
 from strawberryfields.tdm.utils import full_compile, to_args_list
 
 pi = np.pi

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -19,9 +19,15 @@ import pytest
 
 import strawberryfields as sf
 from strawberryfields import ops
-from strawberryfields.tdm import (TDMProgram, get_mode_indices, move_vac_modes,
-                                  random_bs, random_r, to_args_list,
-                                  vacuum_padding)
+from strawberryfields.tdm import (
+    TDMProgram,
+    get_mode_indices,
+    move_vac_modes,
+    random_bs,
+    random_r,
+    to_args_list,
+    vacuum_padding,
+)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_tdmprogram.py
+++ b/tests/frontend/test_tdmprogram.py
@@ -14,20 +14,14 @@
 r"""Unit tests for tdm/program.py"""
 from collections.abc import Iterable
 
-import pytest
 import numpy as np
+import pytest
 
 import strawberryfields as sf
 from strawberryfields import ops
-from strawberryfields.tdm import (
-    TDMProgram,
-    move_vac_modes,
-    get_mode_indices,
-    random_bs,
-    random_r,
-    vacuum_padding,
-    to_args_list,
-)
+from strawberryfields.tdm import (TDMProgram, get_mode_indices, move_vac_modes,
+                                  random_bs, random_r, to_args_list,
+                                  vacuum_padding)
 
 pytestmark = pytest.mark.frontend
 

--- a/tests/frontend/test_utils.py
+++ b/tests/frontend/test_utils.py
@@ -21,10 +21,9 @@ from numpy.polynomial.hermite import hermval as H
 from scipy.special import factorial as fac
 
 import strawberryfields as sf
-from strawberryfields.program_utils import RegRef
-from strawberryfields.ops import Sgate, BSgate, LossChannel, MeasureX, Squeezed
 import strawberryfields.utils as utils
-
+from strawberryfields.ops import BSgate, LossChannel, MeasureX, Sgate, Squeezed
+from strawberryfields.program_utils import RegRef
 
 R_D = np.linspace(-2.00562, 1.0198, 4)
 PHI_D = np.linspace(-1.64566, 1.3734, 4)

--- a/tests/integration/test_algorithms.py
+++ b/tests/integration/test_algorithms.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the Strawberry Fields example algorithms"""
-import pytest
-
 import numpy as np
+import pytest
 
 import strawberryfields as sf
 from strawberryfields.ops import *

--- a/tests/integration/test_decompositions_integration.py
+++ b/tests/integration/test_decompositions_integration.py
@@ -12,27 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Unit tests for the Strawberry Fields decompositions within the ops module"""
-import pytest
-
 import numpy as np
-from scipy.linalg import qr, block_diag
-
+import pytest
+from scipy.linalg import block_diag, qr
 from thewalrus.symplectic import rotation as rot
 from thewalrus.symplectic import xpxp_to_xxpp, xxpp_to_xpxp
 
 import strawberryfields as sf
 from strawberryfields import decompositions as dec
-from strawberryfields.utils import (
-    random_interferometer,
-    random_symplectic,
-    random_covariance,
-    squeezed_state,
-)
 from strawberryfields import ops
-
+from strawberryfields.utils import random_covariance
+from strawberryfields.utils import random_interferometer
 from strawberryfields.utils import random_interferometer as haar_measure
+from strawberryfields.utils import random_symplectic, squeezed_state
 from strawberryfields.utils.program_functions import extract_unitary
-
 
 u1 = random_interferometer(3)
 u2 = random_interferometer(3)

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Integration tests for the frontend engine.py module with the backends"""
-import os
 import numbers
-import pytest
+import os
 
 import numpy as np
+import pytest
 
 import strawberryfields as sf
 from strawberryfields import ops
 from strawberryfields.backends import BaseFock, FockBackend, GaussianBackend
 from strawberryfields.backends.states import BaseState
 
-
 try:
-    from strawberryfields.backends.tfbackend import TFBackend
     import tensorflow as tf
+
+    from strawberryfields.backends.tfbackend import TFBackend
 except (ImportError, ValueError):
     eng_backend_params = [("gaussian", GaussianBackend), ("fock", FockBackend)]
 else:

--- a/tests/integration/test_hbar_integration.py
+++ b/tests/integration/test_hbar_integration.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Integration tests to make sure hbar values are set correctly in returned results"""
-import pytest
-
 import numpy as np
+import pytest
 
 import strawberryfields as sf
 from strawberryfields import ops
-
 
 N_MEAS = 200
 NUM_STDS = 10.0

--- a/tests/integration/test_measurement_integration.py
+++ b/tests/integration/test_measurement_integration.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Integration tests for frontend measurement"""
-import pytest
-
 import numpy as np
+import pytest
 
 from strawberryfields import ops
 

--- a/tests/integration/test_ops_integration.py
+++ b/tests/integration/test_ops_integration.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Integration tests for frontend operations applied to the backend"""
-import pytest
 import numpy as np
-from thewalrus.random import random_symplectic
+import pytest
 from scipy.stats import unitary_group
+from thewalrus.random import random_symplectic
 
 import strawberryfields as sf
 from strawberryfields import ops

--- a/tests/integration/test_parameters_integration.py
+++ b/tests/integration/test_parameters_integration.py
@@ -17,13 +17,13 @@ import inspect
 import itertools
 import warnings
 
-import pytest
 import numpy as np
+import pytest
 
 import strawberryfields.program_utils as pu
 from strawberryfields import ops
-from strawberryfields.parameters import ParameterError, par_funcs as pf
-
+from strawberryfields.parameters import ParameterError
+from strawberryfields.parameters import par_funcs as pf
 
 # ops.Fock requires an integer parameter
 scalar_arg_preparations = (

--- a/tests/integration/test_tf_integration.py
+++ b/tests/integration/test_tf_integration.py
@@ -22,8 +22,7 @@ from scipy.special import factorial
 
 tf = pytest.importorskip("tensorflow", minversion="2.0")
 
-from strawberryfields.ops import (BSgate, Dgate, Fock, Ket, MeasureX, MZgate,
-                                  S2gate, Sgate, Thermal)
+from strawberryfields.ops import BSgate, Dgate, Fock, Ket, MeasureX, MZgate, S2gate, Sgate, Thermal
 
 # this test file is only supported by the TF backend
 pytestmark = pytest.mark.backends("tf")

--- a/tests/integration/test_tf_integration.py
+++ b/tests/integration/test_tf_integration.py
@@ -16,14 +16,14 @@ Tests for the various Tensorflow-specific symbolic options of the frontend/backe
 """
 # pylint: disable=expression-not-assigned,too-many-public-methods,pointless-statement,no-self-use
 
-import pytest
 import numpy as np
+import pytest
 from scipy.special import factorial
 
 tf = pytest.importorskip("tensorflow", minversion="2.0")
 
-from strawberryfields.ops import Dgate, Sgate, MeasureX, Thermal, BSgate, MZgate, Ket, S2gate, Fock
-
+from strawberryfields.ops import (BSgate, Dgate, Fock, Ket, MeasureX, MZgate,
+                                  S2gate, Sgate, Thermal)
 
 # this test file is only supported by the TF backend
 pytestmark = pytest.mark.backends("tf")

--- a/tests/integration/test_utils_integration.py
+++ b/tests/integration/test_utils_integration.py
@@ -15,8 +15,8 @@ r"""Integration tests for the utils.py module"""
 
 # pylint: disable=pointless-statement,expression-not-assigned,no-self-use
 
-import pytest
 import numpy as np
+import pytest
 
 try:
     import tensorflow as tf
@@ -28,11 +28,9 @@ except ImportError:
 import strawberryfields as sf
 import strawberryfields.ops as ops
 import strawberryfields.utils as utils
-
-from strawberryfields.backends.fockbackend.ops import squeezing as sq_U
-from strawberryfields.backends.fockbackend.ops import displacement as disp_U
 from strawberryfields.backends.fockbackend.ops import beamsplitter as bs_U
-
+from strawberryfields.backends.fockbackend.ops import displacement as disp_U
+from strawberryfields.backends.fockbackend.ops import squeezing as sq_U
 
 ALPHA = np.linspace(-0.15, 0.2, 4) + np.linspace(-0.2, 0.1, 4) * 1j
 R = np.linspace(0, 0.21, 4)


### PR DESCRIPTION
**Context:**
I tried to use strawberryfields with scipy 1.15.1 and got this error:
```
    import strawberryfields as sf
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/__init__.py:24: in <module>
    from . import apps
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/apps/__init__.py:36: in <module>
    import strawberryfields.apps.qchem
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/apps/qchem/__init__.py:34: in <module>
    import strawberryfields.apps.qchem.dynamics
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/apps/qchem/dynamics.py:73: in <module>
    from strawberryfields.utils import operation
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/utils/__init__.py:21: in <module>
    from .program_functions import *
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/utils/program_functions.py:28: in <module>
    from strawberryfields.engine import LocalEngine
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/engine.py:29: in <module>
    from strawberryfields.device import Device
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/device.py:23: in <module>
    from strawberryfields.io import to_program
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/io/__init__.py:26: in <module>
    from strawberryfields.program import Program
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/program.py:62: in <module>
    from strawberryfields.compilers import Compiler, compiler_db
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/compilers/__init__.py:40: in <module>
    from .xcov import Xcov
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/compilers/xcov.py:25: in <module>
    import strawberryfields.ops as ops
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/ops.py:33: in <module>
    from .backends.states import BaseFockState, BaseGaussianState, BaseBosonicState
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/backends/__init__.py:72: in <module>
    from .gaussianbackend import GaussianBackend
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/backends/gaussianbackend/__init__.py:16: in <module>
    from .backend import GaussianBackend
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/backends/gaussianbackend/backend.py:23: in <module>
    from strawberryfields.backends.states import BaseGaussianState
/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/strawberryfields/backends/states.py:27: in <module>
    from scipy.integrate import simps
E   ImportError: cannot import name 'simps' from 'scipy.integrate' (/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/scipy/integrate/__init__.py)
```

**Description of the Change:**
Imports either `scipy.integrate.simpson` or `scipy.integrate.simps`, whichever one works.

**Benefits:**
SF works with new scipy.

**Possible Drawbacks:**
I have not checked whether the numerical behaviour of the simpson rule implementation in scipy has changed.

**Related GitHub Issues:**
