### PR TITLE
Replace pkg_resources file ref with pathlib

### DIFF
--- a/strawberryfields/apps/data/feature.py
+++ b/strawberryfields/apps/data/feature.py
@@ -16,10 +16,10 @@ Submodule for feature vector datasets and their base classes.
 """
 # pylint: disable=unnecessary-pass
 from abc import ABC, abstractmethod
-import pkg_resources
 import numpy as np
+from pathlib import Path
 
-DATA_PATH = pkg_resources.resource_filename("strawberryfields", "apps/data/feature_data") + "/"
+DATA_PATH = Path(__file__).parent / "feature_data"
 
 
 class FeatureDataset(ABC):
@@ -87,9 +87,9 @@ class FeatureDataset(ABC):
 
     def __init__(self):
         self.vectors = np.load(
-            f"{DATA_PATH}{self._data_filename}_{self.method}_fv.npy", allow_pickle=True
+            DATA_PATH / f"{self._data_filename}_{self.method}_fv.npy", allow_pickle=True
         )
-        self.adjs = np.load(DATA_PATH + self._data_filename + "_mat.npy", allow_pickle=True)
+        self.adjs = np.load(DATA_PATH / f"{self._data_filename}_mat.npy", allow_pickle=True)
         self.n_vectors, self.n_features = self.vectors.shape
 
     def __iter__(self):

--- a/strawberryfields/apps/data/sample.py
+++ b/strawberryfields/apps/data/sample.py
@@ -16,12 +16,12 @@ Submodule for sample datasets and their base classes.
 """
 # pylint: disable=unnecessary-pass
 from abc import ABC, abstractmethod
+from pathlib import Path
 
-import pkg_resources
 import numpy as np
 import scipy
 
-DATA_PATH = pkg_resources.resource_filename("strawberryfields", "apps/data/sample_data") + "/"
+DATA_PATH = Path(__file__).parent / "sample_data"
 
 
 class SampleDataset(ABC):
@@ -53,7 +53,7 @@ class SampleDataset(ABC):
         pass
 
     def __init__(self):
-        self.data = scipy.sparse.load_npz(DATA_PATH + self._data_filename + ".npz")
+        self.data = scipy.sparse.load_npz(DATA_PATH / f"{self._data_filename}.npz")
         self.n_samples, self.modes = self.data.shape
 
     def __iter__(self):
@@ -124,7 +124,7 @@ class GraphDataset(SampleDataset, ABC):
 
     def __init__(self):
         super().__init__()
-        self.adj = scipy.sparse.load_npz(DATA_PATH + self._data_filename + "_A.npz").toarray()
+        self.adj = scipy.sparse.load_npz(DATA_PATH / f"{self._data_filename}_A.npz").toarray()
 
 
 class Planted(GraphDataset):
@@ -333,11 +333,11 @@ class MoleculeDataset(SampleDataset, ABC):
 
     def __init__(self):
         super().__init__()
-        self.w = scipy.sparse.load_npz(DATA_PATH + self._data_filename + "_w.npz").toarray()[0]
-        self.wp = scipy.sparse.load_npz(DATA_PATH + self._data_filename + "_wp.npz").toarray()[0]
-        self.Ud = scipy.sparse.load_npz(DATA_PATH + self._data_filename + "_Ud.npz").toarray()
+        self.w = scipy.sparse.load_npz(DATA_PATH / f"{self._data_filename}_w.npz").toarray()[0]
+        self.wp = scipy.sparse.load_npz(DATA_PATH / f"{self._data_filename}_wp.npz").toarray()[0]
+        self.Ud = scipy.sparse.load_npz(DATA_PATH / f"{self._data_filename}_Ud.npz").toarray()
         self.delta = scipy.sparse.load_npz(
-            DATA_PATH + self._data_filename + "_delta.npz"
+            DATA_PATH / f"{self._data_filename}_delta.npz"
         ).toarray()[0]
 
     # pylint: disable=missing-docstring
@@ -409,14 +409,14 @@ class Water(SampleDataset):
             )
         index = self._times_to_indices[t]
 
-        all_data = np.load(DATA_PATH + "water.npz")["arr_0"]
+        all_data = np.load(DATA_PATH / "water.npz")["arr_0"]
 
         self.data = all_data[index]
         self.data = scipy.sparse.csr_matrix(self.data)
         self.n_samples, self.modes = self.data.shape
 
-        self.w = scipy.sparse.load_npz(DATA_PATH + "water_w.npz").toarray()[0]
-        self.U = scipy.sparse.load_npz(DATA_PATH + "water_U.npz").toarray()
+        self.w = scipy.sparse.load_npz(DATA_PATH / "water_w.npz").toarray()[0]
+        self.U = scipy.sparse.load_npz(DATA_PATH / "water_U.npz").toarray()
 
     n_mean = 1 / 3
     threshold = False
@@ -461,20 +461,20 @@ class Pyrrole(SampleDataset):
             )
         index = self._times_to_indices[t]
 
-        all_data = np.load(DATA_PATH + "pyrrole.npz")["arr_0"]
+        all_data = np.load(DATA_PATH / "pyrrole.npz")["arr_0"]
 
         self.data = all_data[index]
         self.data = scipy.sparse.csr_matrix(self.data)
         self.n_samples, self.modes = self.data.shape
 
-        self.ri = scipy.sparse.load_npz(DATA_PATH + "pyrrole_ri.npz").toarray()[0]
-        self.rf = scipy.sparse.load_npz(DATA_PATH + "pyrrole_rf.npz").toarray()[0]
-        self.wi = scipy.sparse.load_npz(DATA_PATH + "pyrrole_wi.npz").toarray()[0]
-        self.wf = scipy.sparse.load_npz(DATA_PATH + "pyrrole_wf.npz").toarray()[0]
-        self.Li = scipy.sparse.load_npz(DATA_PATH + "pyrrole_Li.npz").toarray()
-        self.Lf = scipy.sparse.load_npz(DATA_PATH + "pyrrole_Lf.npz").toarray()
-        self.m = scipy.sparse.load_npz(DATA_PATH + "pyrrole_m.npz").toarray()[0]
-        self.U = scipy.sparse.load_npz(DATA_PATH + "pyrrole_U.npz").toarray()
+        self.ri = scipy.sparse.load_npz(DATA_PATH / "pyrrole_ri.npz").toarray()[0]
+        self.rf = scipy.sparse.load_npz(DATA_PATH / "pyrrole_rf.npz").toarray()[0]
+        self.wi = scipy.sparse.load_npz(DATA_PATH / "pyrrole_wi.npz").toarray()[0]
+        self.wf = scipy.sparse.load_npz(DATA_PATH / "pyrrole_wf.npz").toarray()[0]
+        self.Li = scipy.sparse.load_npz(DATA_PATH / "pyrrole_Li.npz").toarray()
+        self.Lf = scipy.sparse.load_npz(DATA_PATH / "pyrrole_Lf.npz").toarray()
+        self.m = scipy.sparse.load_npz(DATA_PATH / "pyrrole_m.npz").toarray()[0]
+        self.U = scipy.sparse.load_npz(DATA_PATH / "pyrrole_U.npz").toarray()
 
     n_mean = 0.12599583
     threshold = False


### PR DESCRIPTION
**Context:**
FlamingPy started to depend on strawberryfields and importing `pkg_resources` (by importing this) raises a deprecation warning. Even more concerning, this repo does not express its direct dependency on setuptools despite requiring it (likely because it was shipped with python by default for the longest time).

**Description of the Change:**
Replace `pkg_resources.resource_filename` with `pathlib.Path(__file__)`. The data neighbours the source files so pathlib has no problem getting the job done.

**Benefits:**
- Newer versions of Python do not come with setuptools which makes importing strawberryfields fail
- Other packages (eg. FlamingPy) that depend on strawberryfields can import it without setuptools raising a warning

**Possible Drawbacks:**
While I'm quite certain that `package_data` in `setup.py` doesn't relocate data files, I don't know if there's something in a PEP that says it isn't necessary and some build tools don't respect it. https://github.com/XanaduAI/strawberryfields/blob/cc0a0e4b695f7584a629def02801285c9e7a9da2/setup.py#L45-L46

Anyway, installing strawberryfields today does what one would expect:

<details>
<summary>apps/data/ tree</summary>

```bash
❯ tree .venv/lib/python3.11/site-packages/strawberryfields/apps/data/
.venv/lib/python3.11/site-packages/strawberryfields/apps/data/
├── __init__.py
├── feature_data
│   ├── MUTAG_exact_fv.npy
│   ├── MUTAG_mat.npy
│   ├── QM9_exact_fv.npy
│   ├── QM9_mat.npy
│   └── QM9_mc_fv.npy
├── feature.py
├── sample_data
│   ├── formic_delta.npz
│   ├── formic_Ud.npz
│   ├── formic_w.npz
│   ├── formic_wp.npz
│   ├── formic.npz
│   ├── MUTAG_0_A.npz
│   ├── MUTAG_0.npz
│   ├── MUTAG_1_A.npz
│   ├── MUTAG_1.npz
│   ├── MUTAG_2_A.npz
│   ├── MUTAG_2.npz
│   ├── MUTAG_3_A.npz
│   ├── MUTAG_3.npz
│   ├── p_hat300-1_A.npz
│   ├── p_hat300-1.npz
│   ├── planted_A.npz
│   ├── planted.npz
│   ├── pyrrole_Lf.npz
│   ├── pyrrole_Li.npz
│   ├── pyrrole_m.npz
│   ├── pyrrole_rf.npz
│   ├── pyrrole_ri.npz
│   ├── pyrrole_U.npz
│   ├── pyrrole_wf.npz
│   ├── pyrrole_wi.npz
│   ├── pyrrole.npz
│   ├── TACE-AS_A.npz
│   ├── TACE-AS.npz
│   ├── water_U.npz
│   ├── water_w.npz
│   └── water.npz
└── sample.py
```
</details>

**Related GitHub Issues:**
N/A